### PR TITLE
validate: apply timeout from start of compose up

### DIFF
--- a/specs_engine/validate.txt
+++ b/specs_engine/validate.txt
@@ -57,7 +57,7 @@ stderr 'Setup validation successful.*'
 # 8. Chicken-and-egg: first script emits setup_complete, entrypoint does not.
 #    Validate times out and prints a diagnostic about the deadlock.
 build-image chicken-egg:latest chicken_egg
-! snouty validate config_chicken_egg --timeout 1
+! snouty validate config_chicken_egg --timeout 10
 stderr 'timed out waiting for setup-complete event.*'
 stderr 'suite/first_emit_setup in service runner emits setup_complete.*deadlock.*'
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,7 +93,7 @@ Requires at least one driver or anytime script when test scripts are present.
 
 Example:
   snouty validate ./config
-  snouty validate ./config --timeout 120"#)]
+  snouty validate ./config --timeout 10"#)]
     Validate(ValidateArgs),
 
     /// Print version information

--- a/src/container.rs
+++ b/src/container.rs
@@ -11,6 +11,64 @@ use color_eyre::{
 };
 use tokio::process::Child;
 
+/// RAII wrapper around a [`Child`] spawned with `process_group(0)`.
+///
+/// Ensures the entire process group is killed on drop, not just the leader.
+/// The inner child is `Option<Child>` so `Drop` can handle partially-consumed state.
+pub struct ProcessGroupChild {
+    inner: Option<Child>,
+}
+
+impl ProcessGroupChild {
+    /// Wrap a freshly-spawned child that was created with `process_group(0)`.
+    pub fn new(child: Child) -> Self {
+        Self { inner: Some(child) }
+    }
+
+    /// Send `SIGKILL` to the entire process group, then reap the child.
+    pub async fn kill_group(&mut self) -> std::io::Result<()> {
+        if let Some(ref mut child) = self.inner {
+            if let Some(pid) = child.id() {
+                // Safety: negative PID targets the entire process group.
+                unsafe {
+                    libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+                }
+            }
+            child.wait().await?;
+        }
+        Ok(())
+    }
+
+    /// Delegate to the inner [`Child::wait()`].
+    pub async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.inner
+            .as_mut()
+            .expect("ProcessGroupChild already consumed")
+            .wait()
+            .await
+    }
+
+    /// Delegate to the inner [`Child::id()`].
+    pub fn id(&self) -> Option<u32> {
+        self.inner.as_ref().and_then(|c| c.id())
+    }
+}
+
+impl Drop for ProcessGroupChild {
+    fn drop(&mut self) {
+        if let Some(ref mut child) = self.inner {
+            if let Some(pid) = child.id() {
+                // Safety: best-effort cleanup of the process group.
+                unsafe {
+                    libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+                }
+            }
+            // Best-effort synchronous reap — we can't .await in Drop.
+            let _ = child.try_wait();
+        }
+    }
+}
+
 /// Bundles a compose config directory with optional overlay files (e.g. overrides).
 ///
 /// Used by compose session operations (`up`, `ps`, `exec`,
@@ -354,26 +412,28 @@ pub trait Compose: Send + Sync {
             .wrap_err_with(|| format!("failed to run '{runtime} compose exec'"))
     }
 
-    /// Run `compose up --detach` to start services in detached mode.
+    /// Spawn `compose up --detach` and return the child process.
     ///
     /// stdout and stderr are inherited so progress is visible during pulls.
-    fn up_detached(&self, config: &ComposeConfig) -> Result<()> {
+    /// The caller is responsible for awaiting the child and checking its exit
+    /// status. Uses `process_group(0)` so the whole group can be killed on
+    /// timeout.
+    fn up_detached(&self, config: &ComposeConfig) -> Result<ProcessGroupChild> {
         let runtime = self.runtime().name();
-        let status = self
-            .runtime()
-            .command(&["compose"])
-            .current_dir(&config.dir)
-            .args(config.file_args())
-            .args(self.extra_args())
-            .args(["up", "--detach", "--no-build"])
-            .args(self.up_extra_args())
-            .status()
-            .wrap_err_with(|| format!("failed to run '{runtime} compose up --detach'"))?;
+        let mut cmd = self.runtime().tokio_command(&["compose"]);
+        cmd.current_dir(&config.dir);
+        cmd.args(config.file_args());
+        cmd.args(self.extra_args());
+        cmd.args(["up", "--detach", "--no-build"]);
+        cmd.args(self.up_extra_args());
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::inherit());
+        cmd.stderr(std::process::Stdio::inherit());
+        cmd.process_group(0);
 
-        if !status.success() {
-            bail!("'{runtime} compose up --detach' failed (exit status: {status})");
-        }
-        Ok(())
+        cmd.spawn()
+            .map(ProcessGroupChild::new)
+            .wrap_err_with(|| format!("failed to start '{runtime} compose up --detach'"))
     }
 
     /// Spawn `compose logs --follow` and return the child process.
