### PR TITLE
validate: move arch validation to launch

### DIFF
--- a/specs_engine/launch_config_push.txt
+++ b/specs_engine/launch_config_push.txt
@@ -34,6 +34,22 @@ snouty launch -w basic_test -c local_no_build_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
+# A non-amd64 image scheduled for push is rejected before any push happens.
+mock-server 200 '{"status": "ok"}'
+build-image --platform linux/arm64 arm-launch:latest images/arm_launch
+! snouty launch -w basic_test -c arm_push_config --duration 30
+stderr 'x86-64 \(amd64\).*'
+stderr 'image '\''.*arm-launch:latest'\'' has architecture '\''arm64'\''.*'
+! stderr 'Pushing image:'
+
+# A non-amd64 image that is NOT pushed (no registry prefix, no build) does
+# not trigger the architecture check.
+mock-server 200 '{"status": "ok"}'
+build-image --platform linux/arm64 arm-external:latest images/arm_launch
+snouty launch -w basic_test -c arm_external_config --duration 30
+stderr '"antithesis.config_image":.*@sha256:'
+! stderr '"antithesis.images"'
+
 # Kubernetes config: builds and pushes the config image, never sets
 # antithesis.images (the platform pulls images from the manifests).
 mock-server 200 '{"status": "ok"}'
@@ -45,6 +61,8 @@ stderr '"antithesis.config_image":.*@sha256:'
 placeholder
 -- images/sidecar/content --
 placeholder
+-- images/arm_launch/Dockerfile --
+FROM scratch
 -- push_config/docker-compose.yaml --
 services:
   app:
@@ -68,6 +86,15 @@ services:
 services:
   app:
     image: localapp:latest
+-- arm_push_config/docker-compose.yaml --
+services:
+  app:
+    build: .
+    image: arm-launch:latest
+-- arm_external_config/docker-compose.yaml --
+services:
+  app:
+    image: arm-external:latest
 -- k8s_config/manifests/ns.yaml --
 apiVersion: v1
 kind: Namespace

--- a/specs_engine/validate_network_arch.txt
+++ b/specs_engine/validate_network_arch.txt
@@ -1,4 +1,4 @@
-# snouty validate — network and architecture cases with container runtime
+# snouty validate — network and missing-image cases with container runtime
 
 # Shared emitter image for scenarios that need a local setup-complete source.
 build-image setup-emitter-netarch:latest setup_emitter
@@ -10,13 +10,7 @@ stderr 'Isolating networks: default.*'
 stderr 'Setup-complete event detected.*'
 stderr 'Setup validation successful.*'
 
-# An arm64-only image is rejected during validation.
-build-image --platform linux/arm64 arm-sidecar-netarch:latest arm_meta
-! snouty validate config_arm_image --timeout 15
-stderr 'x86-64 \(amd64\).*'
-stderr 'service '\''arm-sidecar'\'' uses image '\''arm-sidecar-netarch:latest'\'' with architecture '\''arm64'\''.*'
-
-# Missing images are reported together before architecture validation.
+# Missing images are reported together before any container is started.
 ! snouty validate config_missing_images --timeout 15
 stderr 'some images are not available locally.*'
 stderr '.*image: missing-app:latest.*'
@@ -26,9 +20,6 @@ stderr '.*pull or build the missing images, then retry.*'
 -- setup_emitter/Dockerfile --
 FROM busybox
 CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl" && sleep 3600'
-
--- arm_meta/Dockerfile --
-FROM scratch
 
 -- net_check/suite/anytime_ping_blocked --
 #!/bin/sh
@@ -47,15 +38,6 @@ CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHES
 services:
   checker:
     image: net-check-netarch:latest
-    pull_policy: never
-
--- config_arm_image/docker-compose.yaml --
-services:
-  emitter:
-    image: setup-emitter-netarch:latest
-    pull_policy: never
-  arm-sidecar:
-    image: arm-sidecar-netarch:latest
     pull_policy: never
 
 -- config_missing_images/docker-compose.yaml --

--- a/src/container.rs
+++ b/src/container.rs
@@ -274,8 +274,9 @@ pub trait ContainerRuntime: Send + Sync {
             }
         }
 
-        // Phase 2: Push images matching registry prefix (existing logic).
+        // Phase 2: arch-check, then push images matching the registry prefix.
         let pushable = filter_pushable_images(&images, registry);
+        validate_image_architectures(self, &pushable)?;
         let mut pinned = Vec::new();
         for image in pushable {
             eprintln!("Pushing image: {image}");
@@ -929,25 +930,22 @@ pub fn validate_images_are_available(
     Err(err)
 }
 
-/// Ensure the referenced images all use the amd64 architecture.
-pub fn validate_image_architectures(
-    runtime: &dyn ContainerRuntime,
-    services: &[ComposeService],
-) -> Result<()> {
+/// Ensure the given image references all use the amd64 architecture.
+fn validate_image_architectures<R>(runtime: &R, images: &[&str]) -> Result<()>
+where
+    R: ContainerRuntime + ?Sized,
+{
     let mut seen = HashSet::new();
     let mut unsupported = Vec::new();
 
-    for service in services {
-        if !seen.insert(service.image.as_str()) {
+    for image in images {
+        if !seen.insert(*image) {
             continue;
         }
 
-        let arch = runtime.image_architecture(&service.image)?;
+        let arch = runtime.image_architecture(image)?;
         if arch != "amd64" {
-            unsupported.push(format!(
-                "service '{}' uses image '{}' with architecture '{arch}'",
-                service.name, service.image
-            ));
+            unsupported.push(format!("image '{image}' has architecture '{arch}'"));
         }
     }
 
@@ -1412,20 +1410,7 @@ services:
             ]),
         };
 
-        validate_image_architectures(
-            &runtime,
-            &[
-                ComposeService {
-                    name: "app".to_string(),
-                    image: "app:latest".to_string(),
-                },
-                ComposeService {
-                    name: "sidecar".to_string(),
-                    image: "sidecar:latest".to_string(),
-                },
-            ],
-        )
-        .unwrap();
+        validate_image_architectures(&runtime, &["app:latest", "sidecar:latest"]).unwrap();
     }
 
     #[test]
@@ -1438,20 +1423,8 @@ services:
             ]),
         };
 
-        let err = validate_image_architectures(
-            &runtime,
-            &[
-                ComposeService {
-                    name: "app".to_string(),
-                    image: "app:latest".to_string(),
-                },
-                ComposeService {
-                    name: "sidecar".to_string(),
-                    image: "sidecar:latest".to_string(),
-                },
-            ],
-        )
-        .unwrap_err();
+        let err =
+            validate_image_architectures(&runtime, &["app:latest", "sidecar:latest"]).unwrap_err();
 
         let msg = err.to_string();
         let debug = format!("{err:?}");
@@ -1460,8 +1433,63 @@ services:
             "expected architecture guidance, got: {msg}"
         );
         assert!(
-            debug.contains("service 'app' uses image 'app:latest' with architecture 'arm64'"),
+            debug.contains("image 'app:latest' has architecture 'arm64'"),
             "expected offending image details, got: {debug}"
+        );
+    }
+
+    #[test]
+    fn pushable_filter_skips_arch_check_for_non_pushable_images() {
+        // Mirrors how push_compose_images wires filter + arch check together:
+        // bare (non-pushable) images with a non-amd64 arch must not fail the
+        // check, because we never push them.
+        let runtime = FakeRuntime {
+            available_images: BTreeMap::new(),
+            architectures: BTreeMap::from([
+                ("nginx:latest".to_string(), "arm64".to_string()),
+                (
+                    "registry.example.com/app:latest".to_string(),
+                    "amd64".to_string(),
+                ),
+            ]),
+        };
+
+        let images = vec![
+            "nginx:latest".to_string(),
+            "registry.example.com/app:latest".to_string(),
+        ];
+        let pushable = filter_pushable_images(&images, "registry.example.com");
+        validate_image_architectures(&runtime, &pushable).unwrap();
+    }
+
+    #[test]
+    fn pushable_filter_flags_arch_for_pushable_images() {
+        let runtime = FakeRuntime {
+            available_images: BTreeMap::new(),
+            architectures: BTreeMap::from([
+                ("nginx:latest".to_string(), "amd64".to_string()),
+                (
+                    "registry.example.com/app:latest".to_string(),
+                    "arm64".to_string(),
+                ),
+            ]),
+        };
+
+        let images = vec![
+            "nginx:latest".to_string(),
+            "registry.example.com/app:latest".to_string(),
+        ];
+        let pushable = filter_pushable_images(&images, "registry.example.com");
+        let err = validate_image_architectures(&runtime, &pushable).unwrap_err();
+
+        let debug = format!("{err:?}");
+        assert!(
+            debug.contains("image 'registry.example.com/app:latest' has architecture 'arm64'"),
+            "expected pushable image to be flagged, got: {debug}"
+        );
+        assert!(
+            !debug.contains("nginx:latest"),
+            "non-pushable image should not appear in error, got: {debug}"
         );
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -148,7 +148,11 @@ pub trait ContainerRuntime: Send + Sync {
             .trim();
 
         if architecture.is_empty() {
-            bail!("empty image inspect output");
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(eyre!(
+                "'{runtime} image inspect {image_ref}' returned empty architecture"
+            ))
+            .with_section(move || stderr.header("Stderr:"));
         }
 
         Ok(architecture.to_string())

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -198,7 +198,6 @@ async fn validate_compose(
     let compose = rt.compose();
     let contents = compose.contents(&config, None)?;
     container::validate_images_are_available(rt, &contents.services)?;
-    container::validate_image_architectures(rt, &contents.services)?;
     let override_path = generate_setup_override(&contents, temp_dir)?;
     let overlay = Some(override_path.as_path());
 


### PR DESCRIPTION
container: include image ref and stderr in empty architecture error

    When 'image inspect --format {{.Architecture}}' exits 0 with empty stdout,
    the previous error gave no clue which image caused it. Surface the runtime,
    image ref, and stderr so the offending image is obvious.

container: move amd64 arch check from validate to launch

    The validate step previously checked every compose service image for amd64,
    including bare upstream images we never push. It turns out that the
    container ecosystem is messy and there are images which do not have an
    architecture set. In general there is probably not a lot that users can
    immediately do if an upstream image they haven't built has the wrong
    architecture. Plus, it is very likely that most public images have amd64
    anyways.

    Move the check into push_compose_images so it runs only on the images about
    to be pushed to the registry, after Phase 1 tagging and before Phase 2 push.
