### PR TITLE
launch: accept fractional --duration and drop email ETAs

### DIFF
--- a/specs/api_webhook.txt
+++ b/specs/api_webhook.txt
@@ -102,11 +102,6 @@ snouty api webhook -w basic_test --antithesis.duration 30
 stdout '"session_id".*'
 stdout '"status".*'
 
-# On success, no report email ETA is printed (unlike `run`).
-mock-server 200 '{"ok": true}'
-snouty api webhook -w basic_test --antithesis.duration 30
-! stderr 'Expect a report email.*'
-
 # Username/password auth works when ANTITHESIS_API_KEY is not set.
 mock-server 200 '{"ok": true}'
 snouty api webhook -w basic_test --antithesis.duration 30

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -60,13 +60,11 @@ mock-server 200 '{}'
 ! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.session_id sess --antithesis.debugging.vtime 123 --my.custom.prop value
 stderr 'validation failed.*'
 
-# On success, the API response body is printed to stdout and a
-#    human-readable ETA for the debugging session email is printed to stderr.
+# On success, the API response body is printed to stdout.
 mock-server 200 '{"debugging": true}'
 stdin moment_input.txt
 snouty debug --stdin
 stdout '\{"debugging": true\}.*'
-stderr 'Expect a debugging session email.*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -12,7 +12,7 @@ stderr '--webhook.*'
 # Parameters are validated against the testParams schema before making
 #    any API call.
 ! snouty launch -w basic_test --duration abc
-stderr 'invalid value.*'
+stderr 'validation failed.*'
 
 # --stdin applies to `api webhook`, not `launch`.
 ! snouty launch -w basic_test --stdin --duration 30
@@ -73,12 +73,6 @@ stderr 'cannot be overridden via --param.*'
 mock-server 200 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
-
-# On success, the command prints a human-readable ETA for the report
-#    email to stderr.
-mock-server 200 '{"ok": true}'
-snouty launch -w basic_test --duration 30
-stderr 'Expect a report email.*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,9 +242,13 @@ pub struct LaunchArgs {
     #[arg(long)]
     pub description: Option<String>,
 
-    /// Test duration in minutes
+    /// Test duration
+    // The unit is determined by the webhook configuration on the platform side,
+    // so snouty intentionally stays unit-agnostic. A string lets callers pass
+    // fractional values when the unit is something coarse like minutes; the
+    // numeric format is enforced by the params schema.
     #[arg(long)]
-    pub duration: Option<u32>,
+    pub duration: Option<String>,
 
     /// Mark the test run as ephemeral. Ephemeral runs will not appear in future reports as a historic result.
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::{self, ErrorKind, Read};
 use std::process::Command;
 
-use chrono::{Duration, Local};
 use clap::Parser;
 use log::{debug, info};
 
@@ -116,7 +115,7 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         params.insert("antithesis.description", description);
     }
     if let Some(duration) = args.duration {
-        params.insert("antithesis.duration", duration.to_string());
+        params.insert("antithesis.duration", duration);
     }
     let has_source = if let Some(source) = args.source {
         params.insert("antithesis.source", source);
@@ -206,20 +205,7 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         params.insert("antithesis.config_image", pinned_config);
     }
 
-    let duration_mins: i64 = params
-        .as_map()
-        .get("antithesis.duration")
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-
     launch_webhook(&args.webhook, params).await?;
-
-    let eta = Local::now() + Duration::minutes(duration_mins + 10);
-    eprintln!(
-        "\nExpect a report email from Antithesis around {}",
-        eta.format("%b %-d at %-I:%M %p")
-    );
 
     Ok(())
 }
@@ -281,14 +267,6 @@ async fn cmd_debug(args: Vec<String>, use_stdin: bool) -> Result<()> {
 
     if status.is_success() {
         println!("{}", body);
-
-        // Estimate when the debugging session email will arrive
-        let eta = Local::now() + Duration::minutes(10);
-        eprintln!(
-            "\nExpect a debugging session email from Antithesis around {}",
-            eta.format("%b %-d at %-I:%M %p")
-        );
-
         Ok(())
     } else {
         bail!("API error: {} - {}", status.as_u16(), body)

--- a/src/params_schema.json
+++ b/src/params_schema.json
@@ -48,8 +48,8 @@
         },
         "antithesis.duration": {
           "type": "string",
-          "pattern": "^[0-9]+$",
-          "description": "Desired test duration in minutes"
+          "pattern": "^[0-9]+(\\.[0-9]+)?$",
+          "description": "Desired test duration"
         },
         "antithesis.images": {
           "type": "string",

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -213,7 +213,18 @@ fn launch_duration_rejects_non_numeric() {
         .args(["launch", "-w", "basic_test", "--duration", "abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("invalid value"));
+        .stderr(predicate::str::contains("validation failed"));
+}
+
+#[test]
+fn launch_duration_accepts_fractional() {
+    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+
+    snouty_with_mock(&mock_url)
+        .args(["launch", "-w", "basic_test", "--duration", "0.05"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(r#""antithesis.duration": "0.05""#));
 }
 
 #[test]
@@ -592,35 +603,6 @@ fn api_webhook_error_outputs_string_on_stderr() {
         .failure()
         .stderr(predicate::str::contains("API error: 500"))
         .stdout(predicate::str::is_empty());
-}
-
-#[test]
-fn api_webhook_success_does_not_print_email_eta() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
-
-    snouty_with_mock(&mock_url)
-        .args([
-            "api",
-            "webhook",
-            "-w",
-            "basic_test",
-            "--antithesis.duration",
-            "30",
-        ])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Expect a report email").not());
-}
-
-#[test]
-fn launch_prints_email_eta() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
-
-    snouty_with_mock(&mock_url)
-        .args(["launch", "-w", "basic_test", "--duration", "30"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Expect a report email"));
 }
 
 #[test]


### PR DESCRIPTION
The duration unit isn't fixed, so type the flag as a String, let the params schema enforce the numeric format (now allowing decimals), and drop both the launch and debug "Expect a … email" ETAs that assumed the unit was minutes.