### PR TITLE
api webhook: output valid JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap_complete = "4"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+serde_json = "1"
 tempfile = "3"
 wiremock = "0.6"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,16 +171,33 @@ async fn cmd_run(args: RunArgs) -> Result<()> {
         podman::build_and_push_config_image(&config_dir, &image_ref)?;
     }
 
-    launch_webhook(&args.webhook, params).await
+    let duration_mins: i64 = params
+        .as_map()
+        .get("antithesis.duration")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    launch_webhook(&args.webhook, params).await?;
+
+    let eta = Local::now() + Duration::minutes(duration_mins + 10);
+    eprintln!(
+        "\nExpect a report email from Antithesis around {}",
+        eta.format("%b %-d at %-I:%M %p")
+    );
+
+    Ok(())
 }
 
 async fn cmd_api_webhook(webhook: String, args: Vec<String>, use_stdin: bool) -> Result<()> {
     let params = get_params(args, use_stdin, false)?;
     params.validate_test_params()?;
-    launch_webhook(&webhook, params).await
+    let body = launch_webhook(&webhook, params).await?;
+    println!("{}", body);
+    Ok(())
 }
 
-async fn launch_webhook(webhook: &str, params: Params) -> Result<()> {
+async fn launch_webhook(webhook: &str, params: Params) -> Result<String> {
     // Print params to stderr for user visibility (with sensitive values redacted)
     eprintln!(
         "\nRequesting Antithesis test run with params:\n{}",
@@ -199,20 +216,7 @@ async fn launch_webhook(webhook: &str, params: Params) -> Result<()> {
     debug!("response status: {}, body:\n{}", status, body);
 
     if status.is_success() {
-        // Estimate when the report email will arrive
-        let duration_mins: i64 = params
-            .as_map()
-            .get("antithesis.duration")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        let eta = Local::now() + Duration::minutes(duration_mins + 10);
-        eprintln!(
-            "\nExpect a report email from Antithesis around {}",
-            eta.format("%b %-d at %-I:%M %p")
-        );
-
-        Ok(())
+        Ok(body)
     } else {
         bail!("API error: {} - {}", status.as_u16(), body)
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -704,6 +704,79 @@ fn api_webhook_cli_args_override_stdin_json() {
 }
 
 #[test]
+fn api_webhook_success_outputs_valid_json() {
+    let mock_url = start_mock_server(r#"{"session_id": "abc123", "status": "launched"}"#, 200);
+
+    let output = snouty_with_mock(&mock_url)
+        .args([
+            "api",
+            "webhook",
+            "-w",
+            "basic_test",
+            "--antithesis.duration",
+            "30",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
+    assert!(parsed.is_object());
+}
+
+#[test]
+fn api_webhook_error_outputs_string_on_stderr() {
+    let mock_url = start_mock_server(r#"{"error": "something went wrong"}"#, 500);
+
+    snouty_with_mock(&mock_url)
+        .args([
+            "api",
+            "webhook",
+            "-w",
+            "basic_test",
+            "--antithesis.duration",
+            "30",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("API error: 500"))
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn api_webhook_success_does_not_print_email_eta() {
+    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+
+    snouty_with_mock(&mock_url)
+        .args([
+            "api",
+            "webhook",
+            "-w",
+            "basic_test",
+            "--antithesis.duration",
+            "30",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Expect a report email").not());
+}
+
+#[test]
+fn run_prints_email_eta() {
+    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+
+    snouty_with_mock(&mock_url)
+        .args(["run", "-w", "basic_test", "--duration", "30"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Expect a report email"));
+}
+
+#[test]
 fn api_webhook_no_config_flag() {
     // -c/--config should not be accepted on `api webhook`
     snouty()


### PR DESCRIPTION
Move the ETA output to the run command, so that api webhook returns valid JSON.