### PR TITLE
Remove Windows support from codebase and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,6 @@ jobs:
             runtime: docker
           - os: ubuntu-latest
             runtime: podman
-          - os: windows-latest
-            runtime: docker
           - os: macos-15-intel
             runtime: podman
     env:
@@ -106,19 +104,6 @@ jobs:
           podman machine init
           podman machine start
 
-      - name: Start Docker On Windows
-        if: matrix.runtime == 'docker' && startsWith(matrix.os, 'windows')
-        shell: powershell
-        run: |
-          $service = Get-Service docker -ErrorAction SilentlyContinue
-          if ($null -eq $service) {
-            throw "Docker service 'docker' is not installed on this runner."
-          }
-          if ($service.Status -ne 'Running') {
-            Start-Service docker
-          }
-          Get-Service docker
-
       - name: Runtime Info
         shell: bash
         run: |
@@ -129,12 +114,7 @@ jobs:
           fi
 
       - name: Test
-        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: cargo nextest run
-
-      - name: Test (Windows)
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: cargo nextest run -- --skip build_and_push_to_mock_registry --skip engine_spec_tests
   build-nix:
     runs-on: ubuntu-latest
     needs: skip-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,7 @@ which will be subject to extra review.
 
 ## Dependencies & distribution
 
-This tool supports amd64 and arm64 processors, and common operating systems like
-Linux, macOS and to an extent Windows. Keep third party dependencies minimal, it
+This tool supports amd64 and arm64 processors on Linux and macOS. Keep third party dependencies minimal, it
 is fine to turn a transitive dependency into a direct dependency if necessary.
 Try to keep the implementation OS agnostic, if that is not possible return an
 error from the respective command.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ A CLI for the [Antithesis](https://antithesis.com) API. See the [webhook documen
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/antithesishq/snouty/releases/latest/download/snouty-installer.sh | sh
 ```
 
-### Install prebuilt binaries via powershell script
-
-```sh
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/antithesishq/snouty/releases/latest/download/snouty-installer.ps1 | iex"
-```
-
 ### Install prebuilt binaries via cargo binstall
 
 ```sh
@@ -36,7 +30,6 @@ cargo install snouty
 | File                                                                                                                                               | Platform            | Checksum                                                                                                                   |
 | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | [snouty-aarch64-apple-darwin.tar.xz](https://github.com/antithesishq/snouty/releases/latest/download/snouty-aarch64-apple-darwin.tar.xz)           | Apple Silicon macOS | [checksum](https://github.com/antithesishq/snouty/releases/latest/download/snouty-aarch64-apple-darwin.tar.xz.sha256)      |
-| [snouty-x86_64-pc-windows-msvc.zip](https://github.com/antithesishq/snouty/releases/latest/download/snouty-x86_64-pc-windows-msvc.zip)             | x64 Windows         | [checksum](https://github.com/antithesishq/snouty/releases/latest/download/snouty-x86_64-pc-windows-msvc.zip.sha256)       |
 | [snouty-aarch64-unknown-linux-gnu.tar.xz](https://github.com/antithesishq/snouty/releases/latest/download/snouty-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux         | [checksum](https://github.com/antithesishq/snouty/releases/latest/download/snouty-aarch64-unknown-linux-gnu.tar.xz.sha256) |
 | [snouty-x86_64-unknown-linux-gnu.tar.xz](https://github.com/antithesishq/snouty/releases/latest/download/snouty-x86_64-unknown-linux-gnu.tar.xz)   | x64 Linux           | [checksum](https://github.com/antithesishq/snouty/releases/latest/download/snouty-x86_64-unknown-linux-gnu.tar.xz.sha256)  |
 
@@ -122,7 +115,7 @@ echo 'Moment.from({ session_id: "...", input_hash: "...", vtime: ... })' | \
 
 ## Shell Completions
 
-Snouty supports tab completions for bash, zsh, fish, powershell, and elvish.
+Snouty supports tab completions for bash, zsh, fish, and elvish.
 
 ### Bash
 
@@ -142,13 +135,6 @@ eval "$(snouty completions zsh)"
 
 ```sh
 snouty completions fish > ~/.config/fish/completions/snouty.fish
-```
-
-### PowerShell
-
-```powershell
-# Add to your PowerShell profile
-snouty completions powershell | Out-String | Invoke-Expression
 ```
 
 ### Elvish

--- a/build.rs
+++ b/build.rs
@@ -19,13 +19,7 @@ fn main() {
     fs::create_dir_all(&outdir).unwrap();
 
     let mut command = Cli::command();
-    for shell in [
-        Shell::Bash,
-        Shell::Fish,
-        Shell::Zsh,
-        Shell::PowerShell,
-        Shell::Elvish,
-    ] {
+    for shell in [Shell::Bash, Shell::Fish, Shell::Zsh, Shell::Elvish] {
         generate_to(shell, &mut command, "snouty", &outdir).unwrap();
     }
 }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,9 +8,9 @@ cargo-dist-version = "0.30.3"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/specs/completions.txt
+++ b/specs/completions.txt
@@ -17,14 +17,10 @@ snouty completions fish
 stdout '.*complete.*'
 stdout '.*snouty.*'
 
-# 4. PowerShell completions produce a valid completion script.
-snouty completions powershell
-stdout '.*snouty.*'
-
-# 5. Elvish completions produce a valid completion script.
+# 4. Elvish completions produce a valid completion script.
 snouty completions elvish
 stdout '.*snouty.*'
 
-# 6. Unsupported shells are rejected.
+# 5. Unsupported shells are rejected.
 ! snouty completions nushell
 stderr 'unsupported shell: nushell.*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ Using Moment.from (copy from triage report):
 
     /// Output shell completions
     Completions {
-        /// Shell to generate completions for (bash, zsh, fish, powershell, elvish)
+        /// Shell to generate completions for (bash, zsh, fish, elvish)
         shell: String,
     },
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -24,7 +24,7 @@ pub trait ContainerRuntime: Send + Sync {
     /// Build a scratch image containing the directory contents.
     fn build_image(&self, config_dir: &Path, image_ref: &str) -> Result<()> {
         let runtime = self.name();
-        let mut child = runtime_command(runtime)
+        let mut child = Command::new(runtime)
             .args(["build", "-t", image_ref, "-f", "-", "."])
             .current_dir(config_dir)
             .stdin(std::process::Stdio::piped())
@@ -124,7 +124,7 @@ impl ContainerRuntime for PodmanRuntime {
 
         args.push(image_ref);
 
-        let output = runtime_command(&self.cmd)
+        let output = Command::new(&self.cmd)
             .args(&args)
             .output()
             .wrap_err(format!("failed to run '{} push'", self.cmd))?;
@@ -166,7 +166,7 @@ impl ContainerRuntime for DockerRuntime {
     }
 
     fn image_push(&self, image_ref: &str) -> Result<String> {
-        let output = runtime_command(&self.cmd)
+        let output = Command::new(&self.cmd)
             .args(["push", image_ref])
             .output()
             .wrap_err(format!("failed to run '{} push'", self.cmd))?;
@@ -214,7 +214,7 @@ pub fn validate_config_dir(config_dir: &Path) -> Result<()> {
 
 /// Run `{runtime} compose config` to validate the compose file.
 fn validate_compose_file(runtime: &str, config_dir: &Path) -> Result<()> {
-    let output = runtime_command(runtime)
+    let output = Command::new(runtime)
         // Keep compose validation independent of directory naming quirks.
         .env("COMPOSE_PROJECT_NAME", "snouty")
         .args(["compose", "config", "--quiet"])
@@ -251,7 +251,7 @@ pub fn generate_image_ref(registry: &str) -> String {
 /// `docker version` (the subcommand) prints "Podman Engine" in the Client field
 /// when docker is actually podman, while `docker --version` does not.
 pub(crate) fn is_podman_in_disguise(cmd: &str) -> bool {
-    runtime_command(cmd)
+    Command::new(cmd)
         .arg("version")
         .output()
         .ok()
@@ -280,7 +280,7 @@ pub fn runtime() -> Result<&'static dyn ContainerRuntime> {
             }
 
             // Try podman first
-            match runtime_command("podman").arg("--version").output() {
+            match Command::new("podman").arg("--version").output() {
                 Ok(output) if output.status.success() => {
                     return Ok(Box::new(PodmanRuntime::new("podman")));
                 }
@@ -290,7 +290,7 @@ pub fn runtime() -> Result<&'static dyn ContainerRuntime> {
             }
 
             // Fall back to docker
-            match runtime_command("docker").arg("--version").output() {
+            match Command::new("docker").arg("--version").output() {
                 Ok(output) if output.status.success() => {
                     if is_podman_in_disguise("docker") {
                         log::warn!("podman not found as 'podman', but 'docker' is podman");
@@ -386,7 +386,7 @@ fn parse_docker_push_digest(stdout: &str) -> Result<String> {
 /// Extract image references from the docker-compose.yaml in the given config directory.
 /// Uses `{runtime} compose config` to resolve env variable substitutions.
 fn extract_image_refs(runtime: &str, config_dir: &Path) -> Result<Vec<String>> {
-    let output = runtime_command(runtime)
+    let output = Command::new(runtime)
         // Keep image extraction independent of directory naming quirks.
         .env("COMPOSE_PROJECT_NAME", "snouty")
         .args(["compose", "config"])
@@ -436,53 +436,6 @@ fn filter_pushable_images<'a>(images: &'a [String], registry: &str) -> Vec<&'a s
         .filter(|img| img.starts_with(&prefix))
         .map(|s| s.as_str())
         .collect()
-}
-
-fn runtime_command(cmd: &str) -> Command {
-    Command::new(resolve_runtime_command(cmd))
-}
-
-#[cfg(not(windows))]
-fn resolve_runtime_command(cmd: &str) -> PathBuf {
-    PathBuf::from(cmd)
-}
-
-#[cfg(windows)]
-fn resolve_runtime_command(cmd: &str) -> PathBuf {
-    let path = Path::new(cmd);
-    if path.components().count() > 1 || path.extension().is_some() {
-        return path.to_path_buf();
-    }
-
-    find_on_path(path).unwrap_or_else(|| path.to_path_buf())
-}
-
-#[cfg(windows)]
-fn find_on_path(cmd: &Path) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    let pathext = std::env::var_os("PATHEXT")
-        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into())
-        .to_string_lossy()
-        .split(';')
-        .filter(|ext| !ext.is_empty())
-        .map(|ext| ext.to_ascii_lowercase())
-        .collect::<Vec<_>>();
-
-    for dir in std::env::split_paths(&path) {
-        let candidate = dir.join(cmd);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-
-        for ext in &pathext {
-            let candidate = dir.join(format!("{}{}", cmd.display(), ext));
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-    }
-
-    None
 }
 
 #[cfg(test)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -173,21 +173,8 @@ fn atomic_write_db(bytes: &[u8]) -> Result<()> {
 
     let db_path = db_path()?;
 
-    #[cfg(windows)]
-    if db_path.exists() {
-        let metadata = fs::metadata(&db_path)?;
-        let mut perms = metadata.permissions();
-        if perms.readonly() {
-            perms.set_readonly(false);
-            fs::set_permissions(&db_path, perms)?;
-        }
-        fs::remove_file(&db_path)?;
-    }
-
     tmp.persist(&db_path).map_err(|e| e.error)?;
 
-    // Mark the final file read-only after the atomic rename so Windows
-    // observes the permission change on the persisted path.
     let metadata = fs::metadata(&db_path)?;
     let mut perms = metadata.permissions();
     perms.set_readonly(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,11 +280,10 @@ fn cmd_completions(shell: String) -> Result<()> {
         "bash" => include_str!(concat!(env!("OUT_DIR"), "/snouty.bash")),
         "zsh" => include_str!(concat!(env!("OUT_DIR"), "/_snouty")),
         "fish" => include_str!(concat!(env!("OUT_DIR"), "/snouty.fish")),
-        "powershell" => include_str!(concat!(env!("OUT_DIR"), "/_snouty.ps1")),
         "elvish" => include_str!(concat!(env!("OUT_DIR"), "/snouty.elv")),
         _ => {
             bail!(
-                "invalid arguments: unsupported shell: {shell}\nsupported: bash, zsh, fish, powershell, elvish"
+                "invalid arguments: unsupported shell: {shell}\nsupported: bash, zsh, fish, elvish"
             );
         }
     };

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -43,7 +43,7 @@ pub struct OCIRegistry {
 
 impl OCIRegistry {
     /// Try to start a local OCI registry container.  Returns `None` when the
-    /// container cannot be launched (e.g. Linux-only image on a Windows host).
+    /// container cannot be launched.
     pub fn start(runtime: &dyn ContainerRuntime) -> Option<Self> {
         if !runtime_supports_linux_registry_image(runtime.name()) {
             eprintln!(
@@ -105,7 +105,7 @@ impl OCIRegistry {
     }
 
     /// Returns `true` when the registry is ready, `false` when it exited or
-    /// timed out (e.g. Linux image on a Windows Docker host).
+    /// timed out.
     fn wait_until_ready(&mut self) -> bool {
         for _ in 0..200 {
             if registry_v2_ping(self.port) {
@@ -264,29 +264,7 @@ pub fn filtered_path_without_binary(binary: &str) -> Option<String> {
 }
 
 fn directory_contains_binary(dir: &Path, binary: &str) -> bool {
-    let candidate = dir.join(binary);
-    if candidate.is_file() {
-        return true;
-    }
-
-    #[cfg(windows)]
-    {
-        let pathext = std::env::var_os("PATHEXT")
-            .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into())
-            .to_string_lossy()
-            .split(';')
-            .filter(|ext| !ext.is_empty())
-            .map(|ext| ext.to_ascii_lowercase())
-            .collect::<Vec<_>>();
-
-        for ext in pathext {
-            if dir.join(format!("{binary}{ext}")).is_file() {
-                return true;
-            }
-        }
-    }
-
-    false
+    dir.join(binary).is_file()
 }
 
 #[cfg(test)]
@@ -307,11 +285,6 @@ mod tests {
     #[test]
     fn docker_info_with_linux_os_type_supports_registry() {
         assert!(docker_info_supports_linux_registry("linux\n"));
-    }
-
-    #[test]
-    fn docker_info_with_windows_os_type_rejects_registry() {
-        assert!(!docker_info_supports_linux_registry("windows\r\n"));
     }
 
     #[cfg(unix)]
@@ -379,13 +352,5 @@ mod tests {
             log.lines().any(|line| line == "pull registry:2"),
             "expected registry pull command in log, got: {log}"
         );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn directory_contains_windows_binary_extension() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("snouty-update.exe"), "").unwrap();
-        assert!(directory_contains_binary(dir.path(), "snouty-update"));
     }
 }

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -38,8 +38,7 @@ fn cmd_snouty(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     // Forward system env vars needed by container tools, networking, and coverage.
-    // SYSTEMROOT is required on Windows for Winsock (networking) to initialise.
-    for var in ["PATH", "HOME", "SYSTEMROOT", "LLVM_PROFILE_FILE"] {
+    for var in ["PATH", "HOME", "LLVM_PROFILE_FILE"] {
         if let Ok(v) = std::env::var(var) {
             cmd.env(var, v);
         }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -228,32 +228,13 @@ impl ContainerRuntimeShim {
 }
 
 /// Install a shell shim into `dir` so it is found on PATH as `name`.
-///
-/// On Unix the script is written directly as an executable file.
-/// On Windows a tiny `.cmd` wrapper delegates to bash (available via Git
-/// for Windows on all GitHub Actions runners).
 fn install_shim(dir: &Path, name: &str, content: &str) {
-    #[cfg(not(windows))]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let path = dir.join(name);
-        fs::write(&path, content).unwrap();
-        let mut perms = fs::metadata(&path).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).unwrap();
-    }
-
-    #[cfg(windows)]
-    {
-        let sh_name = format!("{name}.sh");
-        fs::write(dir.join(&sh_name), content).unwrap();
-        let cmd_path = dir.join(format!("{name}.cmd"));
-        fs::write(
-            cmd_path,
-            format!("@echo off\r\nbash \"%~dp0{sh_name}\" %*\r\nexit /b %ERRORLEVEL%\r\n"),
-        )
-        .unwrap();
-    }
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join(name);
+    fs::write(&path, content).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
 }
 
 pub(crate) fn expected_docs_user_agent() -> String {


### PR DESCRIPTION
Windows was only partially supported and added complexity across the codebase. This removes:
- Windows CI matrix entry and related workflow steps
- Windows target and PowerShell installer from dist config
- All #[cfg(windows)] code (PATH/PATHEXT resolution, file permission workarounds, binary extension detection, .cmd shim generation)
- Windows-specific documentation (download link, PowerShell install, PowerShell completions)