### PR TITLE
test-stub: add subcommand to run test scripts locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1204,26 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1510,6 +1556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1655,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1742,6 +1827,25 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1920,6 +2024,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "snouty"
 version = "0.2.0"
 dependencies = [
+ "antithesis_sdk",
  "assert_cmd",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/antithesishq/snouty"
 [dependencies]
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
+antithesis_sdk = "0.2.8"
 getrandom = "0.3"
 env_logger = "0.11"
 json5 = "1.3.0"

--- a/specs/help.txt
+++ b/specs/help.txt
@@ -13,6 +13,7 @@ stdout '.*api.*'
 stdout '.*docs.*'
 stdout '.*completions.*'
 stdout '.*update.*'
+stdout '.*test-stub.*'
 
 # 3. api --help shows webhook subcommand.
 snouty api --help

--- a/specs/test_stub.txt
+++ b/specs/test_stub.txt
@@ -1,0 +1,167 @@
+# test-stub — local execution of test scripts
+
+# 1. Happy path: all script types run in order.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/scripts
+chmod 0755 scripts/suite/first_setup
+chmod 0755 scripts/suite/parallel_driver_load
+chmod 0755 scripts/suite/anytime_check
+chmod 0755 scripts/suite/eventually_verify
+chmod 0755 scripts/suite/finally_cleanup
+snouty test-stub
+stderr 'Found 1 first, 1 driver, 1 anytime, 1 eventually, 1 finally.*'
+stderr 'Running \[suite/first_setup\]'
+stderr 'Running \[suite/parallel_driver_load\]'
+stderr 'Running \[suite/anytime_check\]'
+stderr 'Running \[suite/eventually_verify\]'
+stderr 'Running \[suite/finally_cleanup\]'
+stdout 'first_setup ran.*'
+stdout 'parallel_driver_load ran.*'
+stdout 'anytime_check ran.*'
+stdout 'eventually_verify ran.*'
+stdout 'finally_cleanup ran.*'
+
+# 2. No drivers or anytime scripts — exits with error.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/nodrivers
+chmod 0755 nodrivers/suite/first_setup
+! snouty test-stub
+stderr 'no driver or anytime scripts found.*'
+
+# 3. Failing script — all scripts still run, exits with error.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/failing
+chmod 0755 failing/suite/first_setup
+chmod 0755 failing/suite/parallel_driver_bad
+chmod 0755 failing/suite/finally_cleanup
+! snouty test-stub
+stderr 'Running \[suite/first_setup\]'
+stderr 'Running \[suite/parallel_driver_bad\]'
+stderr 'FAIL \[suite/parallel_driver_bad\]'
+stderr 'Running \[suite/finally_cleanup\]'
+stderr 'one or more scripts failed.*'
+stdout 'first_setup ran.*'
+stdout 'this script fails.*'
+stdout 'finally_cleanup ran.*'
+
+# 4. --entrypoint writes SDK lifecycle event.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/scripts
+chmod 0755 scripts/suite/first_setup
+chmod 0755 scripts/suite/parallel_driver_load
+chmod 0755 scripts/suite/anytime_check
+chmod 0755 scripts/suite/eventually_verify
+chmod 0755 scripts/suite/finally_cleanup
+set-env ANTITHESIS_SDK_LOCAL_OUTPUT ${WORK}/sdk.jsonl
+snouty-bg test-stub --entrypoint
+exec sleep 1
+kill snouty
+grep 'antithesis_setup.*complete' sdk.jsonl
+
+# 5. Non-executable script fails the run.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/noexec
+chmod 0755 noexec/suite/parallel_driver_load
+! snouty test-stub
+stderr 'Permission denied.*'
+
+# 6. Unknown prefix file bails with list.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/unknown
+chmod 0755 unknown/suite/first_ok
+! snouty test-stub
+stderr 'unrecognized command names.*'
+stderr 'suite/readme.txt'
+
+# 7. helper_ file is silently ignored.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/withhelper
+chmod 0755 withhelper/suite/first_setup
+chmod 0755 withhelper/suite/parallel_driver_load
+snouty test-stub
+stderr 'Found 1 first, 1 driver, 0 anytime, 0 eventually, 0 finally.*'
+
+# 8. first_ script calling setup_complete is detected.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/setupbad
+chmod 0755 setupbad/suite/first_setup_complete
+chmod 0755 setupbad/suite/parallel_driver_load
+! snouty test-stub
+stderr 'first_ scripts must not call setup_complete.*'
+
+# 9. ANTITHESIS_OUTPUT_DIR set — scripts are not executed.
+set-env SNOUTY_TEST_TEMPLATES_PATH ${WORK}/scripts
+chmod 0755 scripts/suite/first_setup
+chmod 0755 scripts/suite/parallel_driver_load
+chmod 0755 scripts/suite/anytime_check
+chmod 0755 scripts/suite/eventually_verify
+chmod 0755 scripts/suite/finally_cleanup
+set-env ANTITHESIS_OUTPUT_DIR ${WORK}/output
+snouty test-stub
+stderr 'skipping local script execution.*'
+! stdout 'first_setup ran'
+! stdout 'parallel_driver_load ran'
+
+-- scripts/suite/first_setup --
+#!/bin/sh
+echo "first_setup ran"
+
+-- scripts/suite/parallel_driver_load --
+#!/bin/sh
+echo "parallel_driver_load ran"
+
+-- scripts/suite/anytime_check --
+#!/bin/sh
+echo "anytime_check ran"
+
+-- scripts/suite/eventually_verify --
+#!/bin/sh
+echo "eventually_verify ran"
+
+-- scripts/suite/finally_cleanup --
+#!/bin/sh
+echo "finally_cleanup ran"
+
+-- nodrivers/suite/first_setup --
+#!/bin/sh
+echo "first_setup ran"
+
+-- failing/suite/first_setup --
+#!/bin/sh
+echo "first_setup ran"
+
+-- failing/suite/parallel_driver_bad --
+#!/bin/sh
+echo "this script fails"
+exit 1
+
+-- failing/suite/finally_cleanup --
+#!/bin/sh
+echo "finally_cleanup ran"
+
+-- noexec/suite/first_noexec --
+#!/bin/sh
+echo "should not run"
+
+-- noexec/suite/parallel_driver_load --
+#!/bin/sh
+echo "driver ran"
+
+-- unknown/suite/first_ok --
+#!/bin/sh
+echo "first_ok ran"
+
+-- unknown/suite/readme.txt --
+This is not a script.
+
+-- withhelper/suite/first_setup --
+#!/bin/sh
+echo "first_setup ran"
+
+-- withhelper/suite/parallel_driver_load --
+#!/bin/sh
+echo "driver ran"
+
+-- withhelper/suite/helper_utils --
+#!/bin/sh
+echo "helper"
+
+-- setupbad/suite/first_setup_complete --
+#!/bin/sh
+echo '{"antithesis_setup":{"status":"complete"}}' >> "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl"
+
+-- setupbad/suite/parallel_driver_load --
+#!/bin/sh
+echo "driver ran"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,28 @@ Using Moment.from (copy from triage report):
     /// Check for and install updates
     Update,
 
+    /// Run test scripts from /opt/antithesis/test/v1
+    #[command(
+        name = "test-stub",
+        long_about = r#"Run test scripts from /opt/antithesis/test/v1
+
+A simplified, single-process test runner for locally exercising Antithesis
+Test Composer scripts. It is NOT a replacement for the test composer;
+the following simplifications apply:
+
+  - All scripts run once, in a random order.
+  - Scripts are executed sequentially, there is no concurrency.
+
+Every script runs regardless of earlier failures. The exit code is nonzero
+if any script fails.
+
+When ANTITHESIS_OUTPUT_DIR is set, no scripts are executed (the real test
+composer handles orchestration).
+
+Requires at least one driver or anytime script."#
+    )]
+    TestStub(TestStubArgs),
+
     /// Search Antithesis documentation
     Docs {
         /// Don't check for documentation updates
@@ -147,6 +169,13 @@ If the exact path is not found, suggests similar pages."#)]
         /// Page path (e.g. "getting_started/overview")
         path: String,
     },
