### PR TITLE
validate: isolate networks with internal: true in override

### DIFF
--- a/specs_engine/validate.txt
+++ b/specs_engine/validate.txt
@@ -3,6 +3,7 @@
 # 1. Setup-complete only (no test scripts) — validate succeeds.
 build-image setup-emitter:latest setup_emitter
 snouty validate config_no_scripts --timeout 15
+stderr 'Isolating networks: default.*'
 stderr 'Setup-complete event detected.*'
 stderr 'No test scripts in service.*'
 stderr 'Setup validation successful.*'
@@ -42,6 +43,14 @@ stderr 'suite/readme.txt.*'
 build-image noexec:latest noexec
 ! snouty validate config_noexec --timeout 15
 stderr 'FAIL.*'
+
+# 7. Custom networks are isolated and outbound traffic is blocked.
+build-image net-check:latest net_check
+snouty validate config_net_check --timeout 15
+stderr 'Isolating networks: default.*'
+stdout 'Network isolation confirmed.*'
+stderr 'Setup-complete event detected.*'
+stderr 'Setup validation successful.*'
 
 -- setup_emitter/Dockerfile --
 FROM busybox
@@ -156,3 +165,21 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 services:
   runner:
     image: ${ANTITHESIS_REPOSITORY}/noexec:latest
+
+-- net_check/suite/anytime_ping_blocked --
+#!/bin/sh
+if ping -c 1 -W 2 example.org >/dev/null 2>&1; then
+    echo "ERROR: ping to example.org succeeded, network is not isolated"
+    exit 1
+fi
+echo "Network isolation confirmed: ping to example.org failed"
+
+-- net_check/Dockerfile --
+FROM busybox
+COPY suite/ /opt/antithesis/test/v1/suite/
+RUN chmod +x /opt/antithesis/test/v1/suite/*
+CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHESIS_SDK_LOCAL_OUTPUT" && sleep 3600'
+-- config_net_check/docker-compose.yaml --
+services:
+  checker:
+    image: ${ANTITHESIS_REPOSITORY}/net-check:latest

--- a/src/container.rs
+++ b/src/container.rs
@@ -179,8 +179,8 @@ pub trait ContainerRuntime: Send + Sync {
     /// Returns the pinned image reference for each pushed image.
     fn push_compose_images(&self, config_dir: &Path, registry: &str) -> Result<Vec<String>> {
         let yaml = self.compose_config(config_dir)?;
-        let entries = parse_compose_config(&yaml)?;
-        let images: Vec<String> = entries.into_iter().map(|(_, img)| img).collect();
+        let contents = parse_compose_config(&yaml)?;
+        let images: Vec<String> = contents.services.into_iter().map(|(_, img)| img).collect();
         let pushable = filter_pushable_images(&images, registry);
 
         let mut pinned = Vec::new();
@@ -543,24 +543,43 @@ fn parse_docker_push_digest(stdout: &str) -> Result<String> {
     })
 }
 
-/// Parse services from resolved compose config YAML.
-/// Returns `(service_name, image)` pairs. Services without an `image` key are omitted.
-pub fn parse_compose_config(yaml: &str) -> Result<Vec<(String, String)>> {
+/// Parsed contents of a compose config file.
+#[derive(Debug)]
+pub struct ComposeContents {
+    /// `(service_name, image)` pairs. Services without `image` are omitted.
+    pub services: Vec<(String, String)>,
+    /// Explicitly declared network names (from the top-level `networks` key).
+    pub networks: Vec<String>,
+}
+
+/// Parse services and networks from resolved compose config YAML.
+/// Services without an `image` key are omitted.
+pub fn parse_compose_config(yaml: &str) -> Result<ComposeContents> {
     let doc: serde_yaml::Value =
         serde_yaml::from_str(yaml).wrap_err("failed to parse docker-compose.yaml")?;
 
-    let mut entries = Vec::new();
-    if let Some(services) = doc.get("services").and_then(|s| s.as_mapping()) {
-        for (name, service) in services {
+    let mut services = Vec::new();
+    if let Some(svc_map) = doc.get("services").and_then(|s| s.as_mapping()) {
+        for (name, service) in svc_map {
             if let (Some(name), Some(image)) =
                 (name.as_str(), service.get("image").and_then(|i| i.as_str()))
             {
-                entries.push((name.to_string(), image.to_string()));
+                services.push((name.to_string(), image.to_string()));
             }
         }
     }
 
-    Ok(entries)
+    let mut networks = Vec::new();
+    if let Some(net_map) = doc.get("networks").and_then(|s| s.as_mapping()) {
+        for name in net_map.keys() {
+            if let Some(name) = name.as_str() {
+                networks.push(name.to_string());
+            }
+        }
+    }
+    networks.sort();
+
+    Ok(ComposeContents { services, networks })
 }
 
 /// Filter images to only those that should be pushed: images whose name
@@ -792,9 +811,9 @@ services:
     build:
       context: ./builder
 ";
-        let entries = parse_compose_config(yaml).unwrap();
+        let contents = parse_compose_config(yaml).unwrap();
         assert_eq!(
-            entries,
+            contents.services,
             vec![
                 (
                     "app".to_string(),
@@ -806,13 +825,30 @@ services:
                 ),
             ]
         );
+        assert!(contents.networks.is_empty());
     }
 
     #[test]
     fn parse_compose_config_no_services() {
         let yaml = "version: '3'\n";
-        let entries = parse_compose_config(yaml).unwrap();
-        assert!(entries.is_empty());
+        let contents = parse_compose_config(yaml).unwrap();
+        assert!(contents.services.is_empty());
+    }
+
+    #[test]
+    fn parse_compose_config_with_networks() {
+        let yaml = "\
+services:
+  app:
+    image: myapp:latest
+networks:
+  backend: {}
+  frontend:
+    driver: bridge
+";
+        let contents = parse_compose_config(yaml).unwrap();
+        assert_eq!(contents.services.len(), 1);
+        assert_eq!(contents.networks, vec!["backend", "frontend"]);
     }
 
     #[test]
@@ -843,8 +879,12 @@ services:
             .unwrap();
 
             let yaml = rt.compose_config(dir.path()).unwrap();
-            let entries = parse_compose_config(&yaml).unwrap();
-            let images: Vec<&str> = entries.iter().map(|(_, img)| img.as_str()).collect();
+            let contents = parse_compose_config(&yaml).unwrap();
+            let images: Vec<&str> = contents
+                .services
+                .iter()
+                .map(|(_, img)| img.as_str())
+                .collect();
             assert_eq!(
                 images,
                 vec![

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -31,8 +31,8 @@ struct SetupStatus {
 /// `compose_yaml` should be the resolved output of `compose_config()`.
 /// Returns the path to the generated override file.
 fn generate_setup_override(compose_yaml: &str, temp_dir: &Path) -> Result<PathBuf> {
-    let entries = container::parse_compose_config(compose_yaml)?;
-    if entries.is_empty() {
+    let contents = container::parse_compose_config(compose_yaml)?;
+    if contents.services.is_empty() {
         bail!("no services found in docker-compose.yaml");
     }
 
@@ -43,7 +43,7 @@ fn generate_setup_override(compose_yaml: &str, temp_dir: &Path) -> Result<PathBu
     let vol = format!("{}:/tmp/antithesis", antithesis_dir.display());
 
     let mut services = serde_yaml::Mapping::new();
-    for (name, _) in &entries {
+    for (name, _) in &contents.services {
         let mut svc = serde_yaml::Mapping::new();
         svc.insert(
             serde_yaml::Value::String("volumes".to_string()),
@@ -64,10 +64,36 @@ fn generate_setup_override(compose_yaml: &str, temp_dir: &Path) -> Result<PathBu
         );
     }
 
+    // Build network overrides: always include "default", plus any explicit networks.
+    let mut net_names = contents.networks;
+    if !net_names.contains(&"default".to_string()) {
+        net_names.push("default".to_string());
+    }
+    net_names.sort();
+
+    eprintln!("Isolating networks: {}", net_names.join(", "));
+
+    let mut networks = serde_yaml::Mapping::new();
+    for name in &net_names {
+        let mut net = serde_yaml::Mapping::new();
+        net.insert(
+            serde_yaml::Value::String("internal".to_string()),
+            serde_yaml::Value::Bool(true),
+        );
+        networks.insert(
+            serde_yaml::Value::String(name.clone()),
+            serde_yaml::Value::Mapping(net),
+        );
+    }
+
     let mut doc = serde_yaml::Mapping::new();
     doc.insert(
         serde_yaml::Value::String("services".to_string()),
         serde_yaml::Value::Mapping(services),
+    );
+    doc.insert(
+        serde_yaml::Value::String("networks".to_string()),
+        serde_yaml::Value::Mapping(networks),
     );
 
     let override_yaml =
@@ -434,6 +460,59 @@ services:
                 "/tmp/antithesis/sdk_output.jsonl"
             );
         }
+
+        // Check networks — default should always be present and internal
+        let networks = doc.get("networks").unwrap().as_mapping().unwrap();
+        let default_net = networks
+            .get(&serde_yaml::Value::String("default".to_string()))
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+        assert_eq!(
+            default_net
+                .get(&serde_yaml::Value::String("internal".to_string()))
+                .unwrap()
+                .as_bool()
+                .unwrap(),
+            true
+        );
+    }
+
+    #[test]
+    fn generate_setup_override_custom_networks() {
+        let compose_yaml = "\
+services:
+  app:
+    image: myapp:latest
+networks:
+  backend: {}
+  frontend:
+    driver: bridge
+";
+        let dir = tempfile::tempdir().unwrap();
+        let path = generate_setup_override(compose_yaml, dir.path()).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+
+        let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let networks = doc.get("networks").unwrap().as_mapping().unwrap();
+
+        // All three networks should be present: backend, default, frontend
+        for name in ["backend", "default", "frontend"] {
+            let net = networks
+                .get(&serde_yaml::Value::String(name.to_string()))
+                .unwrap()
+                .as_mapping()
+                .unwrap();
+            assert_eq!(
+                net.get(&serde_yaml::Value::String("internal".to_string()))
+                    .unwrap()
+                    .as_bool()
+                    .unwrap(),
+                true,
+                "network '{name}' should be internal"
+            );
+        }
+        assert_eq!(networks.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Mark all compose networks as internal in the generated override file, preventing containers from reaching the internet during local validation (matching Antithesis production behavior). The default network is always included, plus any explicitly declared networks.

Refactors parse_compose_config to return a ComposeContents struct with both services and networks fields.