### PR TITLE
tidy auth env var help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Antithesis supports two forms of authentication. Some tenants have API keys, whi
 export ANTITHESIS_API_KEY="your-api-key"
 ```
 
-Other tenants use legacy username/password authentication, which you can specify like so:
+Other tenants use username/password authentication, which you can specify like so:
 
 ```sh
 export ANTITHESIS_USERNAME="your-username"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,10 +36,10 @@ Extra parameters can be passed with --param:
     --param my.custom.property=value
 
 Environment variables:
-  ANTITHESIS_TENANT       (required) Your Antithesis tenant name.
+  ANTITHESIS_TENANT       Your Antithesis tenant name (required).
   ANTITHESIS_API_KEY      API key authentication (preferred).
-  ANTITHESIS_USERNAME     Legacy username (required when API key is not set).
-  ANTITHESIS_PASSWORD     Legacy password (required when API key is not set).
+  ANTITHESIS_USERNAME     Username (required when API key is not set).
+  ANTITHESIS_PASSWORD     Password (required when API key is not set).
   ANTITHESIS_REPOSITORY   Container registry for pushing images (required with --config).
   SNOUTY_CONTAINER_ENGINE Force "docker" or "podman" (auto-detected by default)."#)]
     Launch(LaunchArgs),


### PR DESCRIPTION
Drop the "legacy" qualifier from username/password authentication and move the (required) marker on ANTITHESIS_TENANT to the end of the line for consistency with the other env vars.