### PR TITLE
rename run command to launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cargo uninstall snouty || rm -f "$(which snouty)" "$(which snouty-update)"
 
 ## Requirements
 
-Commands that work with `docker-compose.yaml` files (e.g. `run --config`, `validate`) require Docker or Podman.
+Commands that work with `docker-compose.yaml` files (e.g. `launch --config`, `validate`) require Docker or Podman.
 
 If both are installed, Podman is preferred. You can override via environment `SNOUTY_CONTAINER_ENGINE=docker`.
 
@@ -71,7 +71,7 @@ export ANTITHESIS_PASSWORD="your-password"
 
 Snouty provides the following subcommands. Invoke `snouty <command> --help` to find out more.
 
-- `snouty run`: push images and kick off an Antithesis run.
+- `snouty launch`: push images and kick off an Antithesis run.
 - `snouty validate`: locally run and validate your docker-compose.yaml setup.
 - `snouty docs`: fast, local search of the Antithesis documentation.
 - `snouty debug`: start a debug session.

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -1,4 +1,4 @@
-# snouty run
+# snouty launch
 #
 # Launch an Antithesis test run.
 #
@@ -6,25 +6,25 @@
 # line so that I can trigger testing without using the web UI.
 
 # The user specifies a webhook endpoint name via -w / --webhook (required).
-! snouty run --duration 30
+! snouty launch --duration 30
 stderr '--webhook.*'
 
 # Parameters are validated against the testParams schema before making
 #    any API call.
-! snouty run -w basic_test --duration abc
+! snouty launch -w basic_test --duration abc
 stderr 'invalid value.*'
 
-# --stdin applies to `api webhook`, not `run`.
-! snouty run -w basic_test --stdin --duration 30
+# --stdin applies to `api webhook`, not `launch`.
+! snouty launch -w basic_test --stdin --duration 30
 stderr 'unexpected argument.*'
 
-# Old-style raw --antithesis.* args are not accepted by `run`.
-! snouty run -w basic_test --antithesis.duration 30
+# Old-style raw --antithesis.* args are not accepted by `launch`.
+! snouty launch -w basic_test --antithesis.duration 30
 
 # The command authenticates with the Antithesis API using either
 #    ANTITHESIS_API_KEY and ANTITHESIS_TENANT, or
 #    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT.
-! snouty run -w basic_test --duration 30
+! snouty launch -w basic_test --duration 30
 stderr 'missing environment variable.*'
 
 # Parameters are provided as --key value typed flags
@@ -32,7 +32,7 @@ stderr 'missing environment variable.*'
 #    parameters are printed to stderr with sensitive values (tokens, email
 #    recipients) redacted.
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
+snouty launch -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
 stderr '"antithesis.test_name": "my-test"'
 stderr '"antithesis.description": "nightly test run"'
 stderr '"antithesis.config_image": "config:latest"'
@@ -42,51 +42,56 @@ stderr '"antithesis.source": "ci-pipeline"'
 
 # 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test --duration 30 --ephemeral
+snouty launch -w basic_test --duration 30 --ephemeral
 stderr '"antithesis.is_ephemeral": "true"'
 
 # 6c. Without --source, is_ephemeral is set automatically and an info message is shown.
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test --duration 30
+snouty launch -w basic_test --duration 30
 stderr '"antithesis.is_ephemeral": "true"'
 stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
 
 # 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test --duration 30 --source ci-pipeline
+snouty launch -w basic_test --duration 30 --source ci-pipeline
 ! stderr 'is_ephemeral.*'
 ! stderr 'Starting ephemeral run.*'
 
 # 6d. --param flag passes custom properties.
 mock-server 200 '{"ok": true}'
-snouty run -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
+snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
 stderr '"my.custom.prop": "value"'
 stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
 
 # 6e. --param cannot override typed flag values.
 mock-server 200 '{"ok": true}'
-! snouty run -w basic_test --duration 30 --param antithesis.duration=60
+! snouty launch -w basic_test --duration 30 --param antithesis.duration=60
 stderr 'cannot be overridden via --param.*'
 
 # At least one source of parameters must be provided; otherwise the
 #    command fails.
 mock-server 200 '{}'
-! snouty run -w basic_test
+! snouty launch -w basic_test
 stderr 'no parameters provided.*'
 
 # On success, the command prints a human-readable ETA for the report
 #    email to stderr.
 mock-server 200 '{"ok": true}'
-snouty run -w basic_test --duration 30
+snouty launch -w basic_test --duration 30
 stderr 'Expect a report email.*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.
 mock-server 400 '{"error": "bad request"}'
-! snouty run -w basic_test --duration 30
+! snouty launch -w basic_test --duration 30
 stderr 'API error: 400.*'
 
 # antithesis.images must not be passed via --param; use api webhook instead.
 mock-server 200 '{"ok": true}'
-! snouty run -w basic_test --duration 30 --param antithesis.images=app:latest
+! snouty launch -w basic_test --duration 30 --param antithesis.images=app:latest
 stderr 'do not specify antithesis.images.*'
+
+# `snouty run` still works but prints a deprecation warning.
+mock-server 200 '{"ok": true}'
+snouty run -w basic_test --duration 30
+stderr 'snouty run.*is deprecated.*snouty launch'

--- a/specs/launch_config.txt
+++ b/specs/launch_config.txt
@@ -1,40 +1,40 @@
-# snouty run --config
+# snouty launch --config
 #
 # The --config/-c flag points to a local directory containing a
 # docker-compose.yaml file that will be pushed as a config image.
 
 # Requires ANTITHESIS_REPOSITORY when --config is used.
-! snouty run -w basic_test -c config --duration 30
+! snouty launch -w basic_test -c config --duration 30
 stderr 'ANTITHESIS_REPOSITORY.*'
 
 env ANTITHESIS_REPOSITORY=registry.example.com/repo
 
 # Rejects a nonexistent directory.
-! snouty run -w basic_test -c /nonexistent/path --duration 30
+! snouty launch -w basic_test -c /nonexistent/path --duration 30
 stderr 'not a directory.*'
 
 # 2b. Long flag --config also accepted.
-! snouty run -w basic_test --config /nonexistent/path --duration 30
+! snouty launch -w basic_test --config /nonexistent/path --duration 30
 stderr 'not a directory.*'
 
 # Rejects a directory without docker-compose.
-! snouty run -w basic_test -c empty --duration 30
+! snouty launch -w basic_test -c empty --duration 30
 stderr 'docker-compose.*'
 
 # Rejects docker-compose.yml (wrong extension).
-! snouty run -w basic_test -c yml_dir --duration 30
+! snouty launch -w basic_test -c yml_dir --duration 30
 stderr 'requires docker-compose.yaml.*'
 
 # --config conflicts with --config-image (clap).
-! snouty run -w basic_test -c config --config-image some-image:latest --duration 30
+! snouty launch -w basic_test -c config --config-image some-image:latest --duration 30
 stderr '--config.*'
 
 # --config conflicts with --param antithesis.config_image.
-! snouty run -w basic_test -c config --param antithesis.config_image=some-image:latest
+! snouty launch -w basic_test -c config --param antithesis.config_image=some-image:latest
 stderr 'cannot be overridden via --param.*'
 
 # basic_k8s_test webhook does not support --config flag.
-! snouty run -w basic_k8s_test -c k8s_config --duration 30
+! snouty launch -w basic_k8s_test -c k8s_config --duration 30
 stderr 'basic_k8s_test.*does not support the --config flag.*'
 
 -- config/docker-compose.yaml --

--- a/specs_engine/launch_config_push.txt
+++ b/specs_engine/launch_config_push.txt
@@ -1,4 +1,4 @@
-# snouty run --config — image push and pinning
+# snouty launch --config — image push and pinning
 #
 # When --config is used, snouty detects local build images, tags them
 # with the ANTITHESIS_REPOSITORY prefix, and pushes them alongside a
@@ -9,28 +9,28 @@
 mock-server 200 '{"status": "ok"}'
 build-image myapp:latest images/myapp
 build-image sidecar:v1 images/sidecar
-snouty run -w basic_test -c push_config --duration 30
+snouty launch -w basic_test -c push_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 stderr '"antithesis.images":.*myapp@sha256:'
 stderr '"antithesis.images":.*sidecar@sha256:'
 
 # No compose images match the registry — only config image is pinned.
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test -c external_config --duration 30
+snouty launch -w basic_test -c external_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
 # Mixed: local build image is tagged+pushed, external image is skipped.
 mock-server 200 '{"status": "ok"}'
 build-image myapp:latest images/myapp
-snouty run -w basic_test -c mixed_config --duration 30
+snouty launch -w basic_test -c mixed_config --duration 30
 stderr '"antithesis.images":.*myapp@sha256:'
 ! stderr 'nginx.*@sha256:'
 stderr '"antithesis.config_image":.*@sha256:'
 
 # Local image without build stanza is not pushed.
 mock-server 200 '{"status": "ok"}'
-snouty run -w basic_test -c local_no_build_config --duration 30
+snouty launch -w basic_test -c local_no_build_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub enum Commands {
     #[command(long_about = r#"Launch a test run
 
 Example:
-  snouty run --webhook basic_test --config ./config \
+  snouty launch --webhook basic_test --config ./config \
     --test-name "my-test" \
     --description "nightly test run" \
     --duration 30 \
@@ -26,12 +26,12 @@ Images required for the run need to have been built already. Pushing happens
 automatically.
 
 Alternatively, pass a pre-built config image directly:
-  snouty run --webhook basic_test \
+  snouty launch --webhook basic_test \
     --config-image us-central1-docker.pkg.dev/proj/repo/config:latest \
     --duration 30
 
 Extra parameters can be passed with --param:
-  snouty run -w basic_test --duration 30 \
+  snouty launch -w basic_test --duration 30 \
     --param antithesis.integrations.github.token=TOKEN \
     --param my.custom.property=value
 
@@ -42,7 +42,11 @@ Environment variables:
   ANTITHESIS_PASSWORD     Legacy password (required when API key is not set).
   ANTITHESIS_REPOSITORY   Container registry for pushing images (required with --config).
   SNOUTY_CONTAINER_ENGINE Force "docker" or "podman" (auto-detected by default)."#)]
-    Run(RunArgs),
+    Launch(LaunchArgs),
+
+    /// Deprecated: use `launch` instead
+    #[command(hide = true)]
+    Run(LaunchArgs),
 
     /// Access raw API endpoints
     #[command(subcommand)]
@@ -216,7 +220,7 @@ pub struct ValidateArgs {
 }
 
 #[derive(Args)]
-pub struct RunArgs {
+pub struct LaunchArgs {
     /// Webhook endpoint name (e.g., basic_test, basic_k8s_test)
     #[arg(short, long)]
     pub webhook: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use log::{debug, info};
 
 use color_eyre::eyre::{Context, Result, bail};
 use snouty::api::AntithesisApi;
-use snouty::cli::{ApiCommands, Cli, Commands, RunArgs};
+use snouty::cli::{ApiCommands, Cli, Commands, LaunchArgs};
 use snouty::container;
 use snouty::docs;
 use snouty::moment;
@@ -71,9 +71,14 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::Launch(args) => {
+            info!("launching test with webhook: {}", args.webhook);
+            cmd_launch(args).await
+        }
         Commands::Run(args) => {
-            info!("running test with webhook: {}", args.webhook);
-            cmd_run(args).await
+            eprintln!("warning: `snouty run` is deprecated, use `snouty launch` instead");
+            info!("launching test with webhook: {}", args.webhook);
+            cmd_launch(args).await
         }
         Commands::Api(ApiCommands::Webhook {
             webhook,
@@ -99,7 +104,7 @@ async fn main() -> Result<()> {
     }
 }
 
-async fn cmd_run(args: RunArgs) -> Result<()> {
+async fn cmd_launch(args: LaunchArgs) -> Result<()> {
     let mut params = Params::new();
 
     // Insert typed flags into params (skip None/false)

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -27,7 +27,7 @@ fn help_shows_subcommands() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("run"))
+        .stdout(predicate::str::contains("launch"))
         .stdout(predicate::str::contains("debug"))
         .stdout(predicate::str::contains("version"));
 }
@@ -68,12 +68,12 @@ fn validate_help_explains_setup_complete_detection() {
 }
 
 #[test]
-fn run_with_typed_flags() {
+fn launch_with_typed_flags() {
     let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "--test-name",
@@ -111,11 +111,18 @@ fn run_with_typed_flags() {
 }
 
 #[test]
-fn run_with_ephemeral_flag() {
+fn launch_with_ephemeral_flag() {
     let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
 
     snouty_with_mock(&mock_url)
-        .args(["run", "-w", "basic_test", "--duration", "30", "--ephemeral"])
+        .args([
+            "launch",
+            "-w",
+            "basic_test",
+            "--duration",
+            "30",
+            "--ephemeral",
+        ])
         .assert()
         .success()
         .stderr(predicate::str::contains(
@@ -124,11 +131,11 @@ fn run_with_ephemeral_flag() {
 }
 
 #[test]
-fn run_without_source_sets_ephemeral() {
+fn launch_without_source_sets_ephemeral() {
     let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
 
     snouty_with_mock(&mock_url)
-        .args(["run", "-w", "basic_test", "--duration", "30"])
+        .args(["launch", "-w", "basic_test", "--duration", "30"])
         .assert()
         .success()
         .stderr(predicate::str::contains(
@@ -140,12 +147,12 @@ fn run_without_source_sets_ephemeral() {
 }
 
 #[test]
-fn run_with_source_omits_ephemeral() {
+fn launch_with_source_omits_ephemeral() {
     let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "--duration",
@@ -160,12 +167,12 @@ fn run_with_source_omits_ephemeral() {
 }
 
 #[test]
-fn run_with_param_flag() {
+fn launch_with_param_flag() {
     let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "--duration",
@@ -184,12 +191,12 @@ fn run_with_param_flag() {
 }
 
 #[test]
-fn run_param_cannot_override_typed_flag() {
+fn launch_param_cannot_override_typed_flag() {
     let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "--duration",
@@ -203,66 +210,66 @@ fn run_param_cannot_override_typed_flag() {
 }
 
 #[test]
-fn run_duration_rejects_non_numeric() {
+fn launch_duration_rejects_non_numeric() {
     snouty()
-        .args(["run", "-w", "basic_test", "--duration", "abc"])
+        .args(["launch", "-w", "basic_test", "--duration", "abc"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
 }
 
 #[test]
-fn run_no_stdin_flag() {
+fn launch_no_stdin_flag() {
     snouty()
-        .args(["run", "-w", "basic_test", "--stdin", "--duration", "30"])
+        .args(["launch", "-w", "basic_test", "--stdin", "--duration", "30"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
-fn run_no_trailing_raw_args() {
+fn launch_no_trailing_raw_args() {
     snouty()
-        .args(["run", "-w", "basic_test", "--antithesis.duration", "30"])
+        .args(["launch", "-w", "basic_test", "--antithesis.duration", "30"])
         .assert()
         .failure();
 }
 
 #[test]
-fn run_fails_without_webhook() {
+fn launch_fails_without_webhook() {
     snouty()
-        .args(["run", "--duration", "30"])
+        .args(["launch", "--duration", "30"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--webhook"));
 }
 
 #[test]
-fn run_fails_without_parameters() {
+fn launch_fails_without_parameters() {
     let mock_url = start_mock_server(r#"{}"#, 200);
 
     snouty_with_mock(&mock_url)
-        .args(["run", "-w", "basic_test"])
+        .args(["launch", "-w", "basic_test"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("no parameters provided"));
 }
 
 #[test]
-fn run_reports_api_errors() {
+fn launch_reports_api_errors() {
     let mock_url = start_mock_server(r#"{"error": "bad request"}"#, 400);
 
     snouty_with_mock(&mock_url)
-        .args(["run", "-w", "basic_test", "--duration", "30"])
+        .args(["launch", "-w", "basic_test", "--duration", "30"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("API error: 400"));
 }
 
 #[test]
-fn run_fails_without_credentials() {
+fn launch_fails_without_credentials() {
     snouty()
-        .args(["run", "-w", "basic_test", "--duration", "30"])
+        .args(["launch", "-w", "basic_test", "--duration", "30"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("missing environment variable"));
@@ -608,14 +615,27 @@ fn api_webhook_success_does_not_print_email_eta() {
 }
 
 #[test]
-fn run_prints_email_eta() {
+fn launch_prints_email_eta() {
+    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+
+    snouty_with_mock(&mock_url)
+        .args(["launch", "-w", "basic_test", "--duration", "30"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Expect a report email"));
+}
+
+#[test]
+fn run_prints_deprecation_warning() {
     let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args(["run", "-w", "basic_test", "--duration", "30"])
         .assert()
         .success()
-        .stderr(predicate::str::contains("Expect a report email"));
+        .stderr(predicate::str::contains(
+            "`snouty run` is deprecated, use `snouty launch` instead",
+        ));
 }
 
 #[test]

--- a/tests/cli_launch_config.rs
+++ b/tests/cli_launch_config.rs
@@ -5,11 +5,11 @@ use support::*;
 use tempfile::TempDir;
 
 #[test]
-fn run_config_rejects_nonexistent_dir() {
+fn launch_config_rejects_nonexistent_dir() {
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",
@@ -23,13 +23,13 @@ fn run_config_rejects_nonexistent_dir() {
 }
 
 #[test]
-fn run_config_rejects_dir_without_compose() {
+fn launch_config_rejects_dir_without_compose() {
     let dir = TempDir::new().unwrap();
 
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",
@@ -43,14 +43,14 @@ fn run_config_rejects_dir_without_compose() {
 }
 
 #[test]
-fn run_config_rejects_yml_extension() {
+fn launch_config_rejects_yml_extension() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("docker-compose.yml"), "version: '3'\n").unwrap();
 
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",
@@ -64,14 +64,14 @@ fn run_config_rejects_yml_extension() {
 }
 
 #[test]
-fn run_config_conflicts_with_config_image_param() {
+fn launch_config_conflicts_with_config_image_param() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("docker-compose.yaml"), "version: '3'\n").unwrap();
 
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",
@@ -87,13 +87,13 @@ fn run_config_conflicts_with_config_image_param() {
 }
 
 #[test]
-fn run_config_requires_registry_env() {
+fn launch_config_requires_registry_env() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("docker-compose.yaml"), "version: '3'\n").unwrap();
 
     snouty()
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",
@@ -107,11 +107,11 @@ fn run_config_requires_registry_env() {
 }
 
 #[test]
-fn run_config_long_flag_accepted() {
+fn launch_config_long_flag_accepted() {
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "--config",
@@ -125,14 +125,14 @@ fn run_config_long_flag_accepted() {
 }
 
 #[test]
-fn run_config_conflicts_with_param_config_image() {
+fn launch_config_conflicts_with_param_config_image() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("docker-compose.yaml"), "version: '3'\n").unwrap();
 
     snouty()
         .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
         .args([
-            "run",
+            "launch",
             "-w",
             "basic_test",
             "-c",

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -345,9 +345,9 @@ macro_rules! engine_spec_case_test {
 }
 
 engine_spec_case_test!(
-    podman_engine_run_config_push_specs,
+    podman_engine_launch_config_push_specs,
     "podman",
-    "run_config_push.txt",
+    "launch_config_push.txt",
     true
 );
 engine_spec_case_test!(
@@ -375,9 +375,9 @@ engine_spec_case_test!(
     false
 );
 engine_spec_case_test!(
-    docker_engine_run_config_push_specs,
+    docker_engine_launch_config_push_specs,
     "docker",
-    "run_config_push.txt",
+    "launch_config_push.txt",
     true
 );
 engine_spec_case_test!(


### PR DESCRIPTION
The `run` subcommand is now `launch`. Invoking `snouty run` still works but prints a deprecation warning to stderr before proceeding.