### PR TITLE
Revert "validate: don't explicitly remove sdl.jsonl in diagnose_setup…

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -364,6 +364,9 @@ fn diagnose_setup_in_first_scripts(
                 );
                 return;
             }
+
+            // Remove any output from the previous script.
+            let _ = std::fs::remove_file(&sdk_file);
         }
     }
 }


### PR DESCRIPTION
…_in_first_scripts"

This reverts commit 54ee709844e76c3b2c2168ce0f994823b25b7131.

We have to remove sdk.jsonl because the path does not contain the name of the script which is being tested.