### PR TITLE
add Kubernetes config support to validate and launch

### DIFF
--- a/specs/help.txt
+++ b/specs/help.txt
@@ -24,11 +24,12 @@ stdout '.*doctor.*'
 snouty api --help
 stdout '.*webhook.*'
 
-# validate --help explains how setup-complete is detected.
+# validate --help documents both the compose and Kubernetes flows.
 snouty validate --help
-stdout '.*\/tmp\/antithesis.*'
-stdout '.*ANTITHESIS_OUTPUT_DIR.*'
-stdout '.*ANTITHESIS_SDK_LOCAL_OUTPUT.*'
-stdout '.*JSONL.*'
-stdout '.*not by scraping compose logs.*'
+stdout '.*Compose configs:.*'
+stdout '.*docker-compose locally.*'
+stdout '.*setup-complete.*'
 stdout '.*Scripts are not executed.*'
+stdout '.*Kubernetes configs:.*'
+stdout '.*k8s-validator.*'
+stdout '.*manifests\/.*'

--- a/specs/launch_config.txt
+++ b/specs/launch_config.txt
@@ -7,6 +7,11 @@
 ! snouty launch -w basic_test -c config --duration 30
 stderr 'ANTITHESIS_REPOSITORY.*'
 
+# Kubernetes config directories (manifests/ subdirectory) are also accepted
+# by --config and likewise require ANTITHESIS_REPOSITORY.
+! snouty launch -w basic_k8s_test -c k8s_config --duration 30
+stderr 'ANTITHESIS_REPOSITORY.*'
+
 env ANTITHESIS_REPOSITORY=registry.example.com/repo
 
 # Rejects a nonexistent directory.
@@ -17,13 +22,17 @@ stderr 'not a directory.*'
 ! snouty launch -w basic_test --config /nonexistent/path --duration 30
 stderr 'not a directory.*'
 
-# Rejects a directory without docker-compose.
+# Rejects a directory without docker-compose.yaml or manifests/.
 ! snouty launch -w basic_test -c empty --duration 30
-stderr 'docker-compose.*'
+stderr '.*does not contain.*docker-compose.yaml.*manifests/.*'
 
 # Rejects docker-compose.yml (wrong extension).
 ! snouty launch -w basic_test -c yml_dir --duration 30
-stderr 'requires docker-compose.yaml.*'
+stderr '.*requires docker-compose.yaml.*'
+
+# Rejects an ambiguous directory containing both compose and manifests/.
+! snouty launch -w basic_test -c ambiguous --duration 30
+stderr '.*both docker-compose.yaml and a manifests/ subdirectory.*'
 
 # --config conflicts with --config-image (clap).
 ! snouty launch -w basic_test -c config --config-image some-image:latest --duration 30
@@ -33,11 +42,18 @@ stderr '--config.*'
 ! snouty launch -w basic_test -c config --param antithesis.config_image=some-image:latest
 stderr 'cannot be overridden via --param.*'
 
-# basic_k8s_test webhook does not support --config flag.
-! snouty launch -w basic_k8s_test -c k8s_config --duration 30
-stderr 'basic_k8s_test.*does not support the --config flag.*'
-
 -- config/docker-compose.yaml --
 -- empty/.keep --
 -- yml_dir/docker-compose.yml --
--- k8s_config/docker-compose.yaml --
+-- k8s_config/manifests/ns.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+-- ambiguous/docker-compose.yaml --
+services: {}
+-- ambiguous/manifests/ns.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/specs/validate.txt
+++ b/specs/validate.txt
@@ -11,13 +11,32 @@ stderr 'required.*'
 ! snouty validate /nonexistent/path
 stderr 'not a directory.*'
 
-# Rejects a directory without docker-compose.yaml.
+# Rejects a directory without docker-compose.yaml or manifests/.
 ! snouty validate empty
-stderr 'docker-compose.*'
+stderr '.*does not contain.*docker-compose.yaml.*manifests/.*'
+
+# Lowercase docker-compose.yml is rejected with a rename hint.
+! snouty validate yml_dir
+stderr '.*rename.*'
+
+# Rejects an ambiguous directory containing both compose and manifests/.
+! snouty validate ambiguous
+stderr '.*both docker-compose.yaml and a manifests/ subdirectory.*'
 
 # Help text mentions --keep-running.
 snouty validate --help
 stdout '.*keep-running.*'
 
+# Help text mentions the manifests/ subdirectory option.
+snouty validate --help
+stdout '.*manifests/.*'
+
 -- empty/.keep --
 -- yml_dir/docker-compose.yml --
+-- ambiguous/docker-compose.yaml --
+services: {}
+-- ambiguous/manifests/ns.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/specs_engine/launch_config_push.txt
+++ b/specs_engine/launch_config_push.txt
@@ -34,6 +34,13 @@ snouty launch -w basic_test -c local_no_build_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
+# Kubernetes config: builds and pushes the config image, never sets
+# antithesis.images (the platform pulls images from the manifests).
+mock-server 200 '{"status": "ok"}'
+snouty launch -w basic_k8s_test -c k8s_config --duration 30
+stderr '"antithesis.config_image":.*@sha256:'
+! stderr '"antithesis.images"'
+
 -- images/myapp/content --
 placeholder
 -- images/sidecar/content --
@@ -61,3 +68,8 @@ services:
 services:
   app:
     image: localapp:latest
+-- k8s_config/manifests/ns.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snouty-demo

--- a/specs_engine/validate_k8s.txt
+++ b/specs_engine/validate_k8s.txt
@@ -1,0 +1,23 @@
+# snouty validate — Kubernetes manifest cases
+
+# Valid manifest — validator passes.
+snouty validate config_valid
+stderr 'Running k8s-validator against manifests in.*'
+stderr 'k8s manifests valid.*'
+
+# Invalid manifest (unknown kind) — validator fails.
+! snouty validate config_invalid
+stderr 'k8s-validator failed.*'
+
+-- config_valid/manifests/ns.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snouty-demo
+-- config_invalid/manifests/pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+spec:
+  containers: "should be a list"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,24 +84,28 @@ Using Moment.from (copy from triage report):
     /// Validate local Antithesis setup
     #[command(long_about = r#"Validate local Antithesis setup
 
-Runs docker-compose locally and watches for the setup-complete event to confirm
-instrumentation is working. After setup-complete is detected, discovers
-Test Composer scripts from /opt/antithesis/test/v1 inside the running
-containers and validates their structure.
+Compose configs:
+  Runs docker-compose locally and watches for the setup-complete event to
+  confirm instrumentation is working. After setup-complete is detected,
+  discovers Test Composer scripts from /opt/antithesis/test/v1 inside the
+  running containers and validates their structure.
 
-snouty validate injects a bind mount at /tmp/antithesis in each container and
-sets ANTITHESIS_OUTPUT_DIR plus ANTITHESIS_SDK_LOCAL_OUTPUT so SDK output is
-written there. It detects setup-complete by reading JSONL files from that mount,
-not by scraping compose logs or container stdout.
 
-Scripts are discovered by copying /opt/antithesis/test/v1 from each running
-container and scanning for {test_name}/{command} entries. Scripts are validated
-to have recognized prefixes and at least one driver or anytime script when
-test scripts are present. Scripts are not executed.
+  Scripts are discovered by scanning /opt/antithesis/test/v1 from each running
+  container for {test_name}/{command} entries. Scripts are
+  validated to have recognized prefixes and at least one driver or anytime
+  script when test scripts are present. Scripts are not executed.
+
+Kubernetes configs:
+  Runs docker.io/antithesishq/k8s-validator against the manifests/
+  directory to perform static analysis of the manifests. --timeout has no
+  effect (the validator does not start any workloads), and --keep-running
+  has no effect (no containers are launched).
 
 Example:
   snouty validate ./config
-  snouty validate ./config --timeout 10"#)]
+  snouty validate ./config --timeout 10
+  snouty validate ./k8s-config"#)]
     Validate(ValidateArgs),
 
     /// Check environment configuration
@@ -197,7 +201,8 @@ If the exact path is not found, suggests similar pages."#)]
 
 #[derive(Args)]
 pub struct ValidateArgs {
-    /// Path to config directory containing docker-compose.yaml
+    /// Path to config directory containing either docker-compose.yaml or a
+    /// manifests/ subdirectory (Kubernetes manifests).
     pub config: std::path::PathBuf,
 
     /// Maximum seconds to wait for the setup-complete event
@@ -215,8 +220,12 @@ pub struct LaunchArgs {
     #[arg(short, long)]
     pub webhook: String,
 
-    /// Path to a local config directory containing docker-compose.yaml.
-    /// Builds and pushes a config image automatically, setting antithesis.config_image.
+    /// Path to a local config directory containing either docker-compose.yaml
+    /// or a manifests/ subdirectory (Kubernetes manifests). Builds and pushes
+    /// a config image automatically, setting antithesis.config_image. For
+    /// docker-compose configs, locally-built service images are also pushed
+    /// and exposed via antithesis.images. For Kubernetes configs, images are
+    /// pulled by the platform from the references in the manifests.
     /// Requires ANTITHESIS_REPOSITORY environment variable.
     #[arg(short, long, conflicts_with = "config_image")]
     pub config: Option<std::path::PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,211 @@
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+
+/// A docker-compose config directory.
+///
+/// Construct via [`detect_config`]; the type guarantees the directory contains
+/// a `docker-compose.yaml` file.
+#[derive(Debug)]
+pub struct ComposeConfig {
+    dir: PathBuf,
+}
+
+impl ComposeConfig {
+    /// The compose config directory.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+/// A Kubernetes config directory: the parent directory containing a
+/// `manifests/` subfolder, per the Antithesis k8s setup convention.
+#[derive(Debug)]
+pub struct KubernetesConfig {
+    dir: PathBuf,
+}
+
+impl KubernetesConfig {
+    /// The root config directory (parent of `manifests/`). This is what gets
+    /// packaged into the config image, so `manifests/` ends up at `/manifests`.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// The `manifests/` subdirectory containing Kubernetes manifest files.
+    pub fn manifests_dir(&self) -> PathBuf {
+        self.dir.join("manifests")
+    }
+}
+
+/// A snouty config directory, either docker-compose or Kubernetes.
+#[derive(Debug)]
+pub enum Config {
+    Compose(ComposeConfig),
+    Kubernetes(KubernetesConfig),
+}
+
+impl Config {
+    /// The root config directory.
+    pub fn dir(&self) -> &Path {
+        match self {
+            Config::Compose(c) => c.dir(),
+            Config::Kubernetes(c) => c.dir(),
+        }
+    }
+}
+
+/// Inspect a config directory and decide whether it is a docker-compose or
+/// Kubernetes config.
+///
+/// - Contains `docker-compose.yaml` → [`Config::Compose`].
+/// - Contains a non-empty `manifests/` subdirectory →
+///   [`Config::Kubernetes`].
+/// - Both present → ambiguous (error).
+/// - Neither present → error mentioning both.
+/// - `docker-compose.yml` (lowercase `.yml`) → rename hint.
+pub fn detect_config(config_dir: &Path) -> Result<Config> {
+    if !config_dir.is_dir() {
+        bail!("'{}' is not a directory", config_dir.display());
+    }
+
+    if config_dir.join("docker-compose.yml").is_file() {
+        bail!(
+            "directory '{}' contains docker-compose.yml, but Antithesis requires docker-compose.yaml (rename the file)",
+            config_dir.display()
+        );
+    }
+
+    let has_compose = config_dir.join("docker-compose.yaml").is_file();
+    let manifests_dir = config_dir.join("manifests");
+    let has_manifests_dir = manifests_dir.is_dir();
+
+    if has_compose && has_manifests_dir {
+        bail!(
+            "directory '{}' contains both docker-compose.yaml and a manifests/ subdirectory; pick one",
+            config_dir.display()
+        );
+    }
+
+    if has_compose {
+        return Ok(Config::Compose(ComposeConfig {
+            dir: config_dir.to_path_buf(),
+        }));
+    }
+
+    if has_manifests_dir {
+        let is_non_empty = std::fs::read_dir(&manifests_dir)
+            .wrap_err_with(|| format!("failed to read {}", manifests_dir.display()))?
+            .filter_map(Result::ok)
+            .next()
+            .is_some();
+        if !is_non_empty {
+            bail!(
+                "directory '{}' contains an empty manifests/ subdirectory",
+                config_dir.display()
+            );
+        }
+        return Ok(Config::Kubernetes(KubernetesConfig {
+            dir: config_dir.to_path_buf(),
+        }));
+    }
+
+    bail!(
+        "directory '{}' does not contain a docker-compose.yaml file or a manifests/ subdirectory",
+        config_dir.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_config_compose() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("docker-compose.yaml"), "services: {}\n").unwrap();
+        match detect_config(dir.path()).unwrap() {
+            Config::Compose(c) => assert_eq!(c.dir(), dir.path()),
+            other => panic!("expected Compose, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_config_kubernetes() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifests = dir.path().join("manifests");
+        std::fs::create_dir(&manifests).unwrap();
+        std::fs::write(manifests.join("ns.yaml"), "kind: Namespace\n").unwrap();
+        match detect_config(dir.path()).unwrap() {
+            Config::Kubernetes(c) => {
+                assert_eq!(c.dir(), dir.path());
+                assert_eq!(c.manifests_dir(), manifests);
+            }
+            other => panic!("expected Kubernetes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_config_kubernetes_subdir_only() {
+        // manifests/ containing only subdirectories (e.g. kustomize overlays)
+        // must be accepted as a valid Kubernetes config.
+        let dir = tempfile::tempdir().unwrap();
+        let manifests = dir.path().join("manifests");
+        std::fs::create_dir(&manifests).unwrap();
+        std::fs::create_dir(manifests.join("overlays")).unwrap();
+        match detect_config(dir.path()).unwrap() {
+            Config::Kubernetes(c) => assert_eq!(c.dir(), dir.path()),
+            other => panic!("expected Kubernetes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_config_both_is_ambiguous() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("docker-compose.yaml"), "services: {}\n").unwrap();
+        let manifests = dir.path().join("manifests");
+        std::fs::create_dir(&manifests).unwrap();
+        std::fs::write(manifests.join("ns.yaml"), "kind: Namespace\n").unwrap();
+        let err = detect_config(dir.path()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("both"), "unexpected error: {msg}");
+        assert!(msg.contains("manifests/"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn detect_config_neither_mentions_manifests() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = detect_config(dir.path()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("docker-compose.yaml"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains("manifests/"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn detect_config_empty_manifests_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("manifests")).unwrap();
+        let err = detect_config(dir.path()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("empty manifests/"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn detect_config_lowercase_yml_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("docker-compose.yml"), "services: {}\n").unwrap();
+        let err = detect_config(dir.path()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("rename"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn detect_config_not_a_directory() {
+        let err = detect_config(Path::new("/nonexistent/snouty/path")).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("not a directory"), "unexpected error: {msg}");
+    }
+}

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -10,6 +10,8 @@ use color_eyre::{
     eyre::{Context, Result, bail, eyre},
 };
 use tokio::process::Child;
+
+use crate::config::ComposeConfig;
 
 /// RAII wrapper around a [`Child`] spawned with `process_group(0)`.
 ///
@@ -69,40 +71,15 @@ impl Drop for ProcessGroupChild {
     }
 }
 
-/// Bundles a compose config directory with optional overlay files (e.g. overrides).
-///
-/// Used by compose session operations (`up`, `ps`, `exec`,
-/// `down`) that run against a live `compose up`.
-#[derive(Debug)]
-pub struct ComposeConfig {
-    dir: PathBuf,
-    extra_files: Vec<PathBuf>,
-}
-
-impl ComposeConfig {
-    /// Add an overlay file (e.g. a compose override) to the config.
-    pub fn with_overlay(mut self, path: PathBuf) -> Self {
-        self.extra_files.push(path);
-        self
+/// Build the `-f` flags for `compose` subcommands: always
+/// `-f docker-compose.yaml`, plus `-f <overlay>` if an overlay was provided.
+fn compose_file_args(overlay: Option<&Path>) -> Vec<String> {
+    let mut args = vec!["-f".to_string(), "docker-compose.yaml".to_string()];
+    if let Some(path) = overlay {
+        args.push("-f".to_string());
+        args.push(path.display().to_string());
     }
-
-    /// The compose config directory.
-    pub fn dir(&self) -> &Path {
-        &self.dir
-    }
-
-    /// Return the `-f` flags for `compose` subcommands.
-    ///
-    /// Always includes `-f docker-compose.yaml`, followed by `-f <path>` for
-    /// each overlay in `extra_files`.
-    fn file_args(&self) -> Vec<String> {
-        let mut args = vec!["-f".to_string(), "docker-compose.yaml".to_string()];
-        for f in &self.extra_files {
-            args.push("-f".to_string());
-            args.push(f.display().to_string());
-        }
-        args
-    }
+    args
 }
 
 /// Trait representing a container runtime (podman or docker).
@@ -252,15 +229,13 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(())
     }
 
-    /// Build and push a config image from a local directory.
-    /// The directory must contain a `docker-compose.yaml` file.
-    /// Returns the pinned image reference.
+    /// Build a scratch image from the contents of `config_dir` and push it.
+    /// Callers are responsible for validating the directory beforehand
+    /// (typically via [`crate::config::detect_config`]). Returns the pinned
+    /// image reference.
     fn build_and_push_config_image(&self, config_dir: &Path, image_ref: &str) -> Result<String> {
-        let compose = self.compose();
-        let config = compose.config(config_dir)?;
-
         eprintln!("Building config image: {}", image_ref);
-        self.build_image(config.dir(), image_ref, None, None)?;
+        self.build_image(config_dir, image_ref, None, None)?;
 
         eprintln!("Pushing config image: {}", image_ref);
         let pinned = self.image_push(image_ref)?;
@@ -270,10 +245,9 @@ pub trait ContainerRuntime: Send + Sync {
 
     /// Push compose images that match the registry.
     /// Returns the pinned image reference for each pushed image.
-    fn push_compose_images(&self, config_dir: &Path, registry: &str) -> Result<Vec<String>> {
+    fn push_compose_images(&self, config: &ComposeConfig, registry: &str) -> Result<Vec<String>> {
         let compose = self.compose();
-        let config = compose.config(config_dir)?;
-        let contents = compose.contents(&config)?;
+        let contents = compose.contents(config, None)?;
         let registry_trimmed = registry.trim_end_matches('/');
         let prefix = format!("{registry_trimmed}/");
 
@@ -363,46 +337,14 @@ pub trait Compose: Send + Sync {
 
     // --- default implementations ---
 
-    /// Validate and wrap a compose config directory.
-    ///
-    /// Snouty requires `docker-compose.yaml`, even if the underlying compose
-    /// backend would also accept `docker-compose.yml`.
-    fn config(&self, config_dir: &Path) -> Result<ComposeConfig> {
-        if !config_dir.is_dir() {
-            bail!(
-                "config directory error: '{}' is not a directory",
-                config_dir.display()
-            );
-        }
-
-        if config_dir.join("docker-compose.yml").is_file() {
-            bail!(
-                "config directory error: directory '{}' contains docker-compose.yml, but Antithesis requires docker-compose.yaml (rename the file)",
-                config_dir.display()
-            );
-        }
-
-        if !config_dir.join("docker-compose.yaml").is_file() {
-            bail!(
-                "config directory error: directory '{}' does not contain a docker-compose.yaml file",
-                config_dir.display()
-            );
-        }
-
-        Ok(ComposeConfig {
-            dir: config_dir.to_path_buf(),
-            extra_files: Vec::new(),
-        })
-    }
-
     /// Run `compose config` to resolve the compose file with env substitutions,
     /// returning the resolved YAML as a string.
-    fn raw_contents(&self, config: &ComposeConfig) -> Result<String> {
+    fn raw_contents(&self, config: &ComposeConfig, overlay: Option<&Path>) -> Result<String> {
         let runtime = self.runtime().name();
         let mut cmd = self.runtime().command(&["compose"]);
         cmd.env("COMPOSE_PROJECT_NAME", "snouty");
-        cmd.current_dir(&config.dir);
-        cmd.args(config.file_args());
+        cmd.current_dir(config.dir());
+        cmd.args(compose_file_args(overlay));
         cmd.arg("config");
         let output = cmd
             .output()
@@ -420,18 +362,18 @@ pub trait Compose: Send + Sync {
     }
 
     /// Resolve and parse a compose config into structured contents.
-    fn contents(&self, config: &ComposeConfig) -> Result<ComposeContents> {
-        let yaml = self.raw_contents(config)?;
+    fn contents(&self, config: &ComposeConfig, overlay: Option<&Path>) -> Result<ComposeContents> {
+        let yaml = self.raw_contents(config, overlay)?;
         parse_compose_config(&yaml)
     }
 
     /// Parse `compose ps --format json` to get `(service_name, container_id)` pairs.
-    fn ps(&self, config: &ComposeConfig) -> Result<Vec<(String, String)>> {
+    fn ps(&self, config: &ComposeConfig, overlay: Option<&Path>) -> Result<Vec<(String, String)>> {
         let runtime = self.runtime().name();
         let mut cmd = self.runtime().command(&["compose"]);
-        cmd.current_dir(&config.dir);
+        cmd.current_dir(config.dir());
         let (pre, post) = self.ps_extra_args();
-        cmd.args(config.file_args());
+        cmd.args(compose_file_args(overlay));
         cmd.args(pre);
         cmd.args(["ps"]);
         cmd.args(post);
@@ -459,6 +401,7 @@ pub trait Compose: Send + Sync {
     fn exec(
         &self,
         config: &ComposeConfig,
+        overlay: Option<&Path>,
         service: &str,
         workdir: Option<&str>,
         env: &[(&str, &str)],
@@ -466,8 +409,8 @@ pub trait Compose: Send + Sync {
     ) -> Result<std::process::Output> {
         let runtime = self.runtime().name();
         let mut command = self.runtime().command(&["compose"]);
-        command.current_dir(&config.dir);
-        command.args(config.file_args());
+        command.current_dir(config.dir());
+        command.args(compose_file_args(overlay));
         command.args(["exec", "-T"]);
         for (k, v) in env {
             command.args(["-e", &format!("{k}={v}")]);
@@ -489,12 +432,16 @@ pub trait Compose: Send + Sync {
     /// The caller is responsible for awaiting the child and checking its exit
     /// status. Uses `process_group(0)` so the whole group can be killed on
     /// timeout.
-    fn up_detached(&self, config: &ComposeConfig) -> Result<ProcessGroupChild> {
+    fn up_detached(
+        &self,
+        config: &ComposeConfig,
+        overlay: Option<&Path>,
+    ) -> Result<ProcessGroupChild> {
         let runtime = self.runtime().name();
         let mut cmd = self.runtime().tokio_command(&["compose"]);
-        cmd.current_dir(&config.dir);
+        cmd.current_dir(config.dir());
         let (pre, post) = self.up_extra_args();
-        cmd.args(config.file_args());
+        cmd.args(compose_file_args(overlay));
         cmd.args(pre);
         cmd.args(["up", "--detach", "--no-build"]);
         cmd.args(post);
@@ -513,12 +460,16 @@ pub trait Compose: Send + Sync {
     /// stdout and stderr are inherited so compose log output goes straight
     /// to the terminal. stdin is null. The process exits when all
     /// containers stop.
-    fn logs_follow(&self, config: &ComposeConfig) -> Result<ProcessGroupChild> {
+    fn logs_follow(
+        &self,
+        config: &ComposeConfig,
+        overlay: Option<&Path>,
+    ) -> Result<ProcessGroupChild> {
         let runtime = self.runtime().name();
         let mut cmd = self.runtime().tokio_command(&["compose"]);
-        cmd.current_dir(&config.dir);
+        cmd.current_dir(config.dir());
         let (pre, post) = self.logs_extra_args();
-        cmd.args(config.file_args());
+        cmd.args(compose_file_args(overlay));
         cmd.args(pre);
         cmd.args(["logs", "--follow"]);
         cmd.args(post);
@@ -533,10 +484,10 @@ pub trait Compose: Send + Sync {
     }
 
     /// Run `compose down` for cleanup. Best-effort, ignores errors.
-    fn down(&self, config: &ComposeConfig) {
+    fn down(&self, config: &ComposeConfig, overlay: Option<&Path>) {
         let mut cmd = self.runtime().command(&["compose"]);
-        cmd.current_dir(&config.dir);
-        cmd.args(config.file_args());
+        cmd.current_dir(config.dir());
+        cmd.args(compose_file_args(overlay));
         cmd.args(["down", "--timeout", "0"]);
         cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::null());
@@ -1121,6 +1072,7 @@ mod tests {
     };
     use std::collections::BTreeMap;
     use std::os::unix::process::ExitStatusExt;
+    use std::path::PathBuf;
 
     #[tokio::test]
     async fn build_and_push_to_mock_registry() {
@@ -1211,48 +1163,6 @@ mod tests {
                 ("app".to_string(), "abc123".to_string()),
                 ("sidecar".to_string(), "def456".to_string()),
             ]
-        );
-    }
-
-    #[test]
-    fn compose_config_rejects_nonexistent_directory() {
-        let runtime = DockerRuntime::new("docker");
-        let result = runtime
-            .compose()
-            .config(Path::new("/nonexistent/path/that/does/not/exist"));
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("not a directory"), "got: {err}");
-    }
-
-    #[test]
-    fn compose_config_rejects_yml_extension() {
-        let runtime = DockerRuntime::new("docker");
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("docker-compose.yml"), "services: {}\n").unwrap();
-
-        let err = runtime
-            .compose()
-            .config(dir.path())
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("docker-compose.yml"), "got: {err}");
-        assert!(err.contains("docker-compose.yaml"), "got: {err}");
-    }
-
-    #[test]
-    fn compose_config_requires_yaml_file() {
-        let runtime = DockerRuntime::new("docker");
-        let dir = tempfile::tempdir().unwrap();
-
-        let err = runtime
-            .compose()
-            .config(dir.path())
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("does not contain a docker-compose.yaml file"),
-            "got: {err}"
         );
     }
 
@@ -1383,8 +1293,11 @@ services:
             .unwrap();
 
             let compose = rt.compose();
-            let config = compose.config(dir.path()).unwrap();
-            let contents = compose.contents(&config).unwrap();
+            let config = match crate::config::detect_config(dir.path()).unwrap() {
+                crate::config::Config::Compose(c) => c,
+                other => panic!("expected Compose, got {other:?}"),
+            };
+            let contents = compose.contents(&config, None).unwrap();
             let images: Vec<&str> = contents
                 .services
                 .iter()
@@ -1433,9 +1346,12 @@ services:
             .unwrap();
 
             let compose = rt.compose();
-            let config = compose.config(dir.path()).unwrap().with_overlay(overlay);
-            let yaml = compose.raw_contents(&config).unwrap();
-            let contents = compose.contents(&config).unwrap();
+            let config = match crate::config::detect_config(dir.path()).unwrap() {
+                crate::config::Config::Compose(c) => c,
+                other => panic!("expected Compose, got {other:?}"),
+            };
+            let yaml = compose.raw_contents(&config, Some(&overlay)).unwrap();
+            let contents = compose.contents(&config, Some(&overlay)).unwrap();
 
             assert!(
                 yaml.contains("overlay:latest"),
@@ -1813,5 +1729,27 @@ services:
             parse_compose_version(""),
             ComposeFlavor::PodmanCompose
         ));
+    }
+
+    #[test]
+    fn compose_file_args_no_overlay() {
+        assert_eq!(
+            compose_file_args(None),
+            vec!["-f".to_string(), "docker-compose.yaml".to_string()]
+        );
+    }
+
+    #[test]
+    fn compose_file_args_with_overlay() {
+        let overlay = PathBuf::from("/tmp/override.yaml");
+        assert_eq!(
+            compose_file_args(Some(&overlay)),
+            vec![
+                "-f".to_string(),
+                "docker-compose.yaml".to_string(),
+                "-f".to_string(),
+                "/tmp/override.yaml".to_string(),
+            ]
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod cli;
+pub mod config;
 pub mod container;
 pub mod docs;
 pub mod doctor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use log::{debug, info};
 use color_eyre::eyre::{Context, Result, bail};
 use snouty::api::AntithesisApi;
 use snouty::cli::{ApiCommands, Cli, Commands, LaunchArgs};
+use snouty::config;
 use snouty::container;
 use snouty::docs;
 use snouty::moment;
@@ -136,19 +137,12 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         "config and config_image are mutually exclusive"
     );
 
-    // TODO: enable config directory support for k8s manifests
-    if args.webhook == "basic_k8s_test" && args.config.is_some() {
-        bail!(
-            "The 'basic_k8s_test' webhook does not support the --config flag. Please use --config-image with a pre-built config image instead."
-        );
-    }
-
     if let Some(config_image) = args.config_image {
         params.insert("antithesis.config_image", config_image);
     }
 
     let config_image_ref = if let Some(config_dir) = args.config {
-        let config = container::runtime()?.compose().config(&config_dir)?;
+        let config = config::detect_config(&config_dir)?;
 
         let registry = std::env::var("ANTITHESIS_REPOSITORY")
             .wrap_err("missing environment variable: ANTITHESIS_REPOSITORY")?;
@@ -198,9 +192,14 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
     if let Some((config, registry, config_image)) = config_image_ref {
         let rt = container::runtime()?;
 
-        let pinned_images = rt.push_compose_images(config.dir(), &registry)?;
-        if !pinned_images.is_empty() {
-            params.insert("antithesis.images", pinned_images.join(";"));
+        // Compose configs reference local image tags that need to be pushed to
+        // the registry; k8s configs reference images by name in the manifests
+        // and the platform pulls them itself.
+        if let config::Config::Compose(compose_config) = &config {
+            let pinned_images = rt.push_compose_images(compose_config, &registry)?;
+            if !pinned_images.is_empty() {
+                params.insert("antithesis.images", pinned_images.join(";"));
+            }
         }
 
         let pinned_config = rt.build_and_push_config_image(config.dir(), &config_image)?;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -9,8 +9,11 @@ use serde::Deserialize;
 use tokio::time::{Duration, sleep};
 
 use crate::cli::ValidateArgs;
-use crate::container::{self, ComposeConfig};
+use crate::config::{self, ComposeConfig, Config, KubernetesConfig};
+use crate::container;
 use crate::scripts::{ScriptType, TestScript, scan_scripts};
+
+const K8S_VALIDATOR_IMAGE: &str = "docker.io/antithesishq/k8s-validator:1.0.0";
 
 #[derive(Deserialize)]
 struct SetupEvent {
@@ -146,11 +149,12 @@ fn mkdir_or_require_empty(path: &Path) -> Result<()> {
 struct ComposeDownGuard<'a> {
     compose: &'a dyn container::Compose,
     config: &'a ComposeConfig,
+    overlay: Option<&'a Path>,
 }
 
 impl Drop for ComposeDownGuard<'_> {
     fn drop(&mut self) {
-        self.compose.down(self.config);
+        self.compose.down(self.config, self.overlay);
     }
 }
 
@@ -178,12 +182,25 @@ async fn validate_with_temp_dir(args: ValidateArgs, temp_dir: &Path) -> Result<(
         keep_running,
     } = args;
     let rt = container::runtime()?;
+    match config::detect_config(&config_path)? {
+        Config::Compose(cfg) => validate_compose(rt, cfg, timeout, keep_running, temp_dir).await,
+        Config::Kubernetes(cfg) => validate_kubernetes(rt, &cfg, keep_running).await,
+    }
+}
+
+async fn validate_compose(
+    rt: &dyn container::ContainerRuntime,
+    config: ComposeConfig,
+    timeout: u64,
+    keep_running: bool,
+    temp_dir: &Path,
+) -> Result<()> {
     let compose = rt.compose();
-    let config = compose.config(&config_path)?;
-    let contents = compose.contents(&config)?;
+    let contents = compose.contents(&config, None)?;
     container::validate_images_are_available(rt, &contents.services)?;
     container::validate_image_architectures(rt, &contents.services)?;
     let override_path = generate_setup_override(&contents, temp_dir)?;
+    let overlay = Some(override_path.as_path());
 
     if keep_running {
         eprintln!(
@@ -195,18 +212,17 @@ async fn validate_with_temp_dir(args: ValidateArgs, temp_dir: &Path) -> Result<(
         );
     }
 
-    let config = config.with_overlay(override_path);
-
     let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
 
     eprintln!("Starting compose services...");
-    let mut up_child = compose.up_detached(&config)?;
+    let mut up_child = compose.up_detached(&config, overlay)?;
     let _guard = if keep_running {
         None
     } else {
         Some(ComposeDownGuard {
             compose: &*compose,
             config: &config,
+            overlay,
         })
     };
 
@@ -230,9 +246,9 @@ async fn validate_with_temp_dir(args: ValidateArgs, temp_dir: &Path) -> Result<(
 
     // Discover scripts early so we can use them for both the success path
     // and the timeout diagnostic.
-    let scripts = discover_scripts(&*compose, &config, temp_dir)?;
+    let scripts = discover_scripts(&*compose, &config, overlay, temp_dir)?;
 
-    let mut logs_child = compose.logs_follow(&config)?;
+    let mut logs_child = compose.logs_follow(&config, overlay)?;
 
     let sdk_output_dir = temp_dir.join("antithesis");
 
@@ -268,6 +284,61 @@ async fn validate_with_temp_dir(args: ValidateArgs, temp_dir: &Path) -> Result<(
     }
 
     test_result
+}
+
+async fn validate_kubernetes(
+    rt: &dyn container::ContainerRuntime,
+    config: &KubernetesConfig,
+    keep_running: bool,
+) -> Result<()> {
+    if keep_running {
+        eprintln!("Note: --keep-running has no effect for Kubernetes configs.");
+    }
+
+    let manifests_dir = config.manifests_dir();
+    eprintln!(
+        "Running k8s-validator against manifests in {}...",
+        manifests_dir.display()
+    );
+
+    // Bind-mount the host path. Podman interprets relative paths as named
+    // volumes, so always pass an absolute path. Include an SELinux relabel
+    // option so the validator can read the manifests directory on
+    // SELinux-enabled systems.
+    let manifests_abs = std::fs::canonicalize(&manifests_dir).wrap_err_with(|| {
+        format!(
+            "failed to resolve manifests directory '{}'",
+            manifests_dir.display()
+        )
+    })?;
+    let mount = format!("{}:/manifests:ro,z", manifests_abs.display());
+    let mut cmd = rt.tokio_command(&["run", "--rm", "-v", &mount, K8S_VALIDATOR_IMAGE]);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::inherit());
+    cmd.stderr(std::process::Stdio::inherit());
+    cmd.process_group(0);
+
+    let runtime_name = rt.name();
+    let mut child = cmd
+        .spawn()
+        .map(container::ProcessGroupChild::new)
+        .wrap_err_with(|| format!("failed to start '{runtime_name} run' for k8s-validator"))?;
+
+    tokio::select! {
+        status = child.wait() => {
+            let status = status.wrap_err("failed to wait for k8s-validator")?;
+            if !status.success() {
+                bail!("k8s-validator failed (exit status: {status})");
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            child.kill_group().await.ok();
+            bail!("interrupted");
+        }
+    };
+
+    eprintln!("k8s manifests valid.");
+    Ok(())
 }
 
 /// Check whether a reader contains the setup-complete event.
@@ -310,9 +381,10 @@ fn contains_setup_complete(reader: &mut (impl std::io::Read + std::io::Seek)) ->
 fn discover_scripts(
     compose: &dyn container::Compose,
     config: &ComposeConfig,
+    overlay: Option<&Path>,
     temp_dir: &Path,
 ) -> Result<Vec<TestScript>> {
-    let services = compose.ps(config)?;
+    let services = compose.ps(config, overlay)?;
 
     let scripts_dir = temp_dir.join("scripts");
     std::fs::create_dir_all(&scripts_dir).wrap_err("failed to create scripts directory")?;

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -51,17 +51,18 @@ fn api_help_shows_webhook() {
 }
 
 #[test]
-fn validate_help_explains_setup_complete_detection() {
+fn validate_help_documents_compose_and_kubernetes() {
     snouty()
         .args(["validate", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("/tmp/antithesis"))
-        .stdout(predicate::str::contains("ANTITHESIS_OUTPUT_DIR"))
-        .stdout(predicate::str::contains("ANTITHESIS_SDK_LOCAL_OUTPUT"))
-        .stdout(predicate::str::contains("JSONL"))
-        .stdout(predicate::str::contains("not by scraping compose logs"))
-        .stdout(predicate::str::contains("Scripts are not executed"));
+        .stdout(predicate::str::contains("Compose configs:"))
+        .stdout(predicate::str::contains("docker-compose locally"))
+        .stdout(predicate::str::contains("setup-complete"))
+        .stdout(predicate::str::contains("Scripts are not executed"))
+        .stdout(predicate::str::contains("Kubernetes configs:"))
+        .stdout(predicate::str::contains("k8s-validator"))
+        .stdout(predicate::str::contains("manifests/"));
 }
 
 #[test]

--- a/tests/cli_launch_config.rs
+++ b/tests/cli_launch_config.rs
@@ -1,8 +1,16 @@
 mod support;
 
 use predicates::prelude::*;
+use std::path::Path;
 use support::*;
 use tempfile::TempDir;
+
+/// Create `dir/manifests/ns.yaml` so the directory looks like a k8s config.
+fn write_manifest(dir: &Path) {
+    let manifests = dir.join("manifests");
+    std::fs::create_dir(&manifests).unwrap();
+    std::fs::write(manifests.join("ns.yaml"), "kind: Namespace\n").unwrap();
+}
 
 #[test]
 fn launch_config_rejects_nonexistent_dir() {
@@ -143,4 +151,71 @@ fn launch_config_conflicts_with_param_config_image() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("cannot be overridden via --param"));
+}
+
+#[test]
+fn launch_config_k8s_dir_is_accepted() {
+    // Directory with manifests/ subdirectory should pass detect_config and
+    // proceed to the ANTITHESIS_REPOSITORY env-var check.
+    let dir = TempDir::new().unwrap();
+    write_manifest(dir.path());
+
+    snouty()
+        .args([
+            "launch",
+            "-w",
+            "basic_k8s_test",
+            "-c",
+            dir.path().to_str().unwrap(),
+            "--duration",
+            "30",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ANTITHESIS_REPOSITORY"));
+}
+
+#[test]
+fn launch_config_rejects_empty_manifests_dir() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join("manifests")).unwrap();
+
+    snouty()
+        .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
+        .args([
+            "launch",
+            "-w",
+            "basic_k8s_test",
+            "-c",
+            dir.path().to_str().unwrap(),
+            "--duration",
+            "30",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("empty manifests/"));
+}
+
+#[test]
+fn launch_config_rejects_ambiguous_dir() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("docker-compose.yaml"), "services: {}\n").unwrap();
+    write_manifest(dir.path());
+
+    snouty()
+        .env("ANTITHESIS_REPOSITORY", "registry.example.com/repo")
+        .args([
+            "launch",
+            "-w",
+            "basic_test",
+            "-c",
+            dir.path().to_str().unwrap(),
+            "--duration",
+            "30",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "both docker-compose.yaml and a manifests/ subdirectory",
+        ));
 }

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -369,6 +369,12 @@ engine_spec_case_test!(
     false
 );
 engine_spec_case_test!(
+    podman_engine_validate_k8s_specs,
+    "podman",
+    "validate_k8s.txt",
+    false
+);
+engine_spec_case_test!(
     docker_engine_launch_config_push_specs,
     "docker",
     "launch_config_push.txt",
@@ -390,5 +396,11 @@ engine_spec_case_test!(
     docker_engine_validate_network_arch_specs,
     "docker",
     "validate_network_arch.txt",
+    false
+);
+engine_spec_case_test!(
+    docker_engine_validate_k8s_specs,
+    "docker",
+    "validate_k8s.txt",
     false
 );


### PR DESCRIPTION
Antithesis k8s tests require a config image with manifests at /manifests. Auto-detect the config type by directory layout: a manifests/ subdirectory selects the Kubernetes path, docker-compose.yaml selects the existing compose path, and both or neither is an error.

For validate, run docker.io/antithesishq/k8s-validator:1.0.0 against the manifests directory. No --timeout deadline since the validator only does static analysis. For launch, build and push the config image as before (scratch + COPY . / already places manifests/ at /manifests in the image) and skip the compose-only push_compose_images / antithesis.images step.

Fixes: https://github.com/antithesishq/snouty/issues/73