### PR TITLE
podman: support docker-compose backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,16 @@ jobs:
         include:
           - os: ubuntu-latest
             runtime: docker
+            compose: docker-compose
           - os: ubuntu-latest
             runtime: podman
+            compose: podman-compose
+          - os: ubuntu-latest
+            runtime: podman
+            compose: docker-compose
           - os: macos-15-intel
             runtime: podman
+            compose: podman-compose
     env:
       SNOUTY_TEST_RUNTIME: ${{ matrix.runtime }}
     steps:
@@ -91,24 +97,32 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@cargo-nextest
 
-      # Actions has both Docker and Podman installed by default. We only want
-      # to test with either.
+      # The matrix tests three compose backend combinations:
+      #   docker  + docker-compose   (ubuntu)
+      #   podman  + podman-compose   (ubuntu + macOS)
+      #   podman  + docker-compose   (ubuntu)
       #
-      # Additionally, podman compose falls back to docker-compose if it is
-      # installed.
-      #
-      # Finally, current ubuntu-latest (24.04LTS) doesn't have new enough
-      # podman-compose.
+      # Each configure step removes the unwanted tools so the runtime
+      # and compose backend are deterministic.
       - name: Configure Docker (Ubuntu)
         if: matrix.runtime == 'docker' && startsWith(matrix.os, 'ubuntu')
         run: |
           sudo rm -v -f "$(which podman)" "$(which podman-compose)"
 
-      - name: Configure Podman (Ubuntu)
-        if: matrix.runtime == 'podman' && startsWith(matrix.os, 'ubuntu')
+      - name: Configure Podman + podman-compose (Ubuntu)
+        if: matrix.runtime == 'podman' && matrix.compose == 'podman-compose' && startsWith(matrix.os, 'ubuntu')
         run: |
           sudo pip install podman-compose==1.1.0
           sudo rm -v -f "$(which docker)" /usr/libexec/docker/cli-plugins/docker-compose
+
+      - name: Configure Podman + docker-compose (Ubuntu)
+        if: matrix.runtime == 'podman' && matrix.compose == 'docker-compose' && startsWith(matrix.os, 'ubuntu')
+        run: |
+          # Remove docker binary so snouty auto-detects podman, but keep
+          # the docker-compose plugin at /usr/libexec/docker/cli-plugins/
+          # so podman compose dispatches to it.
+          sudo rm -v -f "$(which docker)"
+          systemctl --user start podman.socket
 
       - name: Install Podman (macOS)
         if: matrix.runtime == 'podman' && startsWith(matrix.os, 'macos')
@@ -125,6 +139,7 @@ jobs:
           else
             podman info
           fi
+          ${{ matrix.runtime }} compose version
 
       - name: Test
         run: cargo nextest run
@@ -140,9 +155,9 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           persist-credentials: false
 
-      - name: Configure Docker
+      - name: Start Podman socket # required for docker-compose
         run: |
-          sudo rm -v -f "$(which podman)" "$(which podman-compose)"
+          systemctl --user start podman.socket
 
       - name: Test
         run: nix-shell --run "cargo nextest run"

--- a/src/container.rs
+++ b/src/container.rs
@@ -13,8 +13,8 @@ use tokio::process::Child;
 
 /// Bundles a compose config directory with optional overlay files (e.g. overrides).
 ///
-/// Used by compose session operations (`compose_up`, `compose_ps`, `compose_exec`,
-/// `compose_down`) that run against a live `compose up`.
+/// Used by compose session operations (`up`, `ps`, `exec`,
+/// `down`) that run against a live `compose up`.
 #[derive(Debug)]
 pub struct ComposeConfig {
     dir: PathBuf,
@@ -85,6 +85,23 @@ pub trait ContainerRuntime: Send + Sync {
 
     /// Clone into a boxed trait object.
     fn clone_box(&self) -> Box<dyn ContainerRuntime>;
+
+    /// Return a `Command` pre-configured with the runtime binary and given args.
+    fn command(&self, args: &[&str]) -> Command {
+        let mut cmd = Command::new(self.name());
+        cmd.args(args);
+        cmd
+    }
+
+    /// Like [`command`](Self::command) but returns a [`tokio::process::Command`].
+    fn tokio_command(&self, args: &[&str]) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(self.name());
+        cmd.args(args);
+        cmd
+    }
+
+    /// Return a compose backend appropriate for this runtime.
+    fn compose(&self) -> Box<dyn Compose + '_>;
 
     /// Push the image to the registry, returning the pinned image reference
     /// (e.g. `example.com/foo/image@sha256:...`).
@@ -172,31 +189,10 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(pinned)
     }
 
-    /// Run `compose config` to resolve the compose file with env substitutions,
-    /// returning the resolved YAML as a string.
-    fn compose_config(&self, config_dir: &Path) -> Result<String> {
-        let runtime = self.name();
-        let output = Command::new(runtime)
-            .args(["compose", "-f", "docker-compose.yaml", "config"])
-            .current_dir(config_dir)
-            .output()
-            .wrap_err(format!("failed to run '{runtime} compose config'"))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            return Err(eyre!("'{runtime} compose config' failed"))
-                .with_section(move || stdout.trim().to_string().header("Stdout:"))
-                .with_section(move || stderr.trim().to_string().header("Stderr:"));
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-    }
-
     /// Push compose images that match the registry.
     /// Returns the pinned image reference for each pushed image.
     fn push_compose_images(&self, config_dir: &Path, registry: &str) -> Result<Vec<String>> {
-        let yaml = self.compose_config(config_dir)?;
+        let yaml = self.compose().config(config_dir)?;
         let contents = parse_compose_config(&yaml)?;
         let registry_trimmed = registry.trim_end_matches('/');
         let prefix = format!("{registry_trimmed}/");
@@ -232,28 +228,6 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(pinned)
     }
 
-    /// Parse `compose ps --format json` to get `(service_name, container_id)` pairs.
-    fn compose_ps(&self, config: &ComposeConfig) -> Result<Vec<(String, String)>> {
-        let runtime = self.name();
-        let mut cmd = Command::new(runtime);
-        cmd.current_dir(&config.dir);
-        cmd.arg("compose").args(config.file_args());
-        cmd.args(["ps", "--format", "json"]);
-
-        let output = cmd
-            .output()
-            .wrap_err_with(|| format!("failed to run '{runtime} compose ps'"))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(eyre!("'{runtime} compose ps' failed"))
-                .with_section(move || stderr.trim().to_string().header("Stderr:"));
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        parse_compose_ps(&stdout)
-    }
-
     /// Copy files from a container to the local filesystem.
     ///
     /// Runs `{runtime} cp {container_id}:{src} {dst}`.
@@ -273,6 +247,79 @@ pub trait ContainerRuntime: Send + Sync {
 
         Ok(())
     }
+}
+
+/// Compose backend abstraction.
+///
+/// Implementations customize behavior via hook methods (`extra_args`,
+/// `up_extra_args`, `logs_extra_args`). The default method implementations
+/// build commands using `self.runtime().command()`.
+pub trait Compose: Send + Sync {
+    /// Access the underlying container runtime.
+    fn runtime(&self) -> &dyn ContainerRuntime;
+
+    // --- customization hooks (override per-backend) ---
+
+    /// Extra arguments inserted between file args and the subcommand.
+    fn extra_args(&self) -> &[&str] {
+        &[]
+    }
+
+    /// Extra arguments appended after `up --detach --no-build`.
+    fn up_extra_args(&self) -> &[&str] {
+        &[]
+    }
+
+    /// Extra arguments appended after `logs --follow`.
+    fn logs_extra_args(&self) -> &[&str] {
+        &[]
+    }
+
+    // --- default implementations ---
+
+    /// Run `compose config` to resolve the compose file with env substitutions,
+    /// returning the resolved YAML as a string.
+    fn config(&self, config_dir: &Path) -> Result<String> {
+        let runtime = self.runtime().name();
+        let output = self
+            .runtime()
+            .command(&["compose", "-f", "docker-compose.yaml", "config"])
+            .current_dir(config_dir)
+            .output()
+            .wrap_err(format!("failed to run '{runtime} compose config'"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            return Err(eyre!("'{runtime} compose config' failed"))
+                .with_section(move || stdout.trim().to_string().header("Stdout:"))
+                .with_section(move || stderr.trim().to_string().header("Stderr:"));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    /// Parse `compose ps --format json` to get `(service_name, container_id)` pairs.
+    fn ps(&self, config: &ComposeConfig) -> Result<Vec<(String, String)>> {
+        let runtime = self.runtime().name();
+        let mut cmd = self.runtime().command(&["compose"]);
+        cmd.current_dir(&config.dir);
+        cmd.args(config.file_args());
+        cmd.args(["ps", "--format", "json"]);
+
+        let output = cmd
+            .output()
+            .wrap_err_with(|| format!("failed to run '{runtime} compose ps'"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(eyre!("'{runtime} compose ps' failed"))
+                .with_section(move || stderr.trim().to_string().header("Stderr:"));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        parse_compose_ps(&stdout)
+    }
 
     /// Run a command inside a running compose service container.
     ///
@@ -280,7 +327,7 @@ pub trait ContainerRuntime: Send + Sync {
     /// The `-T` flag disables TTY allocation for non-interactive use.
     /// If `workdir` is `Some`, sets the working directory inside the container.
     /// Stdout and stderr are captured in the returned `Output`.
-    fn compose_exec(
+    fn exec(
         &self,
         config: &ComposeConfig,
         service: &str,
@@ -288,10 +335,10 @@ pub trait ContainerRuntime: Send + Sync {
         env: &[(&str, &str)],
         cmd: &[&str],
     ) -> Result<std::process::Output> {
-        let runtime = self.name();
-        let mut command = Command::new(runtime);
+        let runtime = self.runtime().name();
+        let mut command = self.runtime().command(&["compose"]);
         command.current_dir(&config.dir);
-        command.arg("compose").args(config.file_args());
+        command.args(config.file_args());
         command.args(["exec", "-T"]);
         for (k, v) in env {
             command.args(["-e", &format!("{k}={v}")]);
@@ -310,15 +357,16 @@ pub trait ContainerRuntime: Send + Sync {
     /// Run `compose up --detach` to start services in detached mode.
     ///
     /// stdout and stderr are inherited so progress is visible during pulls.
-    fn compose_up_detached(&self, config: &ComposeConfig) -> Result<()> {
-        let runtime = self.name();
-        let status = Command::new(runtime)
+    fn up_detached(&self, config: &ComposeConfig) -> Result<()> {
+        let runtime = self.runtime().name();
+        let status = self
+            .runtime()
+            .command(&["compose"])
             .current_dir(&config.dir)
-            .arg("compose")
             .args(config.file_args())
-            .args(self.compose_extra_args())
+            .args(self.extra_args())
             .args(["up", "--detach", "--no-build"])
-            .args(self.compose_up_extra_args())
+            .args(self.up_extra_args())
             .status()
             .wrap_err_with(|| format!("failed to run '{runtime} compose up --detach'"))?;
 
@@ -328,42 +376,18 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(())
     }
 
-    /// Extra arguments inserted between file args and the subcommand.
-    ///
-    /// Podman overrides this to include `--podman-run-args=--pull=never`
-    /// since podman compose doesn't support `--pull=never` as an `up` flag.
-    fn compose_extra_args(&self) -> &[&str] {
-        &[]
-    }
-
-    /// Extra arguments to pass to `compose up`.
-    ///
-    /// Docker overrides this to include `--pull=never` so validate never
-    /// pulls or builds images.
-    fn compose_up_extra_args(&self) -> &[&str] {
-        &[]
-    }
-
-    /// Extra arguments to pass to `compose logs`.
-    ///
-    /// Podman overrides this to include `--names` so log lines are prefixed
-    /// with service names (docker does this by default).
-    fn compose_logs_extra_args(&self) -> &[&str] {
-        &[]
-    }
-
     /// Spawn `compose logs --follow` and return the child process.
     ///
     /// stdout and stderr are inherited so compose log output goes straight
     /// to the terminal. stdin is null. The process exits when all
     /// containers stop.
-    fn compose_logs_follow(&self, config: &ComposeConfig) -> Result<Child> {
-        let runtime = self.name();
-        let mut cmd = tokio::process::Command::new(runtime);
+    fn logs_follow(&self, config: &ComposeConfig) -> Result<Child> {
+        let runtime = self.runtime().name();
+        let mut cmd = self.runtime().tokio_command(&["compose"]);
         cmd.current_dir(&config.dir);
-        cmd.arg("compose").args(config.file_args());
+        cmd.args(config.file_args());
         cmd.args(["logs", "--follow"]);
-        cmd.args(self.compose_logs_extra_args());
+        cmd.args(self.logs_extra_args());
         cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
@@ -374,11 +398,10 @@ pub trait ContainerRuntime: Send + Sync {
     }
 
     /// Run `compose down` for cleanup. Best-effort, ignores errors.
-    fn compose_down(&self, config: &ComposeConfig) {
-        let runtime = self.name();
-        let mut cmd = Command::new(runtime);
+    fn down(&self, config: &ComposeConfig) {
+        let mut cmd = self.runtime().command(&["compose"]);
         cmd.current_dir(&config.dir);
-        cmd.arg("compose").args(config.file_args());
+        cmd.args(config.file_args());
         cmd.args(["down", "--timeout", "0"]);
         cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::null());
@@ -387,14 +410,86 @@ pub trait ContainerRuntime: Send + Sync {
     }
 }
 
+struct DockerCompose<'a> {
+    rt: &'a dyn ContainerRuntime,
+}
+
+impl Compose for DockerCompose<'_> {
+    fn runtime(&self) -> &dyn ContainerRuntime {
+        self.rt
+    }
+
+    fn up_extra_args(&self) -> &[&str] {
+        &["--pull=never"]
+    }
+}
+
+struct PodmanCompose<'a> {
+    rt: &'a dyn ContainerRuntime,
+}
+
+impl Compose for PodmanCompose<'_> {
+    fn runtime(&self) -> &dyn ContainerRuntime {
+        self.rt
+    }
+
+    fn extra_args(&self) -> &[&str] {
+        &["--podman-run-args=--pull=never"]
+    }
+
+    fn logs_extra_args(&self) -> &[&str] {
+        &["--names"]
+    }
+}
+
+/// Which compose implementation podman dispatches to.
+#[derive(Clone, Copy)]
+enum ComposeFlavor {
+    /// Podman dispatches to `docker-compose` (standalone binary).
+    DockerCompose,
+    /// Podman dispatches to native `podman-compose`.
+    PodmanCompose,
+}
+
+/// Parse `compose version` output to detect which compose backend is in use.
+///
+/// Returns `DockerCompose` when the output contains "docker compose"
+/// (case-insensitive), otherwise returns `PodmanCompose` as the conservative
+/// fallback.
+fn parse_compose_version(output: &str) -> ComposeFlavor {
+    if output.to_lowercase().contains("docker compose") {
+        ComposeFlavor::DockerCompose
+    } else {
+        ComposeFlavor::PodmanCompose
+    }
+}
+
 #[derive(Clone)]
 pub struct PodmanRuntime {
     cmd: String,
+    compose_flavor: ComposeFlavor,
 }
 
 impl PodmanRuntime {
     pub(crate) fn new(cmd: impl Into<String>) -> Self {
-        Self { cmd: cmd.into() }
+        let cmd = cmd.into();
+        let compose_flavor = Command::new(&cmd)
+            .args(["compose", "version"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    String::from_utf8(o.stdout).ok()
+                } else {
+                    None
+                }
+            })
+            .map(|s| parse_compose_version(&s))
+            .unwrap_or(ComposeFlavor::PodmanCompose);
+        Self {
+            cmd,
+            compose_flavor,
+        }
     }
 }
 
@@ -405,6 +500,13 @@ impl ContainerRuntime for PodmanRuntime {
 
     fn clone_box(&self) -> Box<dyn ContainerRuntime> {
         Box::new(self.clone())
+    }
+
+    fn compose(&self) -> Box<dyn Compose + '_> {
+        match self.compose_flavor {
+            ComposeFlavor::DockerCompose => Box::new(DockerCompose { rt: self }),
+            ComposeFlavor::PodmanCompose => Box::new(PodmanCompose { rt: self }),
+        }
     }
 
     fn image_push(&self, image_ref: &str) -> Result<String> {
@@ -441,14 +543,6 @@ impl ContainerRuntime for PodmanRuntime {
             .to_string();
         Ok(pinned_image_ref(image_ref, &digest))
     }
-
-    fn compose_extra_args(&self) -> &[&str] {
-        &["--podman-run-args=--pull=never"]
-    }
-
-    fn compose_logs_extra_args(&self) -> &[&str] {
-        &["--names"]
-    }
 }
 
 #[derive(Clone)]
@@ -471,8 +565,8 @@ impl ContainerRuntime for DockerRuntime {
         &self.cmd
     }
 
-    fn compose_up_extra_args(&self) -> &[&str] {
-        &["--pull=never"]
+    fn compose(&self) -> Box<dyn Compose + '_> {
+        Box::new(DockerCompose { rt: self })
     }
 
     fn image_push(&self, image_ref: &str) -> Result<String> {
@@ -1034,7 +1128,7 @@ services:
             )
             .unwrap();
 
-            let yaml = rt.compose_config(dir.path()).unwrap();
+            let yaml = rt.compose().config(dir.path()).unwrap();
             let contents = parse_compose_config(&yaml).unwrap();
             let images: Vec<&str> = contents
                 .services
@@ -1247,5 +1341,29 @@ services:
             ]
         );
         assert_eq!(contents.build_services, HashSet::from(["app".to_string()]));
+    }
+
+    #[test]
+    fn parse_compose_version_docker() {
+        assert!(matches!(
+            parse_compose_version("Docker Compose version v2.24.5"),
+            ComposeFlavor::DockerCompose
+        ));
+    }
+
+    #[test]
+    fn parse_compose_version_podman() {
+        assert!(matches!(
+            parse_compose_version("podman-compose version 1.0.6"),
+            ComposeFlavor::PodmanCompose
+        ));
+    }
+
+    #[test]
+    fn parse_compose_version_unknown() {
+        assert!(matches!(
+            parse_compose_version(""),
+            ComposeFlavor::PodmanCompose
+        ));
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -112,37 +112,38 @@ fn generate_setup_override(compose_yaml: &str, temp_dir: &Path) -> Result<PathBu
 }
 
 struct ComposeDownGuard<'a> {
-    rt: &'static dyn container::ContainerRuntime,
+    compose: &'a dyn container::Compose,
     config: &'a ComposeConfig,
 }
 
 impl Drop for ComposeDownGuard<'_> {
     fn drop(&mut self) {
-        self.rt.compose_down(self.config);
+        self.compose.down(self.config);
     }
 }
 
 pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
     let config = ComposeConfig::new(args.config)?;
     let rt = container::runtime()?;
+    let compose = rt.compose();
 
     let temp_dir = tempfile::tempdir()?;
-    let compose_yaml = rt.compose_config(config.dir())?;
+    let compose_yaml = compose.config(config.dir())?;
     let override_path = generate_setup_override(&compose_yaml, temp_dir.path())?;
     let config = config.with_overlay(override_path);
 
     eprintln!("Starting compose services...");
-    rt.compose_up_detached(&config)?;
+    compose.up_detached(&config)?;
     let _guard = ComposeDownGuard {
-        rt,
+        compose: &*compose,
         config: &config,
     };
 
     // Discover scripts early so we can use them for both the success path
     // and the timeout diagnostic.
-    let scripts = discover_scripts(rt, &config, temp_dir.path())?;
+    let scripts = discover_scripts(&*compose, &config, temp_dir.path())?;
 
-    let mut logs_child = rt.compose_logs_follow(&config)?;
+    let mut logs_child = compose.logs_follow(&config)?;
 
     let sdk_output_dir = temp_dir.path().join("antithesis");
     let timeout = Duration::from_secs(args.timeout);
@@ -171,10 +172,10 @@ pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
     let test_result = match result {
         Ok(true) => {
             eprintln!("Setup-complete event detected.");
-            run_test_scripts(rt, &config, &scripts)
+            run_test_scripts(&*compose, &config, &scripts)
         }
         Ok(false) => {
-            diagnose_setup_in_first_scripts(rt, &config, &scripts, temp_dir.path());
+            diagnose_setup_in_first_scripts(&*compose, &config, &scripts, temp_dir.path());
             bail!("timed out waiting for setup-complete event");
         }
         Err(e) => Err(e),
@@ -226,7 +227,7 @@ fn contains_setup_complete(reader: &mut (impl std::io::Read + std::io::Seek)) ->
 /// Run first scripts with a redirected output dir and check if they emit setup_complete.
 /// If so, print a diagnostic explaining the chicken-and-egg problem.
 fn diagnose_setup_in_first_scripts(
-    rt: &dyn container::ContainerRuntime,
+    compose: &dyn container::Compose,
     config: &ComposeConfig,
     scripts: &[TestScript],
     temp_dir: &Path,
@@ -256,7 +257,7 @@ fn diagnose_setup_in_first_scripts(
     for s in &first_scripts {
         let script_dir = format!("/opt/antithesis/test/v1/{}", s.test_name);
         let container_path = format!("{}/{}", script_dir, s.command_name);
-        let _ = rt.compose_exec(
+        let _ = compose.exec(
             config,
             &s.service,
             Some(&script_dir),
@@ -284,11 +285,11 @@ fn diagnose_setup_in_first_scripts(
 
 /// Discover test scripts from running containers.
 fn discover_scripts(
-    rt: &dyn container::ContainerRuntime,
+    compose: &dyn container::Compose,
     config: &ComposeConfig,
     temp_dir: &Path,
 ) -> Result<Vec<TestScript>> {
-    let services = rt.compose_ps(config)?;
+    let services = compose.ps(config)?;
 
     let scripts_dir = temp_dir.join("scripts");
     std::fs::create_dir_all(&scripts_dir).wrap_err("failed to create scripts directory")?;
@@ -296,7 +297,10 @@ fn discover_scripts(
     let mut all_scripts: Vec<TestScript> = Vec::new();
     for (service_name, container_id) in &services {
         let service_dir = scripts_dir.join(service_name);
-        match rt.container_cp(container_id, "/opt/antithesis/test/v1", &service_dir) {
+        match compose
+            .runtime()
+            .container_cp(container_id, "/opt/antithesis/test/v1", &service_dir)
+        {
             Ok(()) => {
                 let result = scan_scripts(&service_dir, service_name)?;
                 if !result.unrecognized.is_empty() {
@@ -327,7 +331,7 @@ fn discover_scripts(
 
 /// Categorize and execute pre-discovered test scripts.
 fn run_test_scripts(
-    rt: &dyn container::ContainerRuntime,
+    compose: &dyn container::Compose,
     config: &ComposeConfig,
     scripts: &[TestScript],
 ) -> Result<()> {
@@ -375,24 +379,24 @@ fn run_test_scripts(
 
     // Execute first scripts (sorted by path — already sorted from scan_scripts)
     for s in &first {
-        ok &= exec_script(rt, config, s, &[])?;
+        ok &= exec_script(compose, config, s, &[])?;
     }
 
     // Execute drivers + anytime (shuffled together)
     let mut runnable: Vec<_> = drivers.iter().chain(anytime.iter()).copied().collect();
     shuffle(&mut runnable);
     for s in &runnable {
-        ok &= exec_script(rt, config, s, &[])?;
+        ok &= exec_script(compose, config, s, &[])?;
     }
 
     // Execute eventually scripts (sorted)
     for s in &eventually {
-        ok &= exec_script(rt, config, s, &[])?;
+        ok &= exec_script(compose, config, s, &[])?;
     }
 
     // Execute finally scripts (sorted)
     for s in &finally {
-        ok &= exec_script(rt, config, s, &[])?;
+        ok &= exec_script(compose, config, s, &[])?;
     }
 
     if !ok {
@@ -406,7 +410,7 @@ fn run_test_scripts(
 ///
 /// Returns `true` if the script succeeded, `false` if it failed.
 fn exec_script(
-    rt: &dyn container::ContainerRuntime,
+    compose: &dyn container::Compose,
     config: &ComposeConfig,
     script: &TestScript,
     env: &[(&str, &str)],
@@ -418,7 +422,7 @@ fn exec_script(
         script.test_name, script.command_name, script.service
     );
 
-    let output = rt.compose_exec(
+    let output = compose.exec(
         config,
         &script.service,
         Some(&script_dir),


### PR DESCRIPTION
`podman compose` prefers to dispatch to `docker-compose` if it is available. We currently assume that it always dispatches to `podman-compose`.

Add a new trait Compose and some detection logic which causes PodmanRuntime to return a DockerCompose impl.

Fixes: https://github.com/antithesishq/snouty/issues/51