+}
+
+#[derive(Args)]
+pub struct TestStubArgs {
+    /// Emit setup_complete lifecycle event and wait indefinitely
+    #[arg(long)]
+    pub entrypoint: bool,
 }
 
 #[derive(Args)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod container;
 pub mod docs;
 pub mod moment;
 pub mod params;
+pub mod test_stub;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use snouty::container;
 use snouty::docs;
 use snouty::moment;
 use snouty::params::Params;
+use snouty::test_stub;
 
 fn read_stdin() -> Result<String> {
     let mut buf = String::new();
@@ -81,6 +82,7 @@ async fn main() -> Result<()> {
             info!("starting debug session");
             cmd_debug(args, stdin).await
         }
+        Commands::TestStub(args) => test_stub::cmd_test_stub(args).await,
         Commands::Completions { shell } => cmd_completions(shell),
         Commands::Version => {
             println!("snouty {}", env!("CARGO_PKG_VERSION"));

--- a/src/test_stub.rs
+++ b/src/test_stub.rs
@@ -1,0 +1,346 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use color_eyre::eyre::{Context, Result, bail};
+use log::{debug, info};
+
+use crate::cli::TestStubArgs;
+
+const DEFAULT_TEST_DIR: &str = "/opt/antithesis/test/v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScriptType {
+    First,
+    ParallelDriver,
+    SerialDriver,
+    SingletonDriver,
+    Anytime,
+    Eventually,
+    Finally,
+}
+
+impl ScriptType {
+    fn from_prefix(name: &str) -> Option<Self> {
+        if name.starts_with("first_") {
+            Some(Self::First)
+        } else if name.starts_with("parallel_driver_") {
+            Some(Self::ParallelDriver)
+        } else if name.starts_with("serial_driver_") {
+            Some(Self::SerialDriver)
+        } else if name.starts_with("singleton_driver_") {
+            Some(Self::SingletonDriver)
+        } else if name.starts_with("anytime_") {
+            Some(Self::Anytime)
+        } else if name.starts_with("eventually_") {
+            Some(Self::Eventually)
+        } else if name.starts_with("finally_") {
+            Some(Self::Finally)
+        } else {
+            None
+        }
+    }
+
+    fn is_driver(self) -> bool {
+        matches!(
+            self,
+            Self::ParallelDriver | Self::SerialDriver | Self::SingletonDriver
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestScript {
+    pub test_name: String,
+    pub script_type: ScriptType,
+    pub command_name: String,
+    pub path: std::path::PathBuf,
+}
+
+/// Scan `base` for executable test scripts organized as `{test_name}/{command}`.
+pub fn scan_scripts(base: &Path) -> Result<Vec<TestScript>> {
+    let mut scripts = Vec::new();
+    let mut unrecognized: Vec<String> = Vec::new();
+
+    let entries = match fs::read_dir(base) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(scripts),
+        Err(e) => return Err(e).wrap_err_with(|| format!("reading {}", base.display())),
+    };
+
+    for test_dir_entry in entries {
+        let test_dir_entry = test_dir_entry.wrap_err("reading test directory entry")?;
+        let test_dir_path = test_dir_entry.path();
+        if !test_dir_path.is_dir() {
+            continue;
+        }
+        let test_name = test_dir_entry.file_name().to_string_lossy().into_owned();
+
+        let commands = fs::read_dir(&test_dir_path)
+            .wrap_err_with(|| format!("reading {}", test_dir_path.display()))?;
+
+        for cmd_entry in commands {
+            let cmd_entry = cmd_entry.wrap_err("reading command entry")?;
+            let cmd_path = cmd_entry.path();
+            if cmd_path.is_dir() {
+                continue;
+            }
+
+            let command_name = cmd_entry.file_name().to_string_lossy().into_owned();
+            let script_type = match ScriptType::from_prefix(&command_name) {
+                Some(t) => t,
+                None => {
+                    if command_name.starts_with("helper_") {
+                        debug!("skipping helper: {}", command_name);
+                    } else {
+                        unrecognized.push(format!("  {}/{}", test_name, command_name));
+                    }
+                    continue;
+                }
+            };
+
+            scripts.push(TestScript {
+                test_name: test_name.clone(),
+                script_type,
+                command_name,
+                path: cmd_path,
+            });
+        }
+    }
+
+    if !unrecognized.is_empty() {
+        unrecognized.sort();
+        bail!(
+            "unrecognized command names (not a known prefix or helper_):\n{}",
+            unrecognized.join("\n")
+        );
+    }
+
+    scripts.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(scripts)
+}
+
+/// Fisher-Yates shuffle using `getrandom` for randomness.
+fn shuffle<T>(slice: &mut [T]) {
+    for i in (1..slice.len()).rev() {
+        let mut buf = [0u8; 8];
+        getrandom::fill(&mut buf).expect("getrandom failed");
+        let r = u64::from_le_bytes(buf);
+        let j = (r % (i as u64 + 1)) as usize;
+        slice.swap(i, j);
+    }
+}
+
+/// Run a script and return whether it succeeded.
+fn run_script(script: &TestScript, extra_env: &[(&str, &std::ffi::OsStr)]) -> Result<bool> {
+    eprintln!("Running [{}/{}]", script.test_name, script.command_name,);
+    let mut cmd = Command::new(&script.path);
+    cmd.env_clear();
+    for var in ["PATH", "HOME"] {
+        if let Some(val) = std::env::var_os(var) {
+            cmd.env(var, val);
+        }
+    }
+    if let Some(dir) = script.path.parent() {
+        cmd.current_dir(dir);
+    }
+    for &(key, val) in extra_env {
+        cmd.env(key, val);
+    }
+    let status = cmd
+        .status()
+        .wrap_err_with(|| format!("executing {}", script.path.display()))?;
+    if !status.success() {
+        eprintln!(
+            "FAIL [{}/{}] {}",
+            script.test_name, script.command_name, status
+        );
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+pub async fn cmd_test_stub(args: TestStubArgs) -> Result<()> {
+    let base_dir = std::env::var_os("SNOUTY_TEST_TEMPLATES_PATH")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(DEFAULT_TEST_DIR));
+    let base = base_dir.as_path();
+    let scripts = scan_scripts(base)?;
+
+    let first: Vec<_> = scripts
+        .iter()
+        .filter(|s| s.script_type == ScriptType::First)
+        .collect();
+    let drivers: Vec<_> = scripts
+        .iter()
+        .filter(|s| s.script_type.is_driver())
+        .collect();
+    let anytime: Vec<_> = scripts
+        .iter()
+        .filter(|s| s.script_type == ScriptType::Anytime)
+        .collect();
+    let eventually: Vec<_> = scripts
+        .iter()
+        .filter(|s| s.script_type == ScriptType::Eventually)
+        .collect();
+    let finally: Vec<_> = scripts
+        .iter()
+        .filter(|s| s.script_type == ScriptType::Finally)
+        .collect();
+
+    eprintln!(
+        "Found {} first, {} driver, {} anytime, {} eventually, {} finally",
+        first.len(),
+        drivers.len(),
+        anytime.len(),
+        eventually.len(),
+        finally.len(),
+    );
+
+    if drivers.is_empty() && anytime.is_empty() {
+        bail!("no driver or anytime scripts found in {}", base.display());
+    }
+
+    if args.entrypoint {
+        antithesis_sdk::lifecycle::setup_complete(
+            &serde_json::json!({"source": "snouty test-stub"}),
+        );
+    }
+
+    let mut ok = true;
+
+    if std::env::var_os("ANTITHESIS_OUTPUT_DIR").is_some() {
+        info!("ANTITHESIS_OUTPUT_DIR is set; skipping local script execution");
+    } else {
+        // Run first_ scripts with a temp output dir to detect setup_complete calls.
+        let first_output_dir =
+            tempfile::tempdir().wrap_err("creating temp directory for first_ script output")?;
+        let first_env: [(&str, &std::ffi::OsStr); 1] =
+            [("ANTITHESIS_OUTPUT_DIR", first_output_dir.path().as_os_str())];
+        for s in &first {
+            ok &= run_script(s, &first_env)?;
+        }
+
+        // Detect first_ scripts calling setup_complete (causes deadlock in real composer).
+        let sdk_jsonl = first_output_dir.path().join("sdk.jsonl");
+        if sdk_jsonl.exists() {
+            let content = fs::read_to_string(&sdk_jsonl)
+                .wrap_err("reading sdk.jsonl from first_ script output")?;
+            for line in content.lines() {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                    if v.get("antithesis_setup").is_some() {
+                        bail!(
+                            "first_ scripts must not call setup_complete (causes deadlock in real composer)"
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut runnable: Vec<_> = drivers.iter().chain(anytime.iter()).copied().collect();
+        shuffle(&mut runnable);
+
+        for s in &runnable {
+            ok &= run_script(s, &[])?;
+        }
+
+        for s in &eventually {
+            ok &= run_script(s, &[])?;
+        }
+
+        for s in &finally {
+            ok &= run_script(s, &[])?;
+        }
+    }
+
+    if args.entrypoint {
+        eprintln!("Waiting forever");
+        std::future::pending::<()>().await;
+    }
+
+    if !ok {
+        bail!("one or more scripts failed");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn make_script(base: &Path, test_name: &str, command: &str, executable: bool) {
+        let dir = base.join(test_name);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(command);
+        fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mode = if executable { 0o755 } else { 0o644 };
+        fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn scan_scripts_basic() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        make_script(base, "mytest", "first_setup", true);
+        make_script(base, "mytest", "parallel_driver_load", true);
+        make_script(base, "mytest", "serial_driver_seq", true);
+        make_script(base, "mytest", "singleton_driver_one", true);
+        make_script(base, "mytest", "anytime_check", true);
+        make_script(base, "mytest", "eventually_verify", true);
+        make_script(base, "mytest", "finally_cleanup", true);
+
+        let scripts = scan_scripts(base).unwrap();
+        assert_eq!(scripts.len(), 7);
+
+        let types: Vec<_> = scripts.iter().map(|s| s.script_type).collect();
+        assert!(types.contains(&ScriptType::First));
+        assert!(types.contains(&ScriptType::ParallelDriver));
+        assert!(types.contains(&ScriptType::SerialDriver));
+        assert!(types.contains(&ScriptType::SingletonDriver));
+        assert!(types.contains(&ScriptType::Anytime));
+        assert!(types.contains(&ScriptType::Eventually));
+        assert!(types.contains(&ScriptType::Finally));
+    }
+
+    #[test]
+    fn scan_scripts_helper_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        make_script(base, "mytest", "first_ok", true);
+        make_script(base, "mytest", "helper_utils", true);
+
+        let scripts = scan_scripts(base).unwrap();
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].command_name, "first_ok");
+    }
+
+    #[test]
+    fn scan_scripts_unknown_prefix() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        make_script(base, "mytest", "unknown_thing", true);
+        make_script(base, "mytest", "first_ok", true);
+
+        let err = scan_scripts(base).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unrecognized command names"), "{msg}");
+        assert!(msg.contains("mytest/unknown_thing"), "{msg}");
+    }
+
+    #[test]
+    fn scan_scripts_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let scripts = scan_scripts(tmp.path()).unwrap();
+        assert!(scripts.is_empty());
+    }
+
+    #[test]
+    fn scan_scripts_nonexistent_dir() {
+        let scripts = scan_scripts(Path::new("/nonexistent/path/that/does/not/exist")).unwrap();
+        assert!(scripts.is_empty());
+    }
+}

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -24,13 +24,14 @@ thread_local! {
 
 // --- Shared command handlers (function pointers for testscript CommandFn) ---
 
-fn cmd_snouty(
-    env: &mut testscript_rs::TestEnvironment,
-    args: &[String],
-) -> testscript_rs::Result<()> {
-    // env_clear() so tests don't depend on the parent environment.
-    // testscript-rs's built-in execute_command uses Command::envs
-    // (additive), which leaks the parent env.
+/// System env vars forwarded to child processes (container tools, coverage).
+const FORWARDED_ENV_VARS: &[&str] = &["PATH", "HOME", "LLVM_PROFILE_FILE"];
+
+/// Build a `Command` for the snouty binary with a clean environment.
+///
+/// Clears the parent env, forwards [`FORWARDED_ENV_VARS`], and applies
+/// the test environment's `env_vars`.
+fn snouty_cmd(env: &testscript_rs::TestEnvironment, args: &[String]) -> std::process::Command {
     let bin = env!("CARGO_BIN_EXE_snouty");
     let mut cmd = std::process::Command::new(bin);
     cmd.args(args)
@@ -38,8 +39,7 @@ fn cmd_snouty(
         .env_clear()
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    // Forward system env vars needed by container tools and coverage.
-    for var in ["PATH", "HOME", "LLVM_PROFILE_FILE"] {
+    for var in FORWARDED_ENV_VARS {
         if let Ok(v) = std::env::var(var) {
             cmd.env(var, v);
         }
@@ -47,6 +47,14 @@ fn cmd_snouty(
     for (k, v) in &env.env_vars {
         cmd.env(k, v);
     }
+    cmd
+}
+
+fn cmd_snouty(
+    env: &mut testscript_rs::TestEnvironment,
+    args: &[String],
+) -> testscript_rs::Result<()> {
+    let mut cmd = snouty_cmd(env, args);
     if env.next_stdin.is_some() {
         cmd.stdin(Stdio::piped());
     }
@@ -152,6 +160,25 @@ fn spec_tests() {
         })
         .command("snouty", cmd_snouty)
         .command("mock-server", cmd_mock_server)
+        .command("set-env", |env, args| {
+            // Usage: set-env KEY value...
+            // Interpolates ${VAR} references in value using env.env_vars.
+            if args.len() < 2 {
+                return Err(err("set-env requires KEY and value".to_string()));
+            }
+            let key = &args[0];
+            let raw_value = args[1..].join(" ");
+            let value = env.substitute_env_vars(&raw_value);
+            env.set_env_var(key, &value);
+            Ok(())
+        })
+        .command("snouty-bg", |env, args| {
+            let child = snouty_cmd(env, args)
+                .spawn()
+                .map_err(|e| err(format!("spawn snouty-bg: {e}")))?;
+            env.background_processes.insert("snouty".to_string(), child);
+            Ok(())
+        })
         .command("setup-docs-db", |env, args| {
             // Usage: setup-docs-db
             // Copies the fixture docs.db into the workdir and sets ANTITHESIS_DOCS_DB_PATH.


### PR DESCRIPTION
Add `snouty test-stub`, a simplified single-process test runner for locally exercising Antithesis Test Composer scripts from /opt/antithesis/test/v1.

User-facing behaviour:

  - Scans {test_name}/{command} directories for scripts classified by filename prefix: first_, parallel_driver_, serial_driver_, singleton_driver_, anytime_, eventually_, finally_.
  - helper_ prefixed files are silently skipped; unknown prefixes cause an immediate error listing the offending files.
  - Requires at least one driver or anytime script (exits 1 otherwise).
  - Runs first_ scripts, then drivers + anytime in random order, then eventually_, then finally_. All scripts run even if some fail; exit code is nonzero if any script failed.
  - Non-executable scripts are attempted and surface a permission error.
  - first_ scripts that call setup_complete are detected and rejected (this causes deadlock in the real composer).
  - --entrypoint emits an antithesis_setup lifecycle event via the SDK and waits indefinitely (container entrypoint mode).
  - When ANTITHESIS_OUTPUT_DIR is set, no scripts are executed (the real test composer handles orchestration).
  - SNOUTY_TEST_TEMPLATES_PATH overrides the default script directory, enabling spec tests without container images.


Updates: https://github.com/antithesishq/snouty/issues/2