@@ -381,7 +441,7 @@ pub trait Compose: Send + Sync {
     /// stdout and stderr are inherited so compose log output goes straight
     /// to the terminal. stdin is null. The process exits when all
     /// containers stop.
-    fn logs_follow(&self, config: &ComposeConfig) -> Result<Child> {
+    fn logs_follow(&self, config: &ComposeConfig) -> Result<ProcessGroupChild> {
         let runtime = self.runtime().name();
         let mut cmd = self.runtime().tokio_command(&["compose"]);
         cmd.current_dir(&config.dir);
@@ -394,6 +454,7 @@ pub trait Compose: Send + Sync {
         cmd.process_group(0);
 
         cmd.spawn()
+            .map(ProcessGroupChild::new)
             .wrap_err_with(|| format!("failed to start '{runtime} compose logs --follow'"))
     }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -132,11 +132,31 @@ pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
     let override_path = generate_setup_override(&compose_yaml, temp_dir.path())?;
     let config = config.with_overlay(override_path);
 
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(args.timeout);
+
     eprintln!("Starting compose services...");
-    compose.up_detached(&config)?;
+    let mut up_child = compose.up_detached(&config)?;
     let _guard = ComposeDownGuard {
         compose: &*compose,
         config: &config,
+    };
+
+    // Wait for compose up to finish, but respect the timeout and ctrl+c.
+    tokio::select! {
+        status = up_child.wait() => {
+            let status = status.wrap_err("failed to wait for compose up")?;
+            if !status.success() {
+                bail!("compose up --detach failed (exit status: {status})");
+            }
+        }
+        _ = tokio::time::sleep_until(deadline) => {
+            up_child.kill_group().await.ok();
+            bail!("timed out during 'compose up --detach'");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            up_child.kill_group().await.ok();
+            bail!("interrupted");
+        }
     };
 
     // Discover scripts early so we can use them for both the success path
@@ -146,10 +166,9 @@ pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
     let mut logs_child = compose.logs_follow(&config)?;
 
     let sdk_output_dir = temp_dir.path().join("antithesis");
-    let timeout = Duration::from_secs(args.timeout);
 
     let result = tokio::select! {
-        result = watch_for_setup_complete(&sdk_output_dir, timeout) => result,
+        result = watch_for_setup_complete(&sdk_output_dir, deadline) => result,
         status = logs_child.wait() => {
             match status {
                 Ok(s) if !s.success() => Err(color_eyre::eyre::eyre!("compose exited with status: {s}")),
@@ -162,12 +181,7 @@ pub async fn cmd_validate(args: ValidateArgs) -> Result<()> {
 
     // Stop the entire compose logs process group so child processes
     // (e.g. per-service `podman logs`) don't keep writing to the terminal.
-    if let Some(pid) = logs_child.id() {
-        unsafe {
-            libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-        }
-    }
-    let _ = logs_child.wait().await;
+    logs_child.kill_group().await.ok();
 
     let test_result = match result {
         Ok(true) => {
@@ -465,8 +479,10 @@ fn shuffle<T>(slice: &mut [T]) {
 ///
 /// Uses blocking `std::fs` calls intentionally — reads are small and infrequent,
 /// and this avoids pulling in tokio::fs for a simple poll loop.
-async fn watch_for_setup_complete(output_dir: &Path, timeout: Duration) -> Result<bool> {
-    let deadline = tokio::time::Instant::now() + timeout;
+async fn watch_for_setup_complete(
+    output_dir: &Path,
+    deadline: tokio::time::Instant,
+) -> Result<bool> {
     let sdk_path = output_dir.join("sdk.jsonl");
 
     // Wait for the file to appear.
@@ -671,7 +687,9 @@ services:
         assert!(contains_setup_complete(&mut std::io::Cursor::new(data)).unwrap());
     }
 
-    const TEST_TIMEOUT: Duration = Duration::from_secs(3);
+    fn test_deadline() -> tokio::time::Instant {
+        tokio::time::Instant::now() + Duration::from_secs(3)
+    }
 
     /// Write the setup-complete event before the watcher starts.
     #[tokio::test]
@@ -684,7 +702,7 @@ services:
         .unwrap();
 
         assert!(
-            watch_for_setup_complete(dir.path(), TEST_TIMEOUT)
+            watch_for_setup_complete(dir.path(), test_deadline())
                 .await
                 .expect("watch failed")
         );
@@ -705,7 +723,7 @@ services:
         });
 
         assert!(
-            watch_for_setup_complete(dir.path(), TEST_TIMEOUT)
+            watch_for_setup_complete(dir.path(), test_deadline())
                 .await
                 .expect("watch failed")
         );
@@ -729,7 +747,7 @@ services:
         });
 
         assert!(
-            watch_for_setup_complete(dir.path(), TEST_TIMEOUT)
+            watch_for_setup_complete(dir.path(), test_deadline())
                 .await
                 .expect("watch failed")
         );
@@ -753,7 +771,7 @@ services:
         });
 
         assert!(
-            watch_for_setup_complete(dir.path(), TEST_TIMEOUT)
+            watch_for_setup_complete(dir.path(), test_deadline())
                 .await
                 .expect("watch failed")
         );
@@ -779,7 +797,7 @@ services:
         });
 
         assert!(
-            watch_for_setup_complete(dir.path(), TEST_TIMEOUT)
+            watch_for_setup_complete(dir.path(), test_deadline())
                 .await
                 .expect("watch failed")
         );
@@ -791,7 +809,7 @@ services:
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("sdk.jsonl"), "{\"unrelated\": true}\n").unwrap();
 
-        let found = watch_for_setup_complete(dir.path(), Duration::from_secs(1))
+        let found = watch_for_setup_complete(dir.path(), test_deadline())
             .await
             .expect("watch failed");
         assert!(!found, "expected timeout (false), got true");


### PR DESCRIPTION
Seems like podman-compose up has bugs (gasp!) which make it sit there and wait forever. Fix this by killing the process when the timeout elapses.

Convert `up_detached` from a blocking `.status()` call to an async `tokio::process::Command` spawn, so it can be raced against the timeout deadline and ctrl+c via `tokio::select!`.

The deadline is computed once before compose up starts and then passed through to `watch_for_setup_complete`, so the total wall-clock time is bounded regardless of how long the up phase takes.

Example timeout was shortened because claude seems to like using the examples verbatim.