### PR TITLE
kill compose logs process group to suppress post-setup output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "getrandom 0.3.4",
  "json5",
  "jsonschema",
+ "libc",
  "log",
  "predicates",
  "ptree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ console = "0.15"
 dirs = "6"
 tempfile = "3"
 pulldown-cmark = "0.13"
+libc = "0.2"
 regex = "1"
 ptree = { version = "0.5.2", default-features = false }
 serde_yaml = "0.9"

--- a/src/container.rs
+++ b/src/container.rs
@@ -309,6 +309,7 @@ pub trait ContainerRuntime: Send + Sync {
         cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
+        cmd.process_group(0);
 
         cmd.spawn()
             .wrap_err_with(|| format!("failed to start '{runtime} compose logs --follow'"))

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -154,9 +154,13 @@ pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
         _ = tokio::signal::ctrl_c() => Err(color_eyre::eyre::eyre!("interrupted")),
     };
 
-    // Stop compose logs so subsequent status messages aren't interleaved
-    // with container output.
-    let _ = logs_child.kill().await;
+    // Stop the entire compose logs process group so child processes
+    // (e.g. per-service `podman logs`) don't keep writing to the terminal.
+    if let Some(pid) = logs_child.id() {
+        unsafe {
+            libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+        }
+    }
     let _ = logs_child.wait().await;
 
     // After setup-complete, discover and execute test scripts while compose is still running.


### PR DESCRIPTION
compose logs --follow (especially podman-compose) spawns child processes that inherit the terminal's stdout/stderr FDs. Killing only the top-level process left those children writing to the terminal after "Setup-complete event detected." Start the logs child as a process group leader (process_group(0)) and send SIGKILL to the entire group (-pgid) when stopping.