### PR TITLE
detect and tag local build images for registry push

### DIFF
--- a/specs_engine/run_config_push.txt
+++ b/specs_engine/run_config_push.txt
@@ -1,10 +1,11 @@
 # snouty run --config — image push and pinning
 #
-# When --config is used, snouty pushes compose images matching
-# ANTITHESIS_REPOSITORY and builds+pushes a config image.
+# When --config is used, snouty detects local build images, tags them
+# with the ANTITHESIS_REPOSITORY prefix, and pushes them alongside a
+# config image.
 # Both get pinned references (name@sha256:digest) in the webhook params.
 
-# 1. Compose images matching the registry are pushed and pinned.
+# 1. Local build images are tagged with registry prefix, pushed and pinned.
 mock-server 200 '{"status": "ok"}'
 build-image myapp:latest images/myapp
 build-image sidecar:v1 images/sidecar
@@ -19,13 +20,19 @@ snouty run -w basic_test -c external_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
-# 3. Mixed: only matching images appear in antithesis.images.
+# 3. Mixed: local build image is tagged+pushed, external image is skipped.
 mock-server 200 '{"status": "ok"}'
 build-image myapp:latest images/myapp
 snouty run -w basic_test -c mixed_config --duration 30
 stderr '"antithesis.images":.*myapp@sha256:'
 ! stderr 'nginx.*@sha256:'
 stderr '"antithesis.config_image":.*@sha256:'
+
+# 4. Local image without build stanza is not pushed.
+mock-server 200 '{"status": "ok"}'
+snouty run -w basic_test -c local_no_build_config --duration 30
+stderr '"antithesis.config_image":.*@sha256:'
+! stderr '"antithesis.images"'
 
 -- images/myapp/content --
 placeholder
@@ -34,9 +41,11 @@ placeholder
 -- push_config/docker-compose.yaml --
 services:
   app:
-    image: ${ANTITHESIS_REPOSITORY}/myapp:latest
+    build: .
+    image: myapp:latest
   sidecar:
-    image: ${ANTITHESIS_REPOSITORY}/sidecar:v1
+    build: .
+    image: sidecar:v1
 -- external_config/docker-compose.yaml --
 services:
   app:
@@ -44,6 +53,11 @@ services:
 -- mixed_config/docker-compose.yaml --
 services:
   app:
-    image: ${ANTITHESIS_REPOSITORY}/myapp:latest
+    build: .
+    image: myapp:latest
   nginx:
     image: docker.io/library/nginx:latest
+-- local_no_build_config/docker-compose.yaml --
+services:
+  app:
+    image: localapp:latest

--- a/specs_engine/validate.txt
+++ b/specs_engine/validate.txt
@@ -67,7 +67,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_no_scripts/docker-compose.yaml --
 services:
   emitter:
-    image: ${ANTITHESIS_REPOSITORY}/setup-emitter:latest
+    image: setup-emitter:latest
+    pull_policy: never
 
 -- all_types/suite/first_setup --
 #!/bin/sh
@@ -101,9 +102,11 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_all_types/docker-compose.yaml --
 services:
   runner:
-    image: ${ANTITHESIS_REPOSITORY}/all-types:latest
+    image: all-types:latest
+    pull_policy: never
   sidecar:
-    image: ${ANTITHESIS_REPOSITORY}/setup-emitter:latest
+    image: setup-emitter:latest
+    pull_policy: never
 
 -- fail_with_finally/suite/first_setup --
 #!/bin/sh
@@ -127,7 +130,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_fail_finally/docker-compose.yaml --
 services:
   runner:
-    image: ${ANTITHESIS_REPOSITORY}/fail-with-finally:latest
+    image: fail-with-finally:latest
+    pull_policy: never
 
 -- nodrivers/suite/first_setup --
 #!/bin/sh
@@ -141,7 +145,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_nodrivers/docker-compose.yaml --
 services:
   runner:
-    image: ${ANTITHESIS_REPOSITORY}/nodrivers:latest
+    image: nodrivers:latest
+    pull_policy: never
 
 -- unknown_prefix/suite/first_ok --
 #!/bin/sh
@@ -158,7 +163,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_unknown/docker-compose.yaml --
 services:
   runner:
-    image: ${ANTITHESIS_REPOSITORY}/unknown-prefix:latest
+    image: unknown-prefix:latest
+    pull_policy: never
 
 -- noexec/suite/first_noexec --
 #!/bin/sh
@@ -176,7 +182,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_noexec/docker-compose.yaml --
 services:
   runner:
-    image: ${ANTITHESIS_REPOSITORY}/noexec:latest
+    image: noexec:latest
+    pull_policy: never
 
 -- net_check/suite/anytime_ping_blocked --
 #!/bin/sh
@@ -194,7 +201,8 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_net_check/docker-compose.yaml --
 services:
   checker:
-    image: ${ANTITHESIS_REPOSITORY}/net-check:latest
+    image: net-check:latest
+    pull_policy: never
 
 -- sdk_local_emitter/Dockerfile --
 FROM busybox
@@ -202,4 +210,5 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 -- config_sdk_local/docker-compose.yaml --
 services:
   emitter:
-    image: ${ANTITHESIS_REPOSITORY}/sdk-local-emitter:latest
+    image: sdk-local-emitter:latest
+    pull_policy: never

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -88,6 +89,21 @@ pub trait ContainerRuntime: Send + Sync {
     /// Push the image to the registry, returning the pinned image reference
     /// (e.g. `example.com/foo/image@sha256:...`).
     fn image_push(&self, image_ref: &str) -> Result<String>;
+
+    /// Tag an image with a new reference.
+    fn image_tag(&self, src: &str, dst: &str) -> Result<()> {
+        let runtime = self.name();
+        let output = Command::new(runtime)
+            .args(["tag", src, dst])
+            .output()
+            .wrap_err(format!("failed to run '{runtime} tag'"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(eyre!("'{runtime} tag {src} {dst}' failed"))
+                .with_section(move || stderr.trim().to_string().header("Stderr:"));
+        }
+        Ok(())
+    }
 
     /// Build a container image from a directory.
     ///
@@ -182,9 +198,30 @@ pub trait ContainerRuntime: Send + Sync {
     fn push_compose_images(&self, config_dir: &Path, registry: &str) -> Result<Vec<String>> {
         let yaml = self.compose_config(config_dir)?;
         let contents = parse_compose_config(&yaml)?;
-        let images: Vec<String> = contents.services.into_iter().map(|(_, img)| img).collect();
-        let pushable = filter_pushable_images(&images, registry);
+        let registry_trimmed = registry.trim_end_matches('/');
+        let prefix = format!("{registry_trimmed}/");
 
+        // Phase 1: Build the image list. Local build images get tagged with
+        // the registry prefix so they become pushable.
+        let mut tagged = HashSet::new();
+        let mut images = Vec::new();
+        for (name, image) in &contents.services {
+            if contents.build_services.contains(name)
+                && is_local_image(image)
+                && !image.starts_with(&prefix)
+            {
+                let dest = format!("{prefix}{image}");
+                if tagged.insert(image.clone()) {
+                    self.image_tag(image, &dest)?;
+                }
+                images.push(dest);
+            } else {
+                images.push(image.clone());
+            }
+        }
+
+        // Phase 2: Push images matching registry prefix (existing logic).
+        let pushable = filter_pushable_images(&images, registry);
         let mut pinned = Vec::new();
         for image in pushable {
             eprintln!("Pushing image: {image}");
@@ -192,7 +229,6 @@ pub trait ContainerRuntime: Send + Sync {
             eprintln!("Image pushed: {p}");
             pinned.push(p);
         }
-
         Ok(pinned)
     }
 
@@ -606,6 +642,8 @@ fn parse_docker_push_digest(stdout: &str) -> Result<String> {
 pub struct ComposeContents {
     /// `(service_name, image)` pairs. Services without `image` are omitted.
     pub services: Vec<(String, String)>,
+    /// Service names that have a `build:` stanza.
+    pub build_services: HashSet<String>,
     /// Explicitly declared network names (from the top-level `networks` key).
     pub networks: Vec<String>,
 }
@@ -617,12 +655,16 @@ pub fn parse_compose_config(yaml: &str) -> Result<ComposeContents> {
         serde_yaml::from_str(yaml).wrap_err("failed to parse docker-compose.yaml")?;
 
     let mut services = Vec::new();
+    let mut build_services = HashSet::new();
     if let Some(svc_map) = doc.get("services").and_then(|s| s.as_mapping()) {
         for (name, service) in svc_map {
-            if let (Some(name), Some(image)) =
-                (name.as_str(), service.get("image").and_then(|i| i.as_str()))
-            {
-                services.push((name.to_string(), image.to_string()));
+            if let Some(name_str) = name.as_str() {
+                if service.get("build").is_some() {
+                    build_services.insert(name_str.to_string());
+                }
+                if let Some(image) = service.get("image").and_then(|i| i.as_str()) {
+                    services.push((name_str.to_string(), image.to_string()));
+                }
             }
         }
     }
@@ -644,7 +686,11 @@ pub fn parse_compose_config(yaml: &str) -> Result<ComposeContents> {
     }
     networks.sort();
 
-    Ok(ComposeContents { services, networks })
+    Ok(ComposeContents {
+        services,
+        build_services,
+        networks,
+    })
 }
 
 /// Filter images to only those that should be pushed: images whose name
@@ -652,12 +698,28 @@ pub fn parse_compose_config(yaml: &str) -> Result<ComposeContents> {
 fn filter_pushable_images<'a>(images: &'a [String], registry: &str) -> Vec<&'a str> {
     let registry = registry.trim_end_matches('/');
     let prefix = format!("{registry}/");
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     images
         .iter()
         .filter(|img| img.starts_with(&prefix) && seen.insert(img.as_str()))
         .map(|s| s.as_str())
         .collect()
+}
+
+/// Check whether an image reference is "local" (not from a remote registry).
+///
+/// An image is local if its first path component has no dots, no colons, and
+/// is not literally "localhost". Examples:
+/// - `myapp:latest` -> local
+/// - `org/myapp:latest` -> local
+/// - `docker.io/library/nginx:latest` -> not local
+/// - `localhost/myapp:latest` -> not local
+/// - `registry:5000/myapp:latest` -> not local
+fn is_local_image(image: &str) -> bool {
+    match image.split_once('/') {
+        None => true,
+        Some((first, _)) => !(first.contains('.') || first.contains(':') || first == "localhost"),
+    }
 }
 
 /// Parse the JSON output of `compose ps --format json`.
@@ -866,6 +928,10 @@ services:
                 ),
             ]
         );
+        assert_eq!(
+            contents.build_services,
+            HashSet::from(["builder".to_string()])
+        );
         assert!(contents.networks.is_empty());
     }
 
@@ -874,6 +940,7 @@ services:
         let yaml = "version: '3'\n";
         let contents = parse_compose_config(yaml).unwrap();
         assert!(contents.services.is_empty());
+        assert!(contents.build_services.is_empty());
     }
 
     #[test]
@@ -889,6 +956,7 @@ networks:
 ";
         let contents = parse_compose_config(yaml).unwrap();
         assert_eq!(contents.services.len(), 1);
+        assert!(contents.build_services.is_empty());
         assert_eq!(contents.networks, vec!["backend", "frontend"]);
     }
 
@@ -1090,5 +1158,64 @@ tag2: digest: sha256:bbb222 size: 200
             pinned_image_ref("registry.example.com/team/service@sha256:old", "sha256:new"),
             "registry.example.com/team/service@sha256:new"
         );
+    }
+
+    #[test]
+    fn is_local_image_bare_name() {
+        assert!(is_local_image("myapp:latest"));
+    }
+
+    #[test]
+    fn is_local_image_org_name() {
+        assert!(is_local_image("myorg/myapp:latest"));
+    }
+
+    #[test]
+    fn is_local_image_registry_with_dot() {
+        assert!(!is_local_image("registry.example.com/myapp:latest"));
+    }
+
+    #[test]
+    fn is_local_image_docker_io() {
+        assert!(!is_local_image("docker.io/library/nginx:latest"));
+    }
+
+    #[test]
+    fn is_local_image_localhost() {
+        assert!(!is_local_image("localhost/myapp:latest"));
+    }
+
+    #[test]
+    fn is_local_image_localhost_port() {
+        assert!(!is_local_image("localhost:5000/myapp:latest"));
+    }
+
+    #[test]
+    fn is_local_image_host_port() {
+        assert!(!is_local_image("myregistry:5000/myapp:latest"));
+    }
+
+    #[test]
+    fn parse_compose_config_build_with_image() {
+        let yaml = "\
+services:
+  app:
+    build: .
+    image: myapp:latest
+  sidecar:
+    image: docker.io/library/nginx:latest
+";
+        let contents = parse_compose_config(yaml).unwrap();
+        assert_eq!(
+            contents.services,
+            vec![
+                ("app".to_string(), "myapp:latest".to_string()),
+                (
+                    "sidecar".to_string(),
+                    "docker.io/library/nginx:latest".to_string()
+                ),
+            ]
+        );
+        assert_eq!(contents.build_services, HashSet::from(["app".to_string()]));
     }
 }

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -13,7 +13,6 @@ fn err(msg: String) -> testscript_rs::Error {
 // --- Engine context (thread-local so fn-pointer commands can access it) ---
 
 struct EngineContext {
-    registry: String,
     engine: Box<dyn snouty::container::ContainerRuntime>,
     built_images: Vec<String>,
 }
@@ -147,7 +146,7 @@ fn cmd_build_image(
         let ctx = ctx
             .as_mut()
             .ok_or_else(|| err("ENGINE_CTX not set".to_string()))?;
-        let image_ref = format!("{}/{}", ctx.registry, args[0]);
+        let image_ref = args[0].to_string();
         let dir = env.work_dir.join(&args[1]);
         let dockerfile = dir.join("Dockerfile");
         let dockerfile = dockerfile.exists().then_some(dockerfile.as_path());
@@ -237,7 +236,6 @@ fn engine_spec_tests() {
         let registry_addr = registry.host_port();
 
         ENGINE_CTX.set(Some(EngineContext {
-            registry: registry_addr.clone(),
             engine: engine.clone_box(),
             built_images: Vec::new(),
         }));
@@ -263,6 +261,11 @@ fn engine_spec_tests() {
                 for image in &ctx.built_images {
                     let _ = std::process::Command::new(engine.name())
                         .args(["rmi", "-f", image])
+                        .output();
+                    // Remove registry-prefixed copy created by push_compose_images.
+                    let prefixed = format!("{registry_addr}/{image}");
+                    let _ = std::process::Command::new(engine.name())
+                        .args(["rmi", "-f", &prefixed])
                         .output();
                 }
             }


### PR DESCRIPTION
Local images with a build: stanza in the compose file were silently skipped during push because they lacked the registry prefix. Now push_compose_images detects these, tags them with the registry prefix, and includes them in the push list.

Fixes: https://github.com/antithesishq/snouty/issues/38