### PR TITLE
v0 API support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Build
-        run: cargo build
+        run: cargo build --all-targets
 
       - name: Clippy
         uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,27 @@ cargo fmt
 
 If `cargo nextest` is available, always prefer to use `cargo nextest run` for testing.
 
+### Running spec tests against a staging backend
+
+By default `spec_tests` runs against an in-process mock server. To exercise
+the real HTTP wiring end-to-end, set `SNOUTY_STAGING=1` and make sure your
+normal `ANTITHESIS_*` credentials are exported:
+
+```
+SNOUTY_STAGING=1 cargo nextest run spec_tests
+```
+
+Required env in staging mode: `ANTITHESIS_TENANT` plus either
+`ANTITHESIS_API_KEY` or `ANTITHESIS_USERNAME`+`ANTITHESIS_PASSWORD`.
+`ANTITHESIS_BASE_URL` is optional (defaults to `https://<tenant>.antithesis.com`).
+
+When `SNOUTY_STAGING` is set, the `mock-runs-server` directive becomes a
+pass-through that forwards those vars instead of starting the mock. Spec
+lines prefixed with `[!staging]` are skipped (those assert on hardcoded
+mock data); unprefixed lines still run and hit staging. Only read-oriented
+checks run against staging — any spec that would mutate state is gated
+`[!staging]`.
+
 ## AI Coding Workflow
 
 1. ensure that all changes are reflected by a spec, update that first if needed,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -72,15 +72,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -134,6 +134,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -165,6 +176,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -189,6 +206,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "borrow-or-share"
@@ -226,10 +252,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.56"
+name = "cacache"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b"
+dependencies = [
+ "digest",
+ "either",
+ "futures",
+ "hex",
+ "libc",
+ "memmap2",
+ "miette",
+ "reflink-copy",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "ssri",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "walkdir",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -250,15 +303,16 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -266,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -278,18 +332,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -299,9 +353,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "color-eyre"
@@ -318,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -331,7 +394,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -350,6 +413,25 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctor"
@@ -392,10 +474,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -445,6 +546,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +567,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,9 +586,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -471,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -704,12 +829,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -732,20 +867,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -796,6 +931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +956,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -850,6 +997,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-cache"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01e0b5d3afe17eadd68dad863adc0715b7ccfa887effbb9ea4de3c7c78c6c44"
+dependencies = [
+ "bytes",
+ "cacache",
+ "futures",
+ "hex",
+ "http",
+ "http-body",
+ "http-cache-semantics",
+ "httpdate",
+ "log",
+ "pin-project-lite",
+ "postcard",
+ "serde",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "http-cache-reqwest"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff1fa00fd5b0d38c26d5f24f1cf513e286a988b57880c2bf357304669268fa3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-cache",
+ "http-cache-semantics",
+ "reqwest",
+ "reqwest-middleware",
+ "url",
+]
+
+[[package]]
+name = "http-cache-semantics"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
+dependencies = [
+ "http",
+ "http-serde",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,9 +1073,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -878,10 +1088,25 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -906,7 +1131,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -949,12 +1174,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -962,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -975,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -989,15 +1215,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1009,15 +1235,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1063,27 +1289,27 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1097,15 +1323,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1116,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1127,10 +1353,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.89"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1166,7 +1394,6 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -1187,15 +1414,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
@@ -1219,9 +1446,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1245,6 +1472,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1327,6 +1586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,15 +1652,26 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openapiv3"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "openssl"
@@ -1499,15 +1775,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1523,21 +1793,39 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.4"
+name = "postcard"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -1589,6 +1877,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "progenitor"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba1d77160e6d5c95bdf0792527f76bf528791093fa83015bc2908a0ba9d076"
+dependencies = [
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8a874cf25a33cac7a01b9c1de87bcfbc8aea93f3156d09dcc3bee516a78926"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e349eed84b9a1a6a5dbe478d335e3df73d32a93c5eefe571c9b8cb298aab5d"
+dependencies = [
+ "heck",
+ "http",
+ "indexmap",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror 2.0.18",
+ "typify",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa969a1349979c5f64347f204e794781a86d738206d75672e6c9493f5910002"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn",
+]
+
+[[package]]
 name = "ptree"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1618,9 +1972,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1630,6 +1984,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -1648,7 +2008,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1687,6 +2047,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,20 +2088,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
+name = "regress"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
- "base64",
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -1744,13 +2127,43 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1787,12 +2200,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1818,11 +2255,37 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -1856,9 +2319,13 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1891,6 +2358,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +2379,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -1926,6 +2416,39 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1961,6 +2484,7 @@ name = "snouty"
 version = "0.4.2"
 dependencies = [
  "assert_cmd",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "clap_complete",
@@ -1969,20 +2493,28 @@ dependencies = [
  "ctor",
  "dirs",
  "env_logger",
+ "futures-util",
  "getrandom 0.3.4",
+ "http-cache-reqwest",
  "json5",
  "jsonschema",
  "libc",
  "log",
  "predicates",
+ "prettyplease",
+ "progenitor",
+ "progenitor-client",
  "ptree",
  "pulldown-cmark",
+ "quote",
  "regex",
  "reqwest",
+ "reqwest-middleware",
  "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
+ "syn",
  "tempfile",
  "testscript-rs",
  "tokio",
@@ -1991,12 +2523,29 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ssri"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
+dependencies = [
+ "base64 0.21.7",
+ "digest",
+ "hex",
+ "miette",
+ "serde",
+ "sha-1",
+ "sha2",
+ "thiserror 1.0.69",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2010,6 +2559,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2044,12 +2599,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2070,8 +2625,17 @@ dependencies = [
  "anyhow",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2080,7 +2644,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2095,10 +2670,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
+name = "time"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2106,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2122,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2138,6 +2744,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2225,6 +2852,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typify"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+ "typify-impl",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2930,12 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -2267,6 +2953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2968,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2289,6 +2982,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 
 [[package]]
 name = "uuid-simd"
@@ -2372,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.112"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2385,23 +3084,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.62"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee85afca410ac4abba5b584b12e77ea225db6ee5471d0aebaae0861166f9378a"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.112"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2409,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.112"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2422,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.112"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2452,6 +3147,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.89"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10053fbf9a374174094915bbce141e87a6bf32ecd9a002980db4b638405e8962"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2483,6 +3191,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +3222,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2524,6 +3264,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,20 +3293,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2574,31 +3324,23 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2608,22 +3350,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2632,22 +3362,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2656,22 +3374,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2680,22 +3386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wiremock"
@@ -2704,7 +3398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -2815,10 +3509,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "yoke"
-version = "0.8.1"
+name = "xxhash-rust"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2827,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2839,18 +3539,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2859,18 +3559,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2886,9 +3586,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2897,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2908,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "ctor",
  "dirs",
  "env_logger",
+ "form_urlencoded",
  "futures-util",
  "getrandom 0.3.4",
  "http-cache-reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 getrandom = "0.3"
 env_logger = "0.11"
+form_urlencoded = "1"
 # pinned: alpha API churn between releases
 http-cache-reqwest = "=1.0.0-alpha.6"
 json5 = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,17 +5,24 @@ edition = "2024"
 description = "A CLI tool for using the Antithesis API"
 license = "Apache-2.0"
 repository = "https://github.com/antithesishq/snouty"
+default-run = "snouty"
 
 [dependencies]
-chrono = "0.4"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 getrandom = "0.3"
 env_logger = "0.11"
+# pinned: alpha API churn between releases
+http-cache-reqwest = "=1.0.0-alpha.6"
 json5 = "1.3.0"
-jsonschema = "0.37.4"
+jsonschema = { version = "0.37.4", default-features = false }
 log = "0.4"
-reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls-vendored"] }
+progenitor-client = "0.14.0"
+reqwest = { version = "0.13.1", default-features = false, features = ["http2", "json", "query", "stream", "native-tls-vendored"] }
+reqwest-middleware = "0.5"
 color-eyre = { version = "0.6", default-features = false }
+futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util", "io-std", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,9 +36,18 @@ regex = "1"
 ptree = { version = "0.5.2", default-features = false }
 serde_yaml = "0.9"
 
+[[example]]
+name = "mock_api"
+path = "examples/mock_api.rs"
+
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+prettyplease = "0.2"
+progenitor = "0.14.0"
+quote = "1"
+serde_json = "1"
+syn = "2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 use clap::CommandFactory;
@@ -8,20 +9,40 @@ include!("src/cli.rs");
 
 fn main() {
     println!("cargo:rerun-if-env-changed=RUSTC");
+    println!("cargo:rerun-if-changed=src/openapi.json");
     println!(
         "cargo:rustc-env=SNOUTY_RUSTC_VERSION={}",
         rustc_version().unwrap()
     );
 
-    let outdir = std::env::var_os("SHELL_COMPLETIONS_DIR")
-        .or_else(|| std::env::var_os("OUT_DIR"))
-        .unwrap();
-    fs::create_dir_all(&outdir).unwrap();
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    fs::create_dir_all(&out_dir).unwrap();
+    generate_api_client(Path::new(&out_dir));
+
+    let completions_dir = std::env::var_os("SHELL_COMPLETIONS_DIR").unwrap_or(out_dir);
+    fs::create_dir_all(&completions_dir).unwrap();
 
     let mut command = Cli::command();
     for shell in [Shell::Bash, Shell::Fish, Shell::Zsh, Shell::Elvish] {
-        generate_to(shell, &mut command, "snouty", &outdir).unwrap();
+        generate_to(shell, &mut command, "snouty", &completions_dir).unwrap();
     }
+}
+
+fn generate_api_client(out_dir: &Path) {
+    let file = std::fs::File::open("src/openapi.json").unwrap();
+    let spec = serde_json::from_reader(file).unwrap();
+
+    let mut settings = progenitor::GenerationSettings::default();
+    settings.with_interface(progenitor::InterfaceStyle::Builder);
+    settings.with_inner_type(quote::quote!(
+        ::std::option::Option<::reqwest_middleware::ClientWithMiddleware>
+    ));
+    let mut generator = progenitor::Generator::new(&settings);
+    let tokens = generator.generate_tokens(&spec).unwrap();
+    let ast = syn::parse2(tokens).unwrap();
+    let content = prettyplease::unparse(&ast);
+
+    fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
 }
 
 fn rustc_version() -> Result<String, Box<dyn std::error::Error>> {

--- a/build.rs
+++ b/build.rs
@@ -34,9 +34,7 @@ fn generate_api_client(out_dir: &Path) {
 
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_interface(progenitor::InterfaceStyle::Builder);
-    settings.with_inner_type(quote::quote!(
-        ::std::option::Option<::reqwest_middleware::ClientWithMiddleware>
-    ));
+    settings.with_inner_type(quote::quote!(crate::api::ClientState));
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(&spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();

--- a/examples/mock_api.rs
+++ b/examples/mock_api.rs
@@ -1,0 +1,15 @@
+use snouty::testutils::MockApiServer;
+
+fn main() {
+    let server = MockApiServer::start();
+    let url = server.url();
+    let token = server.token();
+
+    eprintln!("Mock Antithesis API listening on {url}");
+    eprintln!();
+    eprintln!("  export ANTITHESIS_BASE_URL={url}");
+    eprintln!("  export ANTITHESIS_API_KEY={token}");
+    eprintln!("  export ANTITHESIS_TENANT=mock");
+
+    server.wait();
+}

--- a/specs/api_webhook.txt
+++ b/specs/api_webhook.txt
@@ -1,6 +1,11 @@
 # snouty api webhook
 #
 # Submit raw parameters to an Antithesis webhook endpoint.
+#
+# Each successful invocation starts a real test run, so the bulk of this
+# file is gated behind `[staging] skip`. Read-only checks (env-var
+# enforcement, missing flags, bad stdin, unexpected positional, etc.) fail
+# before any API call and run in both modes.
 
 # Requires API credentials from environment.
 ! snouty api webhook -w basic_test --antithesis.duration 30
@@ -15,44 +20,6 @@ stderr '--webhook.*'
 mock-server 200 '{}'
 ! snouty api webhook -w basic_test
 stderr 'no parameters provided.*'
-
-# Parameters are provided as --key value pairs and printed to stderr
-#    with sensitive values redacted.
-mock-server 200 '{"status": "ok"}'
-snouty api webhook -w basic_test --antithesis.test_name my-test --antithesis.description 'nightly test run' --antithesis.config_image config:latest --antithesis.images app:latest --antithesis.duration 30 --antithesis.report.recipients team@example.com
-stderr '"antithesis.test_name": "my-test"'
-stderr '"antithesis.description": "nightly test run"'
-stderr '"antithesis.config_image": "config:latest"'
-stderr '"antithesis.images": "app:latest"'
-stderr '"antithesis.duration": "30"'
-stderr '"antithesis.report.recipients": "\[REDACTED\]"'
-
-# Parameters can be read from stdin via --stdin as JSON.
-mock-server 200 '{"launched": true}'
-stdin webhook_stdin.json
-snouty api webhook -w basic_test --stdin
-stderr '"antithesis.duration": "60"'
-stderr '"antithesis.is_ephemeral": "true"'
-
-# Custom (non-antithesis) properties are accepted.
-mock-server 200 '{"ok": true}'
-snouty api webhook -w basic_test --antithesis.duration 30 --my.custom.prop value
-stderr '"my.custom.prop": "value"'
-
-# Without --stdin flag, stdin content is ignored.
-mock-server 200 '{"ok": true}'
-stdin ignored_stdin.json
-snouty api webhook -w basic_test --antithesis.duration 30
-stderr '"antithesis.duration": "30"'
-! stderr '.*SHOULD_BE_IGNORED.*'
-
-# --webhook long flag form accepted.
-mock-server 200 '{"status": "ok"}'
-snouty api webhook --webhook basic_k8s_test --antithesis.duration 30
-
-# Custom webhook names accepted.
-mock-server 200 '{"status": "ok"}'
-snouty api webhook -w my_custom_webhook --antithesis.duration 30
 
 # Invalid JSON on stdin fails.
 mock-server 200 '{}'
@@ -70,19 +37,62 @@ mock-server 200 '{}'
 ! snouty api webhook -w basic_test notaflag
 stderr 'unexpected argument.*'
 
+# -c/--config flag is not accepted on api webhook.
+! snouty api webhook -w basic_test -c /some/path --antithesis.duration 30
+
+[staging] skip
+
+# Parameters are provided as --key value pairs and printed to stderr
+#    with sensitive values redacted.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty api webhook -w basic_test --antithesis.test_name my-test --antithesis.description 'nightly test run' --antithesis.config_image config:latest --antithesis.images app:latest --antithesis.duration 30 --antithesis.report.recipients team@example.com
+stderr '"antithesis.test_name": "my-test"'
+stderr '"antithesis.description": "nightly test run"'
+stderr '"antithesis.config_image": "config:latest"'
+stderr '"antithesis.images": "app:latest"'
+stderr '"antithesis.duration": "30"'
+stderr '"antithesis.report.recipients": "\[REDACTED\]"'
+
+# Parameters can be read from stdin via --stdin as JSON.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+stdin webhook_stdin.json
+snouty api webhook -w basic_test --stdin
+stderr '"antithesis.duration": "60"'
+stderr '"antithesis.is_ephemeral": "true"'
+
+# Custom (non-antithesis) properties are accepted.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty api webhook -w basic_test --antithesis.duration 30 --my.custom.prop value
+stderr '"my.custom.prop": "value"'
+
+# Without --stdin flag, stdin content is ignored.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+stdin ignored_stdin.json
+snouty api webhook -w basic_test --antithesis.duration 30
+stderr '"antithesis.duration": "30"'
+! stderr '.*SHOULD_BE_IGNORED.*'
+
+# --webhook long flag form accepted.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty api webhook --webhook basic_k8s_test --antithesis.duration 30
+
+# Custom webhook names accepted (CLI does no client-side validation).
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty api webhook -w my_custom_webhook --antithesis.duration 30
+
 # API errors are reported with status code.
-mock-server 400 '{"error": "bad request"}'
+mock-server 400 '{"message":"bad request"}'
 ! snouty api webhook -w basic_test --antithesis.duration 30
 stderr 'API error: 400.*'
 
 # On API error, nothing is printed to stdout.
-mock-server 500 '{"error": "something went wrong"}'
+mock-server 500 '{"message":"something went wrong"}'
 ! snouty api webhook -w basic_test --antithesis.duration 30
 stderr 'API error: 500.*'
 ! stdout .+
 
 # Stdin JSON is merged with CLI args; CLI args take priority.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 stdin merge_stdin.json
 snouty api webhook -w basic_test --stdin --antithesis.report.recipients team@example.com
 stderr '"antithesis.duration": "60"'
@@ -90,38 +100,35 @@ stderr '"antithesis.description": "from stdin"'
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
 # CLI args override values from stdin.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 stdin merge_stdin.json
 snouty api webhook -w basic_test --stdin --antithesis.duration 120
 stderr '"antithesis.duration": "120"'
 stderr '"antithesis.description": "from stdin"'
 
 # On success, response body is printed as JSON to stdout.
-mock-server 200 '{"session_id": "abc123", "status": "launched"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 snouty api webhook -w basic_test --antithesis.duration 30
-stdout '"session_id".*'
-stdout '"status".*'
+stdout '"runId".*'
+stdout '"statusCode".*'
 
 # Username/password auth works when ANTITHESIS_API_KEY is not set.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-456","statusCode":200}'
 snouty api webhook -w basic_test --antithesis.duration 30
 
 # ANTITHESIS_API_KEY switches authentication to bearer auth and removes the
 #    ANTITHESIS_USERNAME / ANTITHESIS_PASSWORD requirement.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-456","statusCode":200}'
 env ANTITHESIS_API_KEY=test-api-key
 env ANTITHESIS_USERNAME=
 env ANTITHESIS_PASSWORD=
 snouty api webhook -w basic_test --antithesis.duration 30
 
 # When both auth styles are present, ANTITHESIS_API_KEY still takes precedence.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-456","statusCode":200}'
 env ANTITHESIS_USERNAME=testuser
 env ANTITHESIS_PASSWORD=testpass
 snouty api webhook -w basic_test --antithesis.duration 30
-
-# -c/--config flag is not accepted on api webhook.
-! snouty api webhook -w basic_test -c /some/path --antithesis.duration 30
 
 -- webhook_stdin.json --
 {"antithesis.duration": "60", "antithesis.is_ephemeral": "true"}

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -5,25 +5,46 @@
 # As a developer, I want to launch a debugging session from the command line
 # using details from a triage report so that I can reproduce and investigate
 # a specific moment in time.
+#
+# Each successful invocation actually starts a debugging session against the
+# API, so the bulk of this file is gated behind `[staging] skip` to avoid
+# mutating staging. Read-only checks (env-var and schema validation that
+# fail before any API call) run in both modes.
 
 # The command authenticates with the Antithesis API using either
 #    ANTITHESIS_API_KEY and ANTITHESIS_TENANT, or
 #    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT.
-! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.session_id sess --antithesis.debugging.vtime 123
+! snouty debug --input-hash abc --session-id sess --vtime 123
 stderr 'missing environment variable.*'
 
-# Parameters are provided as --key value pairs
-#    (e.g. --antithesis.debugging.session_id ...).
-mock-server 200 '{"session": "started"}'
-snouty debug --antithesis.debugging.input_hash abc123 --antithesis.debugging.session_id sess-456 --antithesis.debugging.vtime 1234567890
+# Parameters are validated against the debuggingParams schema before
+#    making any API call. Required fields: session_id, input_hash, vtime.
+mock-server 200 '{}'
+! snouty debug --input-hash abc
+stderr 'validation failed.*'
+
+# Old-style raw --antithesis.* args are not accepted by `debug`.
+! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.session_id sess --antithesis.debugging.vtime 123
+stderr 'unexpected argument.*'
+
+[staging] skip
+
+# Parameters are provided as typed flags. Before sending, the resolved
+#    parameters are printed to stderr with sensitive values redacted.
+mock-server 200 '{"runId":"run-123","statusCode":202}'
+snouty debug --input-hash abc123 --session-id sess-456 --vtime 1234567890 --description 'debug this moment' --recipients team@example.com
 stderr '"antithesis.debugging.input_hash": "abc123"'
+stderr '"antithesis.debugging.session_id": "sess-456"'
+stderr '"antithesis.debugging.vtime": "1234567890"'
+stderr '"antithesis.event_description": "debug this moment"'
+stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
 # Parameters can alternatively be read from stdin via --stdin, as JSON,
 #    JSON5, or Moment.from format. Moment.from format
 #    (e.g. Moment.from({ session_id: "...", ... })) is auto-detected on
 #    stdin. Keys are mapped to antithesis.debugging.* and numeric values are
 #    converted to strings.
-mock-server 200 '{"debugging": true}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 stdin moment_input.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22"'
@@ -31,45 +52,37 @@ stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 
 # 3b. stdin as JSON
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 stdin debug_json.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.input_hash": "abc"'
 
 # When both stdin and CLI args are provided, CLI args take priority over
 #    stdin values.
-mock-server 200 '{"debugging": true}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 stdin moment_input.txt
-snouty debug --stdin --antithesis.report.recipients team@example.com
+snouty debug --stdin --input-hash override --recipients team@example.com
 stderr '"antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22"'
-stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
+stderr '"antithesis.debugging.input_hash": "override"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
-
-# Before sending, the resolved parameters are printed to stderr with
-#    sensitive values redacted.
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
-# Parameters are validated against the debuggingParams schema before
-#    making any API call. Required fields: session_id, input_hash, vtime.
-mock-server 200 '{}'
-! snouty debug --antithesis.debugging.input_hash abc
-stderr 'validation failed.*'
-
-# 6b. Rejects custom/extra properties.
-mock-server 200 '{}'
-! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.session_id sess --antithesis.debugging.vtime 123 --my.custom.prop value
-stderr 'validation failed.*'
-
-# On success, the API response body is printed to stdout.
-mock-server 200 '{"debugging": true}'
+# On success, a one-line confirmation with the run_id is printed to stdout.
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 stdin moment_input.txt
 snouty debug --stdin
-stdout '\{"debugging": true\}.*'
+stdout 'Debugging session started: run_id run-123'
+
+# With --json, the full response body is printed as pretty JSON.
+mock-server 200 '{"runId":"run-123","statusCode":202}'
+stdin moment_input.txt
+snouty --json debug --stdin
+stdout '\s*"runId": "run-123".*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.
-mock-server 401 '{"error": "unauthorized"}'
-! snouty debug --antithesis.debugging.input_hash abc123 --antithesis.debugging.session_id sess-456 --antithesis.debugging.vtime 1234567890
+mock-server 401 '{"message": "unauthorized"}'
+! snouty debug --input-hash abc123 --session-id sess-456 --vtime 1234567890
 stderr 'API error: 401.*'
 
 -- moment_input.txt --

--- a/specs/docs_search.txt
+++ b/specs/docs_search.txt
@@ -22,18 +22,18 @@ snouty docs --offline search docker
 stdout '/docs/guides/docker_basics/.*'
 stdout 'Docker basics.*'
 
-# When search runs with --json/-j, stdout is always JSON. If --json is
+# When search runs with --json, stdout is always JSON. If --json is
 #    present, any non-JSON stdout is a bug.
-snouty docs --offline search --json sdk
+snouty --json docs --offline search sdk
 stdout '"path".*'
 stdout '"title".*'
 stdout '"snippet".*'
 
 # Supports --limit/-n <n> with a default limit of 10.
-snouty docs --offline search --json -n 2 test
+snouty --json docs --offline search -n 2 test
 stdout '"path".*'
 
-# When search runs with --list/-l and --json/-j is not present, it
+# When search runs with --list/-l and --json is not present, it
 #    returns only the matching page paths.
 snouty docs --offline search --list -n 2 test
 stdout '/docs/reference/test_patterns/.*'
@@ -41,24 +41,24 @@ stdout '/docs/environment/fault_injection/.*'
 ! stderr .+
 
 # 5b. --list --json outputs a JSON array of paths.
-snouty docs --offline search --list --json -n 2 test
+snouty --json docs --offline search --list -n 2 test
 stdout '/docs/reference/test_patterns/.*'
 stdout '/docs/environment/fault_injection/.*'
 ! stderr .+
 
-# When search finds no matches and --json/-j is not present, it exits
+# When search finds no matches and --json is not present, it exits
 #    successfully and prints a "No results found" message to stderr.
 snouty docs --offline search xyznonexistent999
 stderr 'No results found.*'
 
-# When search finds no matches and --json/-j is present, it exits
+# When search finds no matches and --json is present, it exits
 #    successfully and prints an empty JSON array to stdout.
-snouty docs --offline search --json xyznonexistent999
+snouty --json docs --offline search xyznonexistent999
 stdout '\[\]'
 ! stderr .+
 
 # 7b. --list --json with no results also produces an empty array.
-snouty docs --offline search --list --json xyznonexistent999
+snouty --json docs --offline search --list xyznonexistent999
 stdout '\[\]'
 ! stderr .+
 

--- a/specs/help.txt
+++ b/specs/help.txt
@@ -11,6 +11,7 @@ stdout 'snouty \d+\.\d+\.\d+'
 # --help shows primary subcommands.
 snouty --help
 stdout '.*run.*'
+stdout '.*runs.*'
 stdout '.*debug.*'
 stdout '.*version.*'
 stdout '.*api.*'

--- a/specs/help.txt
+++ b/specs/help.txt
@@ -10,8 +10,6 @@ stdout 'snouty \d+\.\d+\.\d+'
 
 # --help shows primary subcommands.
 snouty --help
-stdout '.*run.*'
-stdout '.*runs.*'
 stdout '.*debug.*'
 stdout '.*version.*'
 stdout '.*api.*'

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -4,6 +4,11 @@
 #
 # As a developer, I want to launch an Antithesis test run from the command
 # line so that I can trigger testing without using the web UI.
+#
+# Each successful invocation actually starts a test run against the API, so
+# the bulk of this file is gated behind `[staging] skip`. Read-only checks
+# (arg parsing, schema validation, env-var enforcement) all fail before any
+# API call and run in both modes.
 
 # The user specifies a webhook endpoint name via -w / --webhook (required).
 ! snouty launch --duration 30
@@ -27,44 +32,8 @@ stderr 'unexpected argument.*'
 ! snouty launch -w basic_test --duration 30
 stderr 'missing environment variable.*'
 
-# Parameters are provided as --key value typed flags
-#    (e.g. --duration 30, --test-name my-test). Before sending, the resolved
-#    parameters are printed to stderr with sensitive values (tokens, email
-#    recipients) redacted.
-mock-server 200 '{"status": "ok"}'
-snouty launch -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
-stderr '"antithesis.test_name": "my-test"'
-stderr '"antithesis.description": "nightly test run"'
-stderr '"antithesis.config_image": "config:latest"'
-stderr '"antithesis.duration": "30"'
-stderr '"antithesis.report.recipients": "\[REDACTED\]"'
-stderr '"antithesis.source": "ci-pipeline"'
-
-# 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
-mock-server 200 '{"status": "ok"}'
-snouty launch -w basic_test --duration 30 --ephemeral
-stderr '"antithesis.is_ephemeral": "true"'
-
-# 6c. Without --source, is_ephemeral is set automatically and an info message is shown.
-mock-server 200 '{"status": "ok"}'
-snouty launch -w basic_test --duration 30
-stderr '"antithesis.is_ephemeral": "true"'
-stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
-
-# 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
-mock-server 200 '{"status": "ok"}'
-snouty launch -w basic_test --duration 30 --source ci-pipeline
-! stderr 'is_ephemeral.*'
-! stderr 'Starting ephemeral run.*'
-
-# 6d. --param flag passes custom properties.
-mock-server 200 '{"ok": true}'
-snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
-stderr '"my.custom.prop": "value"'
-stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
-
-# 6e. --param cannot override typed flag values.
-mock-server 200 '{"ok": true}'
+# --param cannot override typed flag values.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.duration=60
 stderr 'cannot be overridden via --param.*'
 
@@ -74,18 +43,64 @@ mock-server 200 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
 
-# On API failure, the command exits with an error showing the HTTP status
-#    and response body.
-mock-server 400 '{"error": "bad request"}'
-! snouty launch -w basic_test --duration 30
-stderr 'API error: 400.*'
-
 # antithesis.images must not be passed via --param; use api webhook instead.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.images=app:latest
 stderr 'do not specify antithesis.images.*'
 
+[staging] skip
+
+# Parameters are provided as --key value typed flags
+#    (e.g. --duration 30, --test-name my-test). Before sending, the resolved
+#    parameters are printed to stderr with sensitive values (tokens, email
+#    recipients) redacted. On success, a one-line confirmation with the
+#    run_id is printed to stdout.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty launch -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
+stderr '"antithesis.test_name": "my-test"'
+stderr '"antithesis.description": "nightly test run"'
+stderr '"antithesis.config_image": "config:latest"'
+stderr '"antithesis.duration": "30"'
+stderr '"antithesis.report.recipients": "\[REDACTED\]"'
+stderr '"antithesis.source": "ci-pipeline"'
+stdout 'Test run started: run_id run-123'
+
+# With --json, the full response body is printed as pretty JSON.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty --json launch -w basic_test --config-image config:latest --duration 30 --source ci-pipeline
+stdout '\s*"runId": "run-123".*'
+! stdout 'Test run started.*'
+
+# 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty launch -w basic_test --duration 30 --ephemeral
+stderr '"antithesis.is_ephemeral": "true"'
+
+# 6c. Without --source, is_ephemeral is set automatically and an info message is shown.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty launch -w basic_test --duration 30
+stderr '"antithesis.is_ephemeral": "true"'
+stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
+
+# 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty launch -w basic_test --duration 30 --source ci-pipeline
+! stderr 'is_ephemeral.*'
+! stderr 'Starting ephemeral run.*'
+
+# 6d. --param flag passes custom properties.
+mock-server 200 '{"runId":"run-123","statusCode":200}'
+snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
+stderr '"my.custom.prop": "value"'
+stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
+
+# On API failure, the command exits with an error showing the HTTP status
+#    and response body.
+mock-server 400 '{"message":"bad request"}'
+! snouty launch -w basic_test --duration 30
+stderr 'API error: 400.*'
+
 # `snouty run` still works but prints a deprecation warning.
-mock-server 200 '{"ok": true}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 snouty run -w basic_test --duration 30
 stderr 'snouty run.*is deprecated.*snouty launch'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -1,0 +1,213 @@
+# snouty runs
+#
+# List all Antithesis runs.
+#
+# Assertions prefixed with [!staging] are skipped when SNOUTY_STAGING is
+# set: they assert against hardcoded mock data (or behaviors that only make
+# sense against the in-process mock) that does not exist on the live staging
+# backend. Unprefixed assertions are structural and run in both modes.
+#
+# Run-id scoped read responses may be cached under
+# $XDG_RUNTIME_DIR/snouty/api-cache-v1. Caching is internal and must not change
+# command output or required arguments.
+
+# The command authenticates with the Antithesis API using
+#    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT env vars.
+! snouty runs
+stderr 'missing environment variable.*'
+
+# On success, the command fetches all pages via next_cursor and prints a table.
+mock-runs-server
+snouty runs
+stdout 'RUN ID.*STATUS.*CREATED AT.*LAUNCHER'
+[!staging] stdout 'run-1.*completed.*2025-03-20T02:00:00\+00:00.*nightly'
+[!staging] stdout 'run-2.*in_progress.*2025-03-19T14:00:00\+00:00.*debug'
+
+# `snouty runs list` is the same as bare `snouty runs`.
+mock-runs-server
+snouty runs list
+stdout 'RUN ID.*STATUS.*CREATED AT.*LAUNCHER'
+[!staging] stdout 'run-1.*completed.*2025-03-20T02:00:00\+00:00.*nightly'
+[!staging] stdout 'run-2.*in_progress.*2025-03-19T14:00:00\+00:00.*debug'
+
+# `snouty runs show` requires a run ID.
+! snouty runs show
+stderr '.*'
+
+# `snouty --json runs` outputs NDJSON (one run per line) so a run id can be
+#    captured for use in subsequent commands as $R_run_id. Subsequent read
+#    endpoints (properties, build-logs, events) only return data once a run
+#    has reached a terminal state, so list with --status completed first.
+mock-runs-server
+snouty --json runs list --status completed
+[!staging] stdout '"run_id":"run-.*'
+env_from_json 0 run_id
+
+# `snouty runs show` displays run details in key-value format.
+mock-runs-server
+snouty runs show $R_run_id
+stdout 'Run ID.*$R_run_id'
+[!staging] stdout 'Status.*completed'
+[!staging] stdout 'Launcher.*nightly'
+
+# `snouty --json runs show` outputs JSON.
+mock-runs-server
+snouty --json runs show $R_run_id
+stdout '"run_id".*"$R_run_id"'
+[!staging] stdout '"status".*"completed"'
+
+# `snouty runs properties` renders event-based properties as a flattened HASH/VTIME
+# table and non-event properties as a separate NAME/VALUE table.
+mock-runs-server
+snouty runs properties $R_run_id
+[!staging] stdout 'EXAMPLE.*HASH.*VTIME.*NAME'
+[!staging] stdout 'Failing.*-100.*5\.0.*Counter value stays below limit'
+[!staging] stdout 'Failing.*-200.*10\.0.*Counter value stays below limit'
+[!staging] stdout 'Passing.*-300.*15\.0.*Counter value stays below limit'
+[!staging] stdout 'EXAMPLE.*NAME.*VALUE'
+[!staging] stdout 'Passing.*Setup completes.*"final_counter":42'
+
+# `snouty runs properties --failing` shows only failing properties.
+mock-runs-server
+snouty runs properties --failing $R_run_id
+[!staging] stdout 'Failing.*-100.*5\.0.*Counter value stays below limit'
+[!staging] stdout 'Failing.*-200.*10\.0.*Counter value stays below limit'
+[!staging] stdout 'Passing.*-300.*15\.0.*Counter value stays below limit'
+[!staging] stdout -count=0 'Setup completes'
+
+# `snouty runs properties --passing` shows only passing properties.
+mock-runs-server
+snouty runs properties --passing $R_run_id
+[!staging] stdout 'EXAMPLE.*NAME.*VALUE'
+[!staging] stdout 'Passing.*Setup completes.*"final_counter":42'
+[!staging] stdout -count=0 'Counter value stays below limit'
+
+# `snouty runs properties --passing --failing` is rejected.
+! snouty runs properties --passing --failing $R_run_id
+stderr '.*cannot be used with.*'
+
+# `snouty --json runs properties` outputs JSON.
+mock-runs-server
+snouty --json runs properties $R_run_id
+[!staging] stdout '"name".*"Counter value stays below limit"'
+[!staging] stdout '"status".*"Failing"'
+
+# `snouty runs build-logs` streams formatted build log lines.
+mock-runs-server
+snouty runs build-logs $R_run_id
+[!staging] stdout '2025-03-20T02:01:12Z \[stdout\] Building image payments-service\.\.\.'
+[!staging] stdout '2025-03-20T02:01:15Z \[stderr\] Warning: deprecated feature'
+[!staging] stdout '2025-03-20T02:01:20Z \[stdout\] Build complete'
+
+# `snouty --json runs build-logs` outputs raw NDJSON.
+mock-runs-server
+snouty --json runs build-logs $R_run_id
+[!staging] stdout '"timestamp".*"text"'
+
+# `snouty runs events` outputs a table by default.
+mock-runs-server
+snouty runs events $R_run_id request
+[!staging] stdout '^HASH\s+VTIME\s+SOURCE\s+OUTPUT'
+[!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
+
+# `snouty --json runs events` outputs raw NDJSON.
+mock-runs-server
+snouty --json runs events $R_run_id counter
+[!staging] stdout '"antithesis_assert".*"Counter'\''s value retrieved"'
+[!staging] stdout '.*"moment".*"input_hash":"-4735081784258020614".*'
+[!staging] stdout '.*"moment".*"vtime":"311\.8487535319291".*'
+
+# An incomplete run carries the failure moment (input_hash + vtime) in its detail
+#    response. Filter the list with --status incomplete so we know the run we
+#    inspect actually entered the incomplete terminal state, then assert that
+#    the human-readable view shows "Failure VTime" / "Failure Hash" and the
+#    --json view exposes failure_moment with input_hash and vtime.
+mock-runs-server
+snouty --json runs list --status incomplete
+stdout '"run_id":.*'
+stdout '"status":"incomplete".*'
+env_from_json 0 run_id
+
+mock-runs-server
+snouty runs show $R_run_id
+stdout 'Failure VTime.*'
+stdout 'Failure Hash.*'
+
+mock-runs-server
+snouty --json runs show $R_run_id
+stdout '"failure_moment".*'
+stdout '"input_hash".*'
+stdout '"vtime".*'
+
+[staging] skip
+
+# If no runs are returned, the command prints a friendly empty-state message.
+mock-runs-server empty
+snouty runs
+stdout 'No runs found\.'
+
+# API errors are reported with status code and body.
+mock-server 400 '{"message":"bad request"}'
+! snouty runs
+stderr 'API error: 400.*'
+
+# `snouty runs properties` prints a friendly empty-state message when no properties exist.
+mock-runs-server
+snouty runs properties run-empty
+stdout 'No properties found\.'
+
+# `snouty runs properties` shows a values table for non-event properties even
+# when they have no sampled values; such properties render as "-" rows and the
+# events table is omitted.
+mock-runs-server
+snouty runs properties run-no-events
+stdout 'EXAMPLE.*NAME.*VALUE'
+stdout '-.*No events property.*-'
+! stdout 'EXAMPLE.*HASH.*VTIME'
+
+# `snouty runs properties` requires a run ID.
+! snouty runs properties
+stderr '.*'
+
+# `snouty runs logs` outputs a table by default.
+mock-runs-server
+snouty runs logs run-1 -123 1.0
+stdout 'VTIME.*SOURCE.*OUTPUT'
+stdout '1\.0.*\[app:out\].*\{"level":"info","msg":"starting"\}'
+stdout '2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
+stdout '3\.0.*\[app:out\].*line one\\\\nline two'
+stdout '73\.94233945617452.*\[control:error\].*Post "http://10\.0\.1\.123:8003/"'
+stdout '311\.8487535319291.*\[control:assert\].*UNHIT AlwaysOrUnreachable "Counter'\''s value retrieved" @ control\.go:get:87'
+# Events without source.container fall back to a sanitized source.name label
+# (with any leading `antithesis_` stripped). Known sources render their
+# curated fields as <path>=<value> pairs in config order.
+stdout '400\.5.*\[test_composer\].*task_status=started command=core/parallel_driver_fetch container_id=d700ef3d05a263 tasks_len=1'
+stdout '401\.5.*\[fault_injector\].*fault\.name=clog fault\.type=network fault\.details\.disruption_type=Stopped fault\.affected_nodes=client2,setup fault\.max_duration=0\.267'
+
+# `snouty --json runs logs` outputs raw NDJSON.
+mock-runs-server
+snouty --json runs logs run-1 -123 1.0
+stdout 'output_text.*starting'
+stdout 'output_text.*slow request'
+stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
+
+# `snouty --json runs logs` emits a record whose output_text contains
+# a JSON-escaped newline on a single output line.
+mock-runs-server
+snouty --json runs logs run-1 -123 1.0
+stdout -count=1 'line one\\nline two'
+
+# `snouty runs logs` requires hash and vtime positional arguments.
+mock-runs-server
+! snouty runs logs run-1
+stderr '.*INPUT_HASH.*'
+
+# `snouty runs events` prints a friendly empty-state message.
+mock-runs-server
+snouty runs events run-1 nomatch
+stdout 'No matching events found\.'
+
+# `snouty runs events` requires a query.
+mock-runs-server
+! snouty runs events run-1
+stderr '.*'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -202,10 +202,10 @@ mock-runs-server
 ! snouty runs logs run-1
 stderr '.*INPUT_HASH.*'
 
-# `snouty runs events` prints a friendly empty-state message.
+# `snouty runs events` prints the header row even when there are no matching events.
 mock-runs-server
 snouty runs events run-1 nomatch
-stdout 'No matching events found\.'
+stdout '^HASH\s+VTIME\s+SOURCE\s+OUTPUT'
 
 # `snouty runs events` requires a query.
 mock-runs-server

--- a/specs_engine/launch_config_push.txt
+++ b/specs_engine/launch_config_push.txt
@@ -6,7 +6,7 @@
 # Both get pinned references (name@sha256:digest) in the webhook params.
 
 # Local build images are tagged with registry prefix, pushed and pinned.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 build-image myapp:latest images/myapp
 build-image sidecar:v1 images/sidecar
 snouty launch -w basic_test -c push_config --duration 30
@@ -15,13 +15,13 @@ stderr '"antithesis.images":.*myapp@sha256:'
 stderr '"antithesis.images":.*sidecar@sha256:'
 
 # No compose images match the registry — only config image is pinned.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 snouty launch -w basic_test -c external_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
 # Mixed: local build image is tagged+pushed, external image is skipped.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 build-image myapp:latest images/myapp
 snouty launch -w basic_test -c mixed_config --duration 30
 stderr '"antithesis.images":.*myapp@sha256:'
@@ -29,13 +29,13 @@ stderr '"antithesis.images":.*myapp@sha256:'
 stderr '"antithesis.config_image":.*@sha256:'
 
 # Local image without build stanza is not pushed.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 snouty launch -w basic_test -c local_no_build_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'
 
 # A non-amd64 image scheduled for push is rejected before any push happens.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 build-image --platform linux/arm64 arm-launch:latest images/arm_launch
 ! snouty launch -w basic_test -c arm_push_config --duration 30
 stderr 'x86-64 \(amd64\).*'
@@ -44,7 +44,7 @@ stderr 'image '\''.*arm-launch:latest'\'' has architecture '\''arm64'\''.*'
 
 # A non-amd64 image that is NOT pushed (no registry prefix, no build) does
 # not trigger the architecture check.
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 build-image --platform linux/arm64 arm-external:latest images/arm_launch
 snouty launch -w basic_test -c arm_external_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
@@ -52,7 +52,7 @@ stderr '"antithesis.config_image":.*@sha256:'
 
 # Kubernetes config: builds and pushes the config image, never sets
 # antithesis.images (the platform pulls images from the manifests).
-mock-server 200 '{"status": "ok"}'
+mock-server 200 '{"runId":"run-123","statusCode":200}'
 snouty launch -w basic_k8s_test -c k8s_config --duration 30
 stderr '"antithesis.config_image":.*@sha256:'
 ! stderr '"antithesis.images"'

--- a/src/api.rs
+++ b/src/api.rs
@@ -618,6 +618,11 @@ fn normalize_base_url(base_url: impl Into<String>) -> String {
 fn default_request_headers(config: &Config) -> Result<reqwest::header::HeaderMap> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(reqwest::header::AUTHORIZATION, auth_header(&config.auth)?);
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        reqwest::header::HeaderValue::from_str(&crate::user_agent())
+            .wrap_err("failed to build User-Agent header")?,
+    );
     Ok(headers)
 }
 
@@ -1031,6 +1036,35 @@ mod tests {
         );
         let api = AntithesisApi::with_base_url(config, "http://example.com/api/v1/").unwrap();
         assert_eq!(api.base_url(), "http://example.com");
+    }
+
+    #[tokio::test]
+    async fn launch_test_sends_snouty_user_agent() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/basic_test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "runId": "run-123",
+                "statusCode": 200
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = AntithesisApi::with_base_url(test_config(), mock_server.uri()).unwrap();
+        let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
+        api.launch_test("basic_test", &params).await.unwrap();
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let user_agent = requests[0]
+            .headers
+            .get("user-agent")
+            .expect("request should carry a User-Agent")
+            .to_str()
+            .unwrap();
+        assert_eq!(user_agent, crate::user_agent());
+        assert!(user_agent.starts_with("snouty/"));
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -159,11 +159,16 @@ impl Auth {
 pub struct Config {
     pub auth: Auth,
     pub tenant: String,
+    pub verbose: bool,
 }
 
 impl Config {
     pub fn new(auth: Auth, tenant: String) -> Self {
-        Self { auth, tenant }
+        Self {
+            auth,
+            tenant,
+            verbose: false,
+        }
     }
 
     pub fn from_env() -> Result<Self> {
@@ -171,6 +176,7 @@ impl Config {
         Ok(Self {
             auth: Auth::from_env()?,
             tenant: required_env("ANTITHESIS_TENANT")?,
+            verbose: false,
         })
     }
 }
@@ -187,8 +193,9 @@ impl AntithesisApi {
         Self::with_base_url(config, base_url)
     }
 
-    pub fn from_env() -> Result<Self> {
-        let config = Config::from_env()?;
+    pub fn from_env(verbose: bool) -> Result<Self> {
+        let mut config = Config::from_env()?;
+        config.verbose = verbose;
         if let Ok(base_url) = env::var("ANTITHESIS_BASE_URL") {
             debug!("using ANTITHESIS_BASE_URL override: {}", base_url);
             Self::with_base_url(config, base_url)
@@ -220,9 +227,14 @@ impl AntithesisApi {
         let base_url = normalize_base_url(base_url);
         debug!("initializing API client for {}", base_url);
 
-        let http_client = build_http_client(&config)?;
+        let default_headers = default_request_headers(&config)?;
+        let http_client = build_http_client(default_headers.clone())?;
         let cached = build_cache(http_client.clone());
-        let client = generated::Client::new_with_client(&base_url, http_client, cached);
+        let state = ClientState {
+            cached,
+            default_headers: config.verbose.then_some(default_headers),
+        };
+        let client = generated::Client::new_with_client(&base_url, http_client, state);
 
         Ok(Self { client, base_url })
     }
@@ -401,32 +413,163 @@ impl AntithesisApi {
     }
 }
 
-impl ClientHooks<Option<ClientWithMiddleware>> for generated::Client {
+#[derive(Clone, Debug)]
+pub struct ClientState {
+    pub(crate) cached: Option<ClientWithMiddleware>,
+    /// Default headers reqwest will merge into the outgoing request at
+    /// `Client::execute` time (after our `exec` hook runs). `Some` enables
+    /// verbose request/response logging to stderr; we hold the headers here
+    /// so the log matches what's actually sent.
+    pub(crate) default_headers: Option<reqwest::header::HeaderMap>,
+}
+
+impl ClientHooks<ClientState> for generated::Client {
     async fn exec(
         &self,
         request: reqwest::Request,
         _info: &OperationInfo,
     ) -> reqwest::Result<reqwest::Response> {
-        let Some(cached) = self.inner() else {
-            return self.client().execute(request).await;
-        };
+        let state = self.inner();
+        let verbose_headers = state.default_headers.as_ref();
+        if let Some(default_headers) = verbose_headers {
+            let mut out = String::new();
+            format_request(&request, default_headers, &mut out);
+            eprint!("{out}");
+        }
 
-        // Bypass the cache for non-cloneable (streaming) bodies so the
-        // remaining path always has a fallback to retry against on cache I/O
-        // failures (which surface as `Error::Middleware` and can't be
-        // re-packaged as a `reqwest::Error`).
-        let Some(fallback) = request.try_clone() else {
-            return self.client().execute(request).await;
-        };
+        let result = send_request(self.client(), state.cached.as_ref(), request).await;
 
-        match cached.execute(request).await {
-            Ok(response) => Ok(response),
-            Err(reqwest_middleware::Error::Reqwest(err)) => Err(err),
-            Err(reqwest_middleware::Error::Middleware(err)) => {
-                log::warn!("API cache failure, bypassing cache: {err}");
-                self.client().execute(fallback).await
+        if verbose_headers.is_some()
+            && let Ok(response) = &result
+        {
+            let mut out = String::new();
+            format_response(response, &mut out);
+            eprint!("{out}");
+        }
+        result
+    }
+}
+
+async fn send_request(
+    client: &Client,
+    cached: Option<&ClientWithMiddleware>,
+    request: reqwest::Request,
+) -> reqwest::Result<reqwest::Response> {
+    let Some(cached) = cached else {
+        return client.execute(request).await;
+    };
+
+    // Bypass the cache for non-cloneable (streaming) bodies so the remaining
+    // path always has a fallback to retry against on cache I/O failures
+    // (which surface as `Error::Middleware` and can't be re-packaged as a
+    // `reqwest::Error`).
+    let Some(fallback) = request.try_clone() else {
+        return client.execute(request).await;
+    };
+
+    match cached.execute(request).await {
+        Ok(response) => Ok(response),
+        Err(reqwest_middleware::Error::Reqwest(err)) => Err(err),
+        Err(reqwest_middleware::Error::Middleware(err)) => {
+            log::warn!("API cache failure, bypassing cache: {err}");
+            client.execute(fallback).await
+        }
+    }
+}
+
+fn format_response(response: &reqwest::Response, out: &mut String) {
+    use std::fmt::Write;
+
+    let status = response.status();
+    match status.canonical_reason() {
+        Some(reason) => {
+            let _ = writeln!(out, "< {} {reason}", status.as_u16());
+        }
+        None => {
+            let _ = writeln!(out, "< {}", status.as_u16());
+        }
+    }
+    for (name, value) in response.headers() {
+        let value = value.to_str().unwrap_or("[non-ascii]");
+        if is_sensitive_header(name) {
+            let _ = writeln!(out, "< {name}: {}", redact_sensitive_value(name, value));
+        } else {
+            let _ = writeln!(out, "< {name}: {value}");
+        }
+    }
+}
+
+fn format_request(
+    request: &reqwest::Request,
+    default_headers: &reqwest::header::HeaderMap,
+    out: &mut String,
+) {
+    use std::fmt::Write;
+
+    let _ = writeln!(out, "> {} {}", request.method(), request.url());
+
+    // reqwest merges `default_headers` at `Client::execute` time, after this
+    // hook runs. Merge them in explicitly so the verbose log matches what's
+    // actually sent, with sensitive values redacted.
+    let mut emit = |name: &reqwest::header::HeaderName, value: &reqwest::header::HeaderValue| {
+        let value = value.to_str().unwrap_or("[non-ascii]");
+        if is_sensitive_header(name) {
+            let _ = writeln!(out, "> {name}: {}", redact_sensitive_value(name, value));
+        } else {
+            let _ = writeln!(out, "> {name}: {value}");
+        }
+    };
+    for (name, value) in request.headers() {
+        emit(name, value);
+    }
+    for (name, value) in default_headers {
+        if !request.headers().contains_key(name) {
+            emit(name, value);
+        }
+    }
+    let Some(body) = request.body() else {
+        return;
+    };
+    let Some(bytes) = body.as_bytes() else {
+        let _ = writeln!(out, "> <streaming body>");
+        return;
+    };
+    if bytes.is_empty() {
+        return;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(text) => {
+            out.push_str(">\n");
+            out.push_str(text);
+            if !text.ends_with('\n') {
+                out.push('\n');
             }
         }
+        Err(_) => {
+            let _ = writeln!(out, "> <{} bytes>", bytes.len());
+        }
+    }
+}
+
+fn is_sensitive_header(name: &reqwest::header::HeaderName) -> bool {
+    use reqwest::header::{AUTHORIZATION, COOKIE, PROXY_AUTHORIZATION, SET_COOKIE};
+    matches!(name, n if n == AUTHORIZATION || n == PROXY_AUTHORIZATION || n == COOKIE || n == SET_COOKIE)
+}
+
+/// Redact a sensitive header value. For `Authorization` /
+/// `Proxy-Authorization` the auth scheme is preserved so the log still shows
+/// what kind of credential was sent (`Bearer secret-token` becomes
+/// `bearer sec...`). Other sensitive headers (cookies) are reduced to their
+/// first three chars.
+fn redact_sensitive_value(name: &reqwest::header::HeaderName, value: &str) -> String {
+    use reqwest::header::{AUTHORIZATION, PROXY_AUTHORIZATION};
+    let take_prefix = |s: &str| s.chars().take(3).collect::<String>();
+    let is_auth = name == AUTHORIZATION || name == PROXY_AUTHORIZATION;
+    match value.split_once(' ') {
+        Some((scheme, rest)) if is_auth => {
+            format!("{} {}...", scheme.to_ascii_lowercase(), take_prefix(rest))
+        }
+        _ => format!("{}...", take_prefix(value)),
     }
 }
 
@@ -472,12 +615,15 @@ fn normalize_base_url(base_url: impl Into<String>) -> String {
         .to_string()
 }
 
-fn build_http_client(config: &Config) -> Result<Client> {
+fn default_request_headers(config: &Config) -> Result<reqwest::header::HeaderMap> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(reqwest::header::AUTHORIZATION, auth_header(&config.auth)?);
+    Ok(headers)
+}
 
+fn build_http_client(default_headers: reqwest::header::HeaderMap) -> Result<Client> {
     Client::builder()
-        .default_headers(headers)
+        .default_headers(default_headers)
         .timeout(Duration::from_secs(CLIENT_TIMEOUT_SECS))
         .build()
         .wrap_err("failed to build API client")
@@ -687,6 +833,144 @@ mod tests {
             cache_dir.path().join("api-cache"),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn format_request_redacts_authorization_and_dumps_text_body() {
+        use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+
+        let mut request = reqwest::Request::new(
+            reqwest::Method::POST,
+            "http://example.com/api/v1/launch".parse().unwrap(),
+        );
+        request.headers_mut().insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer secret-rest-of-token"),
+        );
+        request
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        *request.body_mut() = Some(r#"{"hello":"world"}"#.into());
+
+        let mut out = String::new();
+        format_request(&request, &HeaderMap::new(), &mut out);
+
+        assert!(out.contains("POST http://example.com/api/v1/launch"));
+        assert!(out.contains("authorization: bearer sec...\n"));
+        assert!(!out.contains("secret-rest"));
+        assert!(out.contains("content-type: application/json"));
+        assert!(out.contains(r#"{"hello":"world"}"#));
+    }
+
+    #[test]
+    fn format_request_merges_default_headers_with_redaction() {
+        use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+
+        let request = reqwest::Request::new(
+            reqwest::Method::GET,
+            "http://example.com/api/v1/runs".parse().unwrap(),
+        );
+        let mut defaults = HeaderMap::new();
+        defaults.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Basic dXNlcjpwYXNz"),
+        );
+
+        let mut out = String::new();
+        format_request(&request, &defaults, &mut out);
+
+        assert!(out.contains("authorization: basic dXN...\n"));
+        assert!(!out.contains("dXNlcjpwYXNz"));
+    }
+
+    #[test]
+    fn redact_sensitive_value_handles_bearer_basic_and_cookies() {
+        use reqwest::header::{AUTHORIZATION, COOKIE, HeaderName};
+        let set_cookie = HeaderName::from_static("set-cookie");
+
+        assert_eq!(
+            redact_sensitive_value(&AUTHORIZATION, "Bearer secret-token-12345"),
+            "bearer sec..."
+        );
+        assert_eq!(
+            redact_sensitive_value(&AUTHORIZATION, "Basic dXNlcjpwYXNz"),
+            "basic dXN..."
+        );
+        assert_eq!(
+            redact_sensitive_value(&COOKIE, "sessionid=abcdef"),
+            "ses..."
+        );
+        // Set-Cookie values often contain spaces (e.g. attributes), so the
+        // scheme-detection heuristic must not apply.
+        assert_eq!(
+            redact_sensitive_value(&set_cookie, "session=very-secret; Path=/"),
+            "ses..."
+        );
+    }
+
+    #[test]
+    fn format_request_does_not_duplicate_request_headers() {
+        use reqwest::header::{HeaderMap, HeaderValue};
+
+        let mut request = reqwest::Request::new(
+            reqwest::Method::GET,
+            "http://example.com/api/v1/runs".parse().unwrap(),
+        );
+        request
+            .headers_mut()
+            .insert("api-version", HeaderValue::from_static("2.0"));
+        let mut defaults = HeaderMap::new();
+        defaults.insert("api-version", HeaderValue::from_static("1.0"));
+
+        let mut out = String::new();
+        format_request(&request, &defaults, &mut out);
+
+        assert_eq!(out.matches("api-version").count(), 1);
+        assert!(out.contains("api-version: 2.0"));
+        assert!(!out.contains("api-version: 1.0"));
+    }
+
+    #[tokio::test]
+    async fn format_response_dumps_status_and_redacts_set_cookie() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(
+                ResponseTemplate::new(418)
+                    .insert_header("content-type", "text/plain")
+                    .insert_header("set-cookie", "session=very-secret-token; Path=/"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = reqwest::Client::new()
+            .get(format!("{}/health", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let mut out = String::new();
+        format_response(&response, &mut out);
+
+        assert!(out.contains("< 418 I'm a teapot"));
+        assert!(out.contains("< content-type: text/plain"));
+        assert!(out.contains("< set-cookie: ses..."));
+        assert!(!out.contains("very-secret-token"));
+    }
+
+    #[test]
+    fn format_request_summarizes_binary_body() {
+        let mut request = reqwest::Request::new(
+            reqwest::Method::POST,
+            "http://example.com/upload".parse().unwrap(),
+        );
+        *request.body_mut() = Some(vec![0xff_u8, 0xfe, 0xfd].into());
+
+        let mut out = String::new();
+        format_request(&request, &reqwest::header::HeaderMap::new(), &mut out);
+
+        assert!(out.contains("<3 bytes>"));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,9 +1,102 @@
+use std::collections::{HashMap, VecDeque};
 use std::env;
+use std::time::Duration;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use color_eyre::eyre::{Context, Report, Result, eyre};
+use futures_util::stream;
 use log::debug;
-use reqwest::{Client, RequestBuilder};
+use progenitor_client::{ClientHooks, ClientInfo, Error as ClientError, OperationInfo};
+use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware;
 
-use color_eyre::eyre::{Result, eyre};
+use crate::api_cache;
+use crate::params::Params;
+
+#[allow(dead_code, unused_imports, private_interfaces)]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/antithesis_api.rs"));
+}
+
+pub use generated::types::{
+    BuildLogLine, Event, EventProperty, LaunchResponse, Moment, NonEventProperty, Property,
+    PropertyStatus, RunDetail, RunStatus, RunSummary,
+};
+pub use progenitor_client::ByteStream;
+
+impl Property {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::EventProperty(p) => &p.name,
+            Self::NonEventProperty(p) => &p.name,
+        }
+    }
+
+    pub fn status(&self) -> PropertyStatus {
+        match self {
+            Self::EventProperty(p) => p.status,
+            Self::NonEventProperty(p) => p.status,
+        }
+    }
+
+    /// Sampled example events for an event-based property. Returns an empty
+    /// slice for non-event properties, whose examples are arbitrary values
+    /// without a `moment`.
+    pub fn event_examples(&self) -> &[Event] {
+        match self {
+            Self::EventProperty(p) => &p.examples,
+            Self::NonEventProperty(_) => &[],
+        }
+    }
+
+    /// Sampled counterexample events for an event-based property. Returns an
+    /// empty slice for non-event properties.
+    pub fn event_counterexamples(&self) -> &[Event] {
+        match self {
+            Self::EventProperty(p) => &p.counterexamples,
+            Self::NonEventProperty(_) => &[],
+        }
+    }
+}
+
+/// `Property` is an untagged `oneOf` whose variants are structurally similar:
+/// a `NonEventProperty` whose examples happen to fit `Event`'s shape (or that
+/// has no examples at all) silently deserializes as `EventProperty`. Coerce
+/// each property into the variant indicated by its `is_event` flag.
+fn normalize_property(property: Property) -> Result<Property> {
+    match property {
+        Property::EventProperty(p) if !p.is_event => {
+            let counterexamples = p
+                .counterexamples
+                .into_iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()
+                .wrap_err("re-serializing property counterexamples")?;
+            let examples = p
+                .examples
+                .into_iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()
+                .wrap_err("re-serializing property examples")?;
+            Ok(Property::NonEventProperty(NonEventProperty {
+                counterexample_count: p.counterexample_count,
+                counterexamples,
+                description: p.description,
+                example_count: p.example_count,
+                examples,
+                group: p.group,
+                is_event: p.is_event,
+                is_group: p.is_group,
+                name: p.name,
+                status: p.status,
+            }))
+        }
+        other => Ok(other),
+    }
+}
+
+const CLIENT_TIMEOUT_SECS: u64 = 30;
 
 fn required_env(name: &'static str) -> Result<String> {
     env::var(name).map_err(|e| match e {
@@ -60,13 +153,6 @@ impl Auth {
             required_env("ANTITHESIS_PASSWORD")?,
         ))
     }
-
-    fn authenticate(&self, request: RequestBuilder) -> RequestBuilder {
-        match self {
-            Self::Basic { username, password } => request.basic_auth(username, Some(password)),
-            Self::Bearer { api_key } => request.bearer_auth(api_key),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -90,21 +176,19 @@ impl Config {
 }
 
 pub struct AntithesisApi {
-    client: Client,
+    client: generated::Client,
     base_url: String,
-    auth: Auth,
 }
 
 impl AntithesisApi {
     pub fn new(config: Config) -> Result<Self> {
-        let base_url = format!("https://{}.antithesis.com/api/v1", config.tenant);
+        let base_url = format!("https://{}.antithesis.com", config.tenant);
         debug!("using default base URL: {}", base_url);
         Self::with_base_url(config, base_url)
     }
 
     pub fn from_env() -> Result<Self> {
         let config = Config::from_env()?;
-        // Allow base URL override for testing
         if let Ok(base_url) = env::var("ANTITHESIS_BASE_URL") {
             debug!("using ANTITHESIS_BASE_URL override: {}", base_url);
             Self::with_base_url(config, base_url)
@@ -114,60 +198,495 @@ impl AntithesisApi {
     }
 
     pub fn with_base_url(config: Config, base_url: impl Into<String>) -> Result<Self> {
-        let base_url = base_url.into().trim_end_matches('/').to_string();
-        debug!("initializing API client for {}", base_url);
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()?;
+        Self::build(config, base_url, api_cache::build_cached_client)
+    }
 
-        Ok(Self {
-            client,
-            base_url,
-            auth: config.auth,
+    #[cfg(test)]
+    fn with_base_url_and_cache_dir(
+        config: Config,
+        base_url: impl Into<String>,
+        cache_dir: std::path::PathBuf,
+    ) -> Result<Self> {
+        Self::build(config, base_url, move |client| {
+            Some(api_cache::build_cached_client_at(client, cache_dir))
         })
+    }
+
+    fn build(
+        config: Config,
+        base_url: impl Into<String>,
+        build_cache: impl FnOnce(Client) -> Option<ClientWithMiddleware>,
+    ) -> Result<Self> {
+        let base_url = normalize_base_url(base_url);
+        debug!("initializing API client for {}", base_url);
+
+        let http_client = build_http_client(&config)?;
+        let cached = build_cache(http_client.clone());
+        let client = generated::Client::new_with_client(&base_url, http_client, cached);
+
+        Ok(Self { client, base_url })
     }
 
     pub fn base_url(&self) -> &str {
         &self.base_url
     }
 
-    pub fn get(&self, path: &str) -> RequestBuilder {
-        let url = format!("{}{}", self.base_url, path);
-        debug!("GET {}", url);
-        self.auth.authenticate(self.client.get(url))
+    pub async fn launch_test(&self, launcher: &str, params: &Params) -> Result<LaunchResponse> {
+        let body = launch_request(params)?;
+        match self
+            .client
+            .launch_test()
+            .launcher_name(launcher)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
     }
 
-    pub fn post(&self, path: &str) -> RequestBuilder {
-        let url = format!("{}{}", self.base_url, path);
-        debug!("POST {}", url);
-        self.auth.authenticate(self.client.post(url))
+    pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
+        let body = launch_mvd_request(params)?;
+        match self.client.launch_mvd().body(body).send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    pub async fn get_run(&self, run_id: &str) -> Result<RunDetail> {
+        match self.client.get_run().run_id(run_id).send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    pub async fn get_run_build_logs(&self, run_id: &str) -> Result<ByteStream> {
+        match self.client.get_run_build_logs().run_id(run_id).send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    pub async fn get_run_logs(
+        &self,
+        run_id: &str,
+        input_hash: &str,
+        vtime: &str,
+        begin_input_hash: Option<&str>,
+        begin_vtime: Option<&str>,
+    ) -> Result<ByteStream> {
+        let mut request = self
+            .client
+            .get_run_logs()
+            .run_id(run_id)
+            .input_hash(input_hash)
+            .vtime(vtime);
+        if let Some(v) = begin_input_hash {
+            request = request.begin_input_hash(v);
+        }
+        if let Some(v) = begin_vtime {
+            request = request.begin_vtime(v);
+        }
+
+        match request.send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    pub fn stream_run_properties(
+        &self,
+        run_id: &str,
+        status: Option<PropertyStatus>,
+    ) -> impl futures_util::Stream<Item = Result<Property>> + '_ {
+        let run_id = run_id.to_string();
+        paginate(move |after| {
+            let run_id = run_id.clone();
+            async move {
+                let page = self
+                    .fetch_run_properties_page(&run_id, after.as_deref(), status)
+                    .await?;
+                let generated::types::PropertyListResponse { data, next_cursor } = page;
+                let normalized = data
+                    .into_iter()
+                    .map(normalize_property)
+                    .collect::<Result<Vec<_>>>()?;
+                Ok((normalized, next_cursor))
+            }
+        })
+    }
+
+    pub async fn search_run_events(&self, run_id: &str, query: &str) -> Result<ByteStream> {
+        match self
+            .client
+            .search_run_events()
+            .run_id(run_id)
+            .q(query)
+            .send()
+            .await
+        {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    pub fn stream_runs_filtered(
+        &self,
+        opts: &RunsFilterOptions,
+    ) -> impl futures_util::Stream<Item = Result<RunSummary>> + '_ {
+        let opts = opts.clone();
+        paginate(move |after| {
+            let opts = opts.clone();
+            async move {
+                let page = self
+                    .fetch_runs_page_filtered(after.as_deref(), &opts)
+                    .await?;
+                let generated::types::RunListResponse { data, next_cursor } = page;
+                Ok((data, next_cursor))
+            }
+        })
+    }
+
+    async fn fetch_runs_page_filtered(
+        &self,
+        after: Option<&str>,
+        opts: &RunsFilterOptions,
+    ) -> Result<generated::types::RunListResponse> {
+        let mut request = self.client.list_runs().limit(100_u64);
+        if let Some(cursor) = after {
+            request = request.after(cursor);
+        }
+        if let Some(ref status) = opts.status {
+            request = request.status(*status);
+        }
+        if let Some(ref launcher) = opts.launcher {
+            request = request.launcher(launcher.clone());
+        }
+        if let Some(ref ts) = opts.created_after {
+            request = request.created_after(*ts);
+        }
+        if let Some(ref ts) = opts.created_before {
+            request = request.created_before(*ts);
+        }
+
+        match request.send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    async fn fetch_run_properties_page(
+        &self,
+        run_id: &str,
+        after: Option<&str>,
+        status: Option<PropertyStatus>,
+    ) -> Result<generated::types::PropertyListResponse> {
+        let mut request = self
+            .client
+            .list_run_properties()
+            .run_id(run_id)
+            .limit(100_u64);
+        if let Some(cursor) = after {
+            request = request.after(cursor);
+        }
+        if let Some(status) = status {
+            request = request.status(status);
+        }
+
+        match request.send().await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+}
+
+impl ClientHooks<Option<ClientWithMiddleware>> for generated::Client {
+    async fn exec(
+        &self,
+        request: reqwest::Request,
+        _info: &OperationInfo,
+    ) -> reqwest::Result<reqwest::Response> {
+        let Some(cached) = self.inner() else {
+            return self.client().execute(request).await;
+        };
+
+        // Bypass the cache for non-cloneable (streaming) bodies so the
+        // remaining path always has a fallback to retry against on cache I/O
+        // failures (which surface as `Error::Middleware` and can't be
+        // re-packaged as a `reqwest::Error`).
+        let Some(fallback) = request.try_clone() else {
+            return self.client().execute(request).await;
+        };
+
+        match cached.execute(request).await {
+            Ok(response) => Ok(response),
+            Err(reqwest_middleware::Error::Reqwest(err)) => Err(err),
+            Err(reqwest_middleware::Error::Middleware(err)) => {
+                log::warn!("API cache failure, bypassing cache: {err}");
+                self.client().execute(fallback).await
+            }
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct RunsFilterOptions {
+    pub status: Option<generated::types::RunStatus>,
+    pub launcher: Option<String>,
+    pub created_after: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_before: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn paginate<'a, T, F, Fut>(fetch: F) -> impl futures_util::Stream<Item = Result<T>> + 'a
+where
+    F: FnMut(Option<String>) -> Fut + 'a,
+    Fut: std::future::Future<Output = Result<(Vec<T>, Option<String>)>> + 'a,
+    T: 'a,
+{
+    stream::try_unfold(
+        (None::<String>, VecDeque::<T>::new(), false, fetch),
+        |(mut after, mut buffer, mut finished, mut fetch)| async move {
+            loop {
+                if let Some(item) = buffer.pop_front() {
+                    return Ok(Some((item, (after, buffer, finished, fetch))));
+                }
+                if finished {
+                    return Ok(None);
+                }
+                let (items, next) = fetch(after.take()).await?;
+                buffer.extend(items);
+                finished = next.is_none();
+                after = next;
+            }
+        },
+    )
+}
+
+fn normalize_base_url(base_url: impl Into<String>) -> String {
+    let base_url = base_url.into();
+    let trimmed = base_url.trim_end_matches('/');
+    trimmed
+        .strip_suffix("/api/v1")
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+fn build_http_client(config: &Config) -> Result<Client> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::AUTHORIZATION, auth_header(&config.auth)?);
+
+    Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(CLIENT_TIMEOUT_SECS))
+        .build()
+        .wrap_err("failed to build API client")
+}
+
+fn auth_header(auth: &Auth) -> Result<reqwest::header::HeaderValue> {
+    let value = match auth {
+        Auth::Basic { username, password } => {
+            let credentials = format!("{username}:{password}");
+            let encoded = BASE64_STANDARD.encode(credentials);
+            format!("Basic {encoded}")
+        }
+        Auth::Bearer { api_key } => format!("Bearer {api_key}"),
+    };
+    reqwest::header::HeaderValue::from_str(&value).wrap_err("failed to build Authorization header")
+}
+
+fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
+    let mut builder = generated::types::builder::Params::default();
+    let mut extra = HashMap::new();
+
+    for (key, value) in params.as_map() {
+        let value = value
+            .as_str()
+            .ok_or_else(|| eyre!("launch params must be strings: {key}"))?;
+
+        builder = match key.as_str() {
+            "antithesis.config_image" => builder.antithesis_config_image(Some(value.to_string())),
+            "antithesis.description" => builder.antithesis_description(Some(value.to_string())),
+            "antithesis.duration" => builder.antithesis_duration(Some(value.to_string())),
+            "antithesis.images" => builder.antithesis_images(Some(value.to_string())),
+            "antithesis.is_ephemeral" => builder.antithesis_is_ephemeral(Some(
+                generated::types::ParamsAntithesisIsEphemeral::try_from(value)
+                    .wrap_err("invalid antithesis.is_ephemeral value")?,
+            )),
+            "antithesis.report.recipients" => {
+                builder.antithesis_report_recipients(Some(value.to_string()))
+            }
+            "antithesis.source" => builder.antithesis_source(Some(value.to_string())),
+            _ => {
+                extra.insert(key.clone(), value.to_string());
+                builder
+            }
+        };
+    }
+
+    let typed_params = generated::types::Params::try_from(builder.extra(extra))
+        .wrap_err("failed to build params")?;
+    generated::types::LaunchRequest::try_from(
+        generated::types::builder::LaunchRequest::default().params(typed_params),
+    )
+    .wrap_err("failed to build launch request")
+}
+
+fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequest> {
+    let mut builder = generated::types::builder::MvdParams::default();
+
+    for (key, value) in params.as_map() {
+        let value = value
+            .as_str()
+            .ok_or_else(|| eyre!("debugging params must be strings: {key}"))?;
+
+        builder = match key.as_str() {
+            "antithesis.debugging.input_hash" => {
+                builder.antithesis_debugging_input_hash(value.to_string())
+            }
+            "antithesis.debugging.session_id" => {
+                builder.antithesis_debugging_session_id(value.to_string())
+            }
+            "antithesis.debugging.vtime" => builder.antithesis_debugging_vtime(value.to_string()),
+            "antithesis.event_description" => {
+                builder.antithesis_event_description(Some(value.to_string()))
+            }
+            "antithesis.report.recipients" => {
+                builder.antithesis_report_recipients(Some(value.to_string()))
+            }
+            _ => return Err(eyre!("unknown debugging param: {key}")),
+        };
+    }
+
+    let typed_params = generated::types::MvdParams::try_from(builder)
+        .wrap_err("failed to build debugging params")?;
+    generated::types::LaunchMvdRequest::try_from(
+        generated::types::builder::LaunchMvdRequest::default().params(typed_params),
+    )
+    .wrap_err("failed to build debugging request")
+}
+
+fn format_api_error(status: u16, body: &str) -> Report {
+    let reason = reqwest::StatusCode::from_u16(status)
+        .ok()
+        .and_then(|s| s.canonical_reason())
+        .unwrap_or("");
+    let body = body.trim();
+
+    let mut msg = format!("API error: {status}");
+    if !reason.is_empty() {
+        msg.push(' ');
+        msg.push_str(reason);
+    }
+    if !body.is_empty() {
+        msg.push_str(" — ");
+        msg.push_str(body);
+    }
+    if matches!(status, 401 | 403) {
+        msg.push_str(
+            "\n\nCheck that ANTITHESIS_API_KEY (or ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD) \
+             is set correctly and has access to this tenant.",
+        );
+    }
+    eyre!("{msg}")
+}
+
+fn format_payload_snippet(body: &str, line: usize, column: usize) -> String {
+    const WINDOW: usize = 60;
+
+    let offset = char_pos_to_byte_offset(body, line, column);
+    let start_target = offset.saturating_sub(WINDOW);
+    let end_target = offset.saturating_add(WINDOW).min(body.len());
+    let start = (0..=start_target)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    let end = (end_target..=body.len())
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(body.len());
+
+    let prefix = if start > 0 { "..." } else { "" };
+    let suffix = if end < body.len() { "..." } else { "" };
+
+    let snippet: String = body[start..end]
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    let caret_col = prefix.chars().count() + body[start..offset].chars().count();
+    let caret = format!("{:width$}^", "", width = caret_col);
+
+    format!("  {prefix}{snippet}{suffix}\n  {caret}")
+}
+
+fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
+    let mut cur_line = 1;
+    let mut cur_col = 1;
+    for (i, c) in body.char_indices() {
+        if cur_line == line && cur_col == column {
+            return i;
+        }
+        if c == '\n' {
+            cur_line += 1;
+            cur_col = 1;
+        } else {
+            cur_col += 1;
+        }
+    }
+    body.len()
+}
+
+async fn format_api_client_error(err: ClientError<generated::types::ErrorResponse>) -> Report {
+    match err {
+        ClientError::ErrorResponse(response) => {
+            let status = response.status().as_u16();
+            let body = response.into_inner();
+            format_api_error(status, &body.message)
+        }
+        ClientError::UnexpectedResponse(response) => {
+            let status = response.status().as_u16();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
+            format_api_error(status, &body)
+        }
+        ClientError::InvalidRequest(message) => eyre!("invalid API request: {message}"),
+        ClientError::CommunicationError(err) => eyre!(err).wrap_err("failed to contact API"),
+        ClientError::InvalidUpgrade(err) => eyre!(err).wrap_err("invalid API upgrade response"),
+        ClientError::ResponseBodyError(err) => {
+            eyre!(err).wrap_err("failed to read API response body")
+        }
+        ClientError::InvalidResponsePayload(body, err) => {
+            let body = String::from_utf8_lossy(&body);
+            let snippet = format_payload_snippet(&body, err.line(), err.column());
+            eyre!("invalid API response payload: {err}\n{snippet}")
+        }
+        ClientError::Custom(message) => eyre!(message),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest::header::AUTHORIZATION;
+    use futures_util::TryStreamExt;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[test]
-    fn api_uses_basic_auth() {
-        let config = Config::new(
+    fn test_config() -> Config {
+        Config::new(
             Auth::basic("user".to_string(), "pass".to_string()),
             "tenant".to_string(),
-        );
-        let api = AntithesisApi::with_base_url(config, "http://example.com").unwrap();
-        let request = api.get("/test").build().unwrap();
-
-        assert_eq!(request.headers()[AUTHORIZATION], "Basic dXNlcjpwYXNz");
+        )
     }
 
-    #[test]
-    fn api_uses_bearer_auth() {
-        let config = Config::new(Auth::bearer("api-key".to_string()), "tenant".to_string());
-        let api = AntithesisApi::with_base_url(config, "http://example.com").unwrap();
-        let request = api.post("/test").build().unwrap();
-
-        assert_eq!(request.headers()[AUTHORIZATION], "Bearer api-key");
+    fn test_api_with_cache(mock_server: &MockServer, cache_dir: &TempDir) -> AntithesisApi {
+        AntithesisApi::with_base_url_and_cache_dir(
+            test_config(),
+            mock_server.uri(),
+            cache_dir.path().join("api-cache"),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -178,6 +697,319 @@ mod tests {
         );
         let api = AntithesisApi::with_base_url(config, "http://example.com/").unwrap();
         assert_eq!(api.base_url(), "http://example.com");
+    }
+
+    #[test]
+    fn with_base_url_strips_legacy_api_suffix() {
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, "http://example.com/api/v1/").unwrap();
+        assert_eq!(api.base_url(), "http://example.com");
+    }
+
+    #[tokio::test]
+    async fn launch_test_uses_basic_auth() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/basic_test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "runId": "run-123",
+                "statusCode": 200
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+        let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
+
+        let response = api.launch_test("basic_test", &params).await.unwrap();
+        let requests = mock_server.received_requests().await.unwrap();
+
+        assert_eq!(response.run_id, "run-123");
+        assert_eq!(response.status_code, 200);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/api/v1/launch/basic_test");
+        assert_eq!(requests[0].method, reqwest::Method::POST);
+        assert_eq!(
+            requests[0]
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Basic dXNlcjpwYXNz"
+        );
+        assert_eq!(
+            requests[0].body_json::<serde_json::Value>().unwrap(),
+            serde_json::json!({
+                "params": {
+                    "antithesis.duration": "30"
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_runs_follows_next_cursor() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs"))
+            .and(query_param("limit", "100"))
+            .and(query_param_is_missing("after"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "run_id": "run-1",
+                        "status": "completed",
+                        "created_at": "2025-03-20T02:00:00Z",
+                        "launcher": "nightly"
+                    }
+                ],
+                "next_cursor": "cursor-1"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs"))
+            .and(query_param("limit", "100"))
+            .and(query_param("after", "cursor-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "run_id": "run-2",
+                        "status": "in_progress",
+                        "created_at": "2025-03-19T02:00:00Z",
+                        "launcher": "debug"
+                    }
+                ],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+
+        let runs = api
+            .stream_runs_filtered(&RunsFilterOptions::default())
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let run_ids = runs.into_iter().map(|run| run.run_id).collect::<Vec<_>>();
+        assert_eq!(run_ids, vec!["run-1", "run-2"]);
+    }
+
+    #[tokio::test]
+    async fn stream_runs_returns_empty_when_no_runs_exist() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs"))
+            .and(query_param("limit", "100"))
+            .and(query_param_is_missing("after"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+
+        let runs = api
+            .stream_runs_filtered(&RunsFilterOptions::default())
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cache_serves_repeated_get_with_cache_control() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Cache-Control", "max-age=60")
+                    .set_body_json(serde_json::json!({
+                        "run_id": "run-1",
+                        "status": "completed",
+                        "created_at": "2025-03-20T02:00:00Z",
+                        "launcher": "nightly"
+                    })),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let cache_dir = TempDir::new().unwrap();
+        let api = test_api_with_cache(&mock_server, &cache_dir);
+
+        let first = api.get_run("run-1").await.unwrap();
+        let second = api.get_run("run-1").await.unwrap();
+
+        assert_eq!(first.run_id, "run-1");
+        assert_eq!(second.run_id, "run-1");
+    }
+
+    #[tokio::test]
+    async fn stream_run_properties_follows_next_cursor() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/properties"))
+            .and(query_param("limit", "100"))
+            .and(query_param_is_missing("status"))
+            .and(query_param_is_missing("after"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "name": "Counter value stays below limit",
+                        "status": "Failing",
+                        "is_event": true,
+                        "is_existential": false,
+                        "is_universal": true
+                    }
+                ],
+                "next_cursor": "props-cursor-1"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/properties"))
+            .and(query_param("limit", "100"))
+            .and(query_param_is_missing("status"))
+            .and(query_param("after", "props-cursor-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "name": "Setup completes",
+                        "status": "Passing",
+                        "is_event": false,
+                        "is_existential": true,
+                        "is_universal": false
+                    }
+                ],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+
+        let properties = api
+            .stream_run_properties("run-1", None)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let names = properties
+            .iter()
+            .map(|property| property.name().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "Counter value stays below limit".to_string(),
+                "Setup completes".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_run_properties_forwards_status_filter() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/properties"))
+            .and(query_param("limit", "100"))
+            .and(query_param("status", "Failing"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+
+        let properties = api
+            .stream_run_properties("run-1", Some(PropertyStatus::Failing))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(properties.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_run_events_passes_query_through() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/events"))
+            .and(query_param("q", "slow request"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"output_text":"{\"level\":\"warn\",\"msg\":\"slow request\"}","moment":{"input_hash":"-456","vtime":"2.0"}}"#,
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = Config::new(
+            Auth::basic("user".to_string(), "pass".to_string()),
+            "tenant".to_string(),
+        );
+        let api = AntithesisApi::with_base_url(config, mock_server.uri()).unwrap();
+
+        let mut stream = api
+            .search_run_events("run-1", "slow request")
+            .await
+            .unwrap()
+            .into_inner();
+        let mut body = Vec::new();
+        while let Some(chunk) = futures_util::StreamExt::next(&mut stream).await {
+            body.extend_from_slice(&chunk.unwrap());
+        }
+        let body = String::from_utf8(body).unwrap();
+
+        assert!(body.contains("slow request"));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -804,8 +804,12 @@ async fn format_api_client_error(err: ClientError<generated::types::ErrorRespons
         }
         ClientError::InvalidResponsePayload(body, err) => {
             let body = String::from_utf8_lossy(&body);
-            let snippet = format_payload_snippet(&body, err.line(), err.column());
-            eyre!("invalid API response payload: {err}\n{snippet}")
+            if body.trim().is_empty() {
+                eyre!("invalid API response payload: response body was empty")
+            } else {
+                let snippet = format_payload_snippet(&body, err.line(), err.column());
+                eyre!("invalid API response payload: {err}\n{snippet}")
+            }
         }
         ClientError::Custom(message) => eyre!(message),
     }
@@ -928,6 +932,42 @@ mod tests {
         assert_eq!(out.matches("api-version").count(), 1);
         assert!(out.contains("api-version: 2.0"));
         assert!(!out.contains("api-version: 1.0"));
+    }
+
+    #[tokio::test]
+    async fn format_api_client_error_describes_empty_invalid_payload() {
+        let parse_err = serde_json::from_slice::<serde_json::Value>(b"").unwrap_err();
+        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+            Default::default(),
+            parse_err,
+        );
+
+        let report = format_api_client_error(err).await;
+        let message = format!("{report}");
+
+        assert_eq!(
+            message,
+            "invalid API response payload: response body was empty"
+        );
+        assert!(!message.contains("EOF while parsing"));
+        assert!(!message.contains('^'));
+    }
+
+    #[tokio::test]
+    async fn format_api_client_error_keeps_snippet_for_non_empty_invalid_payload() {
+        let body: &[u8] = b"not json";
+        let parse_err = serde_json::from_slice::<serde_json::Value>(body).unwrap_err();
+        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+            body.to_vec().into(),
+            parse_err,
+        );
+
+        let report = format_api_client_error(err).await;
+        let message = format!("{report}");
+
+        assert!(message.starts_with("invalid API response payload: "));
+        assert!(message.contains("not json"));
+        assert!(message.contains('^'));
     }
 
     #[tokio::test]

--- a/src/api_cache.rs
+++ b/src/api_cache.rs
@@ -1,0 +1,52 @@
+use std::env;
+use std::path::PathBuf;
+
+use http_cache_reqwest::{
+    CACacheManager, Cache, CacheMode, CacheOptions, HttpCache, HttpCacheOptions,
+};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+
+pub(crate) fn build_cached_client(client: reqwest::Client) -> Option<ClientWithMiddleware> {
+    let root = cache_dir_from_runtime_dir(env::var_os("XDG_RUNTIME_DIR"))?;
+    Some(build_cached_client_at(client, root))
+}
+
+pub(crate) fn build_cached_client_at(
+    client: reqwest::Client,
+    root: PathBuf,
+) -> ClientWithMiddleware {
+    let cache = Cache(HttpCache {
+        mode: CacheMode::Default,
+        manager: CACacheManager::new(root, false),
+        options: HttpCacheOptions {
+            cache_options: Some(CacheOptions {
+                shared: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    });
+    ClientBuilder::new(client).with(cache).build()
+}
+
+fn cache_dir_from_runtime_dir(runtime_dir: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    runtime_dir.map(|dir| PathBuf::from(dir).join("snouty").join("api-cache-v1"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_uses_xdg_runtime_dir() {
+        assert_eq!(
+            cache_dir_from_runtime_dir(Some("/run/user/1000".into())).unwrap(),
+            PathBuf::from("/run/user/1000/snouty/api-cache-v1")
+        );
+    }
+
+    #[test]
+    fn cache_dir_is_absent_without_xdg_runtime_dir() {
+        assert_eq!(cache_dir_from_runtime_dir(None), None);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Log API requests to stderr (authentication tokens redacted)
+    #[arg(long, global = true)]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,12 +359,12 @@ pub enum RunsCommands {
         /// The virtual time value identifying the moment
         vtime: String,
 
-        /// Start streaming from this virtual time (must be paired with --begin-input-hash)
-        #[arg(long, requires = "begin_input_hash")]
+        /// Start streaming from this virtual time (defaults to the root)
+        #[arg(long)]
         begin_vtime: Option<String>,
 
-        /// Start streaming from this input hash
-        #[arg(long, allow_hyphen_values = true)]
+        /// Start streaming from this input hash (optimization; must be paired with --begin-vtime)
+        #[arg(long, allow_hyphen_values = true, requires = "begin_vtime")]
         begin_input_hash: Option<String>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,10 @@ use clap::{Args, Parser, Subcommand};
 #[command(about = "CLI for the Antithesis API", long_about = None)]
 #[command(version)]
 pub struct Cli {
+    /// Output JSON where supported (NDJSON for list/stream commands, pretty JSON otherwise)
+    #[arg(long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -48,6 +52,31 @@ Environment variables:
     #[command(hide = true)]
     Run(LaunchArgs),
 
+    /// Interact with test runs
+    #[command(
+        long_about = r#"Interact with test runs
+
+List, inspect, and view logs for Antithesis test runs.
+
+When no subcommand is given, lists all runs (same as `snouty runs list`).
+
+Examples:
+  snouty runs
+  snouty runs list --status completed --launcher nightly
+  snouty runs show <run_id>
+  snouty runs properties <run_id>
+  snouty runs properties --failing <run_id>
+  snouty runs properties --passing <run_id>
+  snouty runs build-logs <run_id>
+  snouty runs logs <run_id> <hash> <vtime>
+  snouty runs events <run_id> <query>"#,
+        subcommand_required = false
+    )]
+    Runs {
+        #[command(subcommand)]
+        command: Option<RunsCommands>,
+    },
+
     /// Access raw API endpoints
     #[command(subcommand)]
     Api(ApiCommands),
@@ -57,23 +86,16 @@ Environment variables:
 
 Using CLI arguments:
   snouty debug \
-    --antithesis.debugging.session_id f89d5c11f5e3bf5e4bb3641809800cee-44-22 \
-    --antithesis.debugging.input_hash 6057726200491963783 \
-    --antithesis.debugging.vtime 329.8037810830865 \
-    --antithesis.report.recipients "team@example.com"
+    --session-id f89d5c11f5e3bf5e4bb3641809800cee-44-22 \
+    --input-hash 6057726200491963783 \
+    --vtime 329.8037810830865 \
+    --description "debug this moment" \
+    --recipients "team@example.com"
 
 Using Moment.from (copy from triage report):
   echo 'Moment.from({ session_id: "...", input_hash: "...", vtime: ... })' | \
-    snouty debug --stdin --antithesis.report.recipients "team@example.com""#)]
-    Debug {
-        /// Read parameters from stdin (JSON or Moment.from format)
-        #[arg(long)]
-        stdin: bool,
-
-        /// Parameters as `--key value` pairs
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    snouty debug --stdin --recipients "team@example.com""#)]
+    Debug(DebugArgs),
 
     /// Output shell completions
     Completions {
@@ -148,10 +170,6 @@ Examples:
   snouty docs search "config image"
   snouty docs --offline search sdk setup"#)]
     Search {
-        /// Print search results as JSON
-        #[arg(short = 'j', long)]
-        json: bool,
-
         /// Print only matching page paths, one per line
         #[arg(short = 'l', long)]
         list: bool,
@@ -269,6 +287,131 @@ pub struct LaunchArgs {
     /// Extra parameters as key=value pairs (repeatable)
     #[arg(long = "param")]
     pub params: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct DebugArgs {
+    /// Read parameters from stdin (JSON or Moment.from format)
+    #[arg(long)]
+    pub stdin: bool,
+
+    /// Session ID of the test run to debug
+    #[arg(long)]
+    pub session_id: Option<String>,
+
+    /// Input hash identifying the moment to debug
+    #[arg(long, allow_hyphen_values = true)]
+    pub input_hash: Option<String>,
+
+    /// Virtual time identifying the moment to debug
+    #[arg(long)]
+    pub vtime: Option<String>,
+
+    /// Debugging session description
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Report recipients (semicolon-delimited email addresses)
+    #[arg(long)]
+    pub recipients: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub enum RunsCommands {
+    /// List all runs
+    List(RunsListArgs),
+
+    /// Show details of a specific run
+    Show {
+        /// Run ID
+        run_id: String,
+    },
+
+    /// List property results for a run
+    Properties {
+        /// Run ID
+        run_id: String,
+
+        /// Show only passing properties
+        #[arg(long, conflicts_with = "failing")]
+        passing: bool,
+
+        /// Show only failing properties
+        #[arg(long)]
+        failing: bool,
+    },
+
+    /// Stream build logs for a run
+    BuildLogs {
+        /// Run ID
+        run_id: String,
+    },
+
+    /// Stream moment logs for a run
+    Logs {
+        /// Run ID
+        run_id: String,
+
+        /// The input hash value identifying the moment
+        #[arg(allow_hyphen_values = true)]
+        input_hash: String,
+
+        /// The virtual time value identifying the moment
+        vtime: String,
+
+        /// Start streaming from this virtual time (must be paired with --begin-input-hash)
+        #[arg(long, requires = "begin_input_hash")]
+        begin_vtime: Option<String>,
+
+        /// Start streaming from this input hash
+        #[arg(long, allow_hyphen_values = true)]
+        begin_input_hash: Option<String>,
+    },
+
+    /// Search events in a run
+    Events {
+        /// Run ID
+        run_id: String,
+
+        /// Search query
+        #[arg(required = true, num_args = 1..)]
+        query: Vec<String>,
+    },
+}
+
+#[derive(Args)]
+pub struct RunsListArgs {
+    /// Filter by status (starting, in_progress, completed, cancelled, incomplete, unknown)
+    #[arg(short, long)]
+    pub status: Option<String>,
+
+    /// Filter by launcher name
+    #[arg(short, long)]
+    pub launcher: Option<String>,
+
+    /// Only show runs created after this timestamp (ISO 8601)
+    #[arg(long)]
+    pub created_after: Option<String>,
+
+    /// Only show runs created before this timestamp (ISO 8601)
+    #[arg(long)]
+    pub created_before: Option<String>,
+
+    /// Maximum number of runs to display
+    #[arg(short = 'n', long, default_value = "50")]
+    pub limit: usize,
+}
+
+impl Default for RunsListArgs {
+    fn default() -> Self {
+        Self {
+            status: None,
+            launcher: None,
+            created_after: None,
+            created_before: None,
+            limit: 50,
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,7 @@ Environment variables:
 
     /// Interact with test runs
     #[command(
+        hide = true,
         long_about = r#"Interact with test runs
 
 List, inspect, and view logs for Antithesis test runs.

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -27,16 +27,6 @@ fn docs_url() -> String {
     base
 }
 
-fn docs_user_agent() -> String {
-    format!(
-        "snouty/{} ({}; {}; rust{})",
-        env!("CARGO_PKG_VERSION"),
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-        env!("SNOUTY_RUSTC_VERSION")
-    )
-}
-
 fn cache_dir() -> Result<PathBuf> {
     let dir = if let Some(dir) = std::env::var_os("SNOUTY_TEST_CACHE_DIR") {
         PathBuf::from(dir)
@@ -127,7 +117,7 @@ async fn download_and_cache_db() -> Result<()> {
 /// has not changed (304 Not Modified).
 async fn fetch_db_if_changed() -> Result<Option<(Vec<u8>, String)>> {
     let client = reqwest::Client::builder()
-        .user_agent(docs_user_agent())
+        .user_agent(crate::user_agent())
         .build()?;
     let mut request = client.get(format!("{}/sqlite.db", docs_url()));
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -63,7 +63,7 @@ fn etag_path() -> Result<PathBuf> {
     Ok(cache_dir()?.join("docs.db.etag"))
 }
 
-pub async fn cmd_docs(command: DocsCommands, offline: bool) -> Result<()> {
+pub async fn cmd_docs(command: DocsCommands, offline: bool, json: bool) -> Result<()> {
     if !(offline || env_db_path_is_set()) {
         update_with_fallback().await?;
     }
@@ -71,12 +71,7 @@ pub async fn cmd_docs(command: DocsCommands, offline: bool) -> Result<()> {
     ensure_docs_db_available(offline)?;
 
     match command {
-        DocsCommands::Search {
-            query,
-            json,
-            list,
-            limit,
-        } => {
+        DocsCommands::Search { query, list, limit } => {
             if query.is_empty() {
                 bail!("search query required");
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,14 @@ pub mod scripts;
 #[doc(hidden)]
 pub mod testutils;
 pub mod validate;
+
+/// User-Agent string sent with every HTTP request snouty makes.
+pub fn user_agent() -> String {
+    format!(
+        "snouty/{} ({}; {}; rust{})",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        env!("SNOUTY_RUSTC_VERSION")
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod api_cache;
+
 pub mod api;
 pub mod cli;
 pub mod config;
@@ -6,6 +8,7 @@ pub mod docs;
 pub mod doctor;
 pub mod moment;
 pub mod params;
+pub mod runs;
 pub mod scripts;
 #[doc(hidden)]
 pub mod testutils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use log::{debug, info};
 
 use color_eyre::eyre::{Context, Result, bail};
 use snouty::api::AntithesisApi;
-use snouty::cli::{ApiCommands, Cli, Commands, LaunchArgs};
+use snouty::cli::{ApiCommands, Cli, Commands, DebugArgs, LaunchArgs};
 use snouty::config;
 use snouty::container;
 use snouty::docs;
@@ -23,31 +23,33 @@ fn read_stdin() -> Result<String> {
     Ok(buf)
 }
 
-fn get_params(args: Vec<String>, use_stdin: bool, support_moment: bool) -> Result<Params> {
-    // Parse stdin params if --stdin flag is set
-    let stdin_params = if use_stdin {
+fn get_stdin_params(use_stdin: bool, support_moment: bool) -> Result<Option<Params>> {
+    if use_stdin {
         let input = read_stdin()?;
         if support_moment && moment::is_moment_format(&input) {
             debug!("detected Moment.from on stdin");
-            Some(moment::parse(&input)?)
+            Ok(Some(moment::parse(&input)?))
         } else {
             debug!("parsing input as JSON");
             let value: serde_json::Value =
                 json5::from_str(&input).wrap_err("invalid arguments: invalid JSON")?;
-            Some(Params::from_json(&value)?)
+            Ok(Some(Params::from_json(&value)?))
         }
     } else {
-        None
-    };
+        Ok(None)
+    }
+}
 
-    // Parse CLI args if provided
+fn get_params(args: Vec<String>, use_stdin: bool, support_moment: bool) -> Result<Params> {
+    let stdin_params = get_stdin_params(use_stdin, support_moment)?;
+
     let args_params = if !args.is_empty() {
         Some(Params::from_args(&args)?)
     } else {
         None
     };
 
-    // Merge params: CLI args take priority over stdin
+    // CLI args take priority over stdin
     match (stdin_params, args_params) {
         (Some(mut stdin), Some(args)) => {
             stdin.merge(args);
@@ -70,16 +72,21 @@ async fn main() -> Result<()> {
         .init();
     let cli = Cli::parse();
 
+    let json = cli.json;
+    if json && let Some(name) = json_unaware_command_name(&cli.command) {
+        eprintln!("warning: --json has no effect for `snouty {name}`");
+    }
     match cli.command {
         Commands::Launch(args) => {
             info!("launching test with webhook: {}", args.webhook);
-            cmd_launch(args).await
+            cmd_launch(args, json).await
         }
         Commands::Run(args) => {
             eprintln!("warning: `snouty run` is deprecated, use `snouty launch` instead");
             info!("launching test with webhook: {}", args.webhook);
-            cmd_launch(args).await
+            cmd_launch(args, json).await
         }
+        Commands::Runs { command } => snouty::runs::cmd_runs(command, json).await,
         Commands::Api(ApiCommands::Webhook {
             webhook,
             stdin,
@@ -88,9 +95,9 @@ async fn main() -> Result<()> {
             info!("running api webhook with webhook: {}", webhook);
             cmd_api_webhook(webhook, args, stdin).await
         }
-        Commands::Debug { stdin, args } => {
+        Commands::Debug(args) => {
             info!("starting debug session");
-            cmd_debug(args, stdin).await
+            cmd_debug(args, json).await
         }
         Commands::Validate(args) => validate::cmd_validate(args).await,
         Commands::Doctor => snouty::doctor::cmd_doctor(),
@@ -100,14 +107,29 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Update => cmd_update(),
-        Commands::Docs { offline, command } => docs::cmd_docs(command, offline).await,
+        Commands::Docs { offline, command } => docs::cmd_docs(command, offline, json).await,
     }
 }
 
-async fn cmd_launch(args: LaunchArgs) -> Result<()> {
+fn json_unaware_command_name(command: &Commands) -> Option<&'static str> {
+    match command {
+        Commands::Launch(_)
+        | Commands::Run(_)
+        | Commands::Runs { .. }
+        | Commands::Docs { .. }
+        | Commands::Debug { .. } => None,
+        Commands::Api(ApiCommands::Webhook { .. }) => Some("api webhook"),
+        Commands::Validate(_) => Some("validate"),
+        Commands::Doctor => Some("doctor"),
+        Commands::Completions { .. } => Some("completions"),
+        Commands::Version => Some("version"),
+        Commands::Update => Some("update"),
+    }
+}
+
+async fn cmd_launch(args: LaunchArgs, json: bool) -> Result<()> {
     let mut params = Params::new();
 
-    // Insert typed flags into params (skip None/false)
     if let Some(test_name) = args.test_name {
         params.insert("antithesis.test_name", test_name);
     }
@@ -130,12 +152,6 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         params.insert("antithesis.report.recipients", recipients);
     }
 
-    // Process config_image and config flags
-    assert!(
-        !(args.config_image.is_some() && args.config.is_some()),
-        "config and config_image are mutually exclusive"
-    );
-
     if let Some(config_image) = args.config_image {
         params.insert("antithesis.config_image", config_image);
     }
@@ -153,7 +169,6 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         None
     };
 
-    // Parse --param key=value pairs
     if !args.params.is_empty() {
         let extra = Params::from_key_value_pairs(&args.params)?;
 
@@ -187,7 +202,6 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
 
     params.validate_test_params()?;
 
-    // Build and push config image (after validation passes)
     if let Some((config, registry, config_image)) = config_image_ref {
         let rt = container::runtime()?;
 
@@ -205,7 +219,13 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
         params.insert("antithesis.config_image", pinned_config);
     }
 
-    launch_webhook(&args.webhook, params).await?;
+    let response = launch_webhook(&args.webhook, params).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Test run started: run_id {}", response.run_id);
+    }
 
     Ok(())
 }
@@ -213,64 +233,74 @@ async fn cmd_launch(args: LaunchArgs) -> Result<()> {
 async fn cmd_api_webhook(webhook: String, args: Vec<String>, use_stdin: bool) -> Result<()> {
     let params = get_params(args, use_stdin, false)?;
     let body = launch_webhook(&webhook, params).await?;
-    println!("{}", body);
+    println!("{}", serde_json::to_string(&body)?);
     Ok(())
 }
 
-async fn launch_webhook(webhook: &str, params: Params) -> Result<String> {
+async fn launch_webhook(webhook: &str, params: Params) -> Result<snouty::api::LaunchResponse> {
     params.validate_test_params()?;
 
-    // Print params to stderr for user visibility (with sensitive values redacted)
     eprintln!(
         "\nRequesting Antithesis test run with params:\n{}",
-        serde_json::to_string_pretty(&params.to_redacted_map()).unwrap()
+        serde_json::to_string_pretty(&params.to_redacted_map())?
     );
 
     let api = AntithesisApi::from_env()?;
-    let response = api
-        .post(&format!("/launch/{}", webhook))
-        .json(&serde_json::json!({ "params": params.to_value() }))
-        .send()
-        .await?;
-
-    let status = response.status();
-    let body = response.text().await?;
-    debug!("response status: {}, body:\n{}", status, body);
-
-    if status.is_success() {
-        Ok(body)
-    } else {
-        bail!("API error: {} - {}", status.as_u16(), body)
-    }
+    api.launch_test(webhook, &params).await
 }
 
-async fn cmd_debug(args: Vec<String>, use_stdin: bool) -> Result<()> {
-    let params = get_params(args, use_stdin, true)?;
+fn debug_typed_params(args: &DebugArgs) -> Params {
+    let mut params = Params::new();
+
+    if let Some(session_id) = &args.session_id {
+        params.insert("antithesis.debugging.session_id", session_id.as_str());
+    }
+    if let Some(input_hash) = &args.input_hash {
+        params.insert("antithesis.debugging.input_hash", input_hash.as_str());
+    }
+    if let Some(vtime) = &args.vtime {
+        params.insert("antithesis.debugging.vtime", vtime.as_str());
+    }
+    if let Some(description) = &args.description {
+        params.insert("antithesis.event_description", description.as_str());
+    }
+    if let Some(recipients) = &args.recipients {
+        params.insert("antithesis.report.recipients", recipients.as_str());
+    }
+
+    params
+}
+
+fn debug_params(args: DebugArgs) -> Result<Params> {
+    let mut params = get_stdin_params(args.stdin, true)?.unwrap_or_default();
+    params.merge(debug_typed_params(&args));
+
+    if params.is_empty() {
+        bail!("invalid arguments: no parameters provided");
+    }
+
+    Ok(params)
+}
+
+async fn cmd_debug(args: DebugArgs, json: bool) -> Result<()> {
+    let params = debug_params(args)?;
     params.validate_debugging_params()?;
 
-    // Print params to stderr for user visibility (with sensitive values redacted)
     eprintln!(
         "\nRequesting the Antithesis multiverse debugger with params:\n{}",
-        serde_json::to_string_pretty(&params.to_redacted_map()).unwrap()
+        serde_json::to_string_pretty(&params.to_redacted_map())?
     );
 
     let api = AntithesisApi::from_env()?;
-    let response = api
-        .post("/launch/debugging")
-        .json(&serde_json::json!({ "params": params.to_value() }))
-        .send()
-        .await?;
+    let response = api.launch_debugging(&params).await?;
 
-    let status = response.status();
-    let body = response.text().await?;
-    debug!("response status: {}, body length: {}", status, body.len());
-
-    if status.is_success() {
-        println!("{}", body);
-        Ok(())
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
-        bail!("API error: {} - {}", status.as_u16(), body)
+        println!("Debugging session started: run_id {}", response.run_id);
     }
+
+    Ok(())
 }
 
 fn cmd_completions(shell: String) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,31 +73,32 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let json = cli.json;
+    let verbose = cli.verbose;
     if json && let Some(name) = json_unaware_command_name(&cli.command) {
         eprintln!("warning: --json has no effect for `snouty {name}`");
     }
     match cli.command {
         Commands::Launch(args) => {
             info!("launching test with webhook: {}", args.webhook);
-            cmd_launch(args, json).await
+            cmd_launch(args, json, verbose).await
         }
         Commands::Run(args) => {
             eprintln!("warning: `snouty run` is deprecated, use `snouty launch` instead");
             info!("launching test with webhook: {}", args.webhook);
-            cmd_launch(args, json).await
+            cmd_launch(args, json, verbose).await
         }
-        Commands::Runs { command } => snouty::runs::cmd_runs(command, json).await,
+        Commands::Runs { command } => snouty::runs::cmd_runs(command, json, verbose).await,
         Commands::Api(ApiCommands::Webhook {
             webhook,
             stdin,
             args,
         }) => {
             info!("running api webhook with webhook: {}", webhook);
-            cmd_api_webhook(webhook, args, stdin).await
+            cmd_api_webhook(webhook, args, stdin, verbose).await
         }
         Commands::Debug(args) => {
             info!("starting debug session");
-            cmd_debug(args, json).await
+            cmd_debug(args, json, verbose).await
         }
         Commands::Validate(args) => validate::cmd_validate(args).await,
         Commands::Doctor => snouty::doctor::cmd_doctor(),
@@ -127,7 +128,7 @@ fn json_unaware_command_name(command: &Commands) -> Option<&'static str> {
     }
 }
 
-async fn cmd_launch(args: LaunchArgs, json: bool) -> Result<()> {
+async fn cmd_launch(args: LaunchArgs, json: bool, verbose: bool) -> Result<()> {
     let mut params = Params::new();
 
     if let Some(test_name) = args.test_name {
@@ -219,7 +220,7 @@ async fn cmd_launch(args: LaunchArgs, json: bool) -> Result<()> {
         params.insert("antithesis.config_image", pinned_config);
     }
 
-    let response = launch_webhook(&args.webhook, params).await?;
+    let response = launch_webhook(&args.webhook, params, verbose).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
@@ -230,14 +231,23 @@ async fn cmd_launch(args: LaunchArgs, json: bool) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_api_webhook(webhook: String, args: Vec<String>, use_stdin: bool) -> Result<()> {
+async fn cmd_api_webhook(
+    webhook: String,
+    args: Vec<String>,
+    use_stdin: bool,
+    verbose: bool,
+) -> Result<()> {
     let params = get_params(args, use_stdin, false)?;
-    let body = launch_webhook(&webhook, params).await?;
+    let body = launch_webhook(&webhook, params, verbose).await?;
     println!("{}", serde_json::to_string(&body)?);
     Ok(())
 }
 
-async fn launch_webhook(webhook: &str, params: Params) -> Result<snouty::api::LaunchResponse> {
+async fn launch_webhook(
+    webhook: &str,
+    params: Params,
+    verbose: bool,
+) -> Result<snouty::api::LaunchResponse> {
     params.validate_test_params()?;
 
     eprintln!(
@@ -245,7 +255,7 @@ async fn launch_webhook(webhook: &str, params: Params) -> Result<snouty::api::La
         serde_json::to_string_pretty(&params.to_redacted_map())?
     );
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     api.launch_test(webhook, &params).await
 }
 
@@ -282,7 +292,7 @@ fn debug_params(args: DebugArgs) -> Result<Params> {
     Ok(params)
 }
 
-async fn cmd_debug(args: DebugArgs, json: bool) -> Result<()> {
+async fn cmd_debug(args: DebugArgs, json: bool, verbose: bool) -> Result<()> {
     let params = debug_params(args)?;
     params.validate_debugging_params()?;
 
@@ -291,7 +301,7 @@ async fn cmd_debug(args: DebugArgs, json: bool) -> Result<()> {
         serde_json::to_string_pretty(&params.to_redacted_map())?
     );
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let response = api.launch_debugging(&params).await?;
 
     if json {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1,0 +1,1305 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Antithesis API",
+    "version": "1.0.0",
+    "description": "The Antithesis API enables programmatic access to the Antithesis autonomous testing environments. List runs, inspect run details and retrieve logs.\n\n### Authentication\n\nAll endpoints require an API key. Pass it in the `Authorization` header as `Authorization: Bearer <api_key>`. To obtain an API key, please contact support at support@antithesis.com.\n\n### Versioning\n\nPublic API endpoints are versioned via a path prefix:\n\n- `/api/v0/...` — **Preview.** APIs accessed from the `v0` route are in preview. They may change or be removed.\n- `/api/v1/...` — **Stable.** The first generally-available version with a compatibility commitment.\n\nIn the future only breaking changes trigger a new major version (e.g., `v2`). When that happens the previous version (`v1`) remains available, and preview APIs restart under `v0`.",
+    "contact": {
+      "name": "Antithesis Team",
+      "url": "https://www.antithesis.com",
+      "email": "support@antithesis.com"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{tenant}.antithesis.com",
+      "description": "Production",
+      "variables": {
+        "tenant": {
+          "description": "Your organization's tenant name.",
+          "default": "demo"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Test runs",
+      "description": "Operations on test runs."
+    },
+    {
+      "name": "Launch",
+      "description": "Launch a test run or debugging session."
+    }
+  ],
+  "paths": {
+    "/api/v0/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "summary": "List all runs",
+        "description": "Returns a paginated list of runs for your organization. Results are ordered by creation time, newest first.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return. Server-capped at 100.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Cursor for pagination. Pass the `next_cursor` value (as well as any filter parameters) from a previous response to fetch the next page.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter runs by status.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Run_Status"
+            }
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "description": "Only return runs created after this timestamp (ISO 8601).",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "description": "Only return runs created before this timestamp (ISO 8601).",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "launcher",
+            "in": "query",
+            "description": "Filter by the launcher that kicked off the run.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of runs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run_List_Response"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "run_id": "9325f006ffd3a399a8497bc888878b97-50-1",
+                      "status": "completed",
+                      "created_at": "2025-03-20T02:00:00Z",
+                      "started_at": "2025-03-20T02:01:12Z",
+                      "completed_at": "2025-03-20T02:31:45Z",
+                      "launcher": "Payments Nightly"
+                    },
+                    {
+                      "run_id": "a1c4e7f2b5d8039c6e9f1a4b7d0e3f68-50-1",
+                      "status": "completed",
+                      "created_at": "2025-03-19T14:00:00Z",
+                      "started_at": "2025-03-19T14:00:32Z",
+                      "completed_at": "2025-03-19T14:45:10Z",
+                      "launcher": "Debug Runner"
+                    }
+                  ],
+                  "next_cursor": "eyJjcmVhdGVkX2F0IjoiMjAyNS0wMy0xOVQxNDowMDowMFoiLCJydW5faWQiOiJiN2YzYTFlOWQwNDg0N2ExYjJjM2Q0ZTVmNmE3YjhjOSJ9"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v0/runs/{run_id}": {
+      "get": {
+        "operationId": "getRun",
+        "summary": "Get run details",
+        "description": "Returns the full details of a single run, including results.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Unique identifier of the run to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full details of the requested run.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Run_Detail"
+                },
+                "examples": {
+                  "test_run": {
+                    "summary": "A completed test run",
+                    "value": {
+                      "run_id": "9325f006ffd3a399a8497bc888878b97-50-1",
+                      "status": "completed",
+                      "created_at": "2025-03-20T02:00:00Z",
+                      "started_at": "2025-03-20T02:01:12Z",
+                      "completed_at": "2025-03-20T02:31:45Z",
+                      "launcher": "Payments Nightly",
+                      "links": {
+                        "triage_report": "https://demo.antithesis.com/report/dBDNYWsHWywLBl1mtobJjjuB/dw8bjBJES6HzQ9iw8PSlGUXNnraLuWpLlbavyABg_R0.html"
+                      },
+                      "results": {
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v0/runs/{run_id}/logs": {
+      "get": {
+        "operationId": "getRunLogs",
+        "summary": "Get logs for a specific moment",
+        "description": "Streams the logs for a moment in the run as newline-delimited JSON (NDJSON) in chronological order. Each line is a self-contained JSON object. The response is streamed — the connection remains open until all matching log lines have been sent.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Unique identifier of the run to retrieve logs for.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "input_hash",
+            "in": "query",
+            "description": "The input hash value identifying the moment.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vtime",
+            "in": "query",
+            "description": "The virtual time value identifying the moment.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "8.692346630850807"
+            }
+          },
+          {
+            "name": "begin_vtime",
+            "in": "query",
+            "description": "Start streaming logs from this virtual time instead of from the beginning of the run.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "8.692346630850807"
+            }
+          },
+          {
+            "name": "begin_input_hash",
+            "in": "query",
+            "description": "The input hash of the moment to start streaming logs from. Must be provided together with `begin_vtime` to fully identify the begin moment.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "-3625518438076122494"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A stream of log lines in NDJSON format. Each line is a JSON object.",
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                },
+                "examples": {
+                  "raft_vote_log": {
+                    "summary": "A raft pre-vote request log line",
+                    "value": {
+                      "output_text": "{\"level\":\"info\",\"ts\":\"2026-03-26T01:42:55.628233Z\",\"logger\":\"raft\",\"caller\":\"v3@v3.6.0/raft.go:1064\",\"msg\":\"2c6c7b8d0d0933f7 [logterm: 78, index: 436] sent MsgPreVote request to dcb68c82481661be at term 79\"}",
+                      "source": {
+                        "container": "etcd0",
+                        "name": "etcd0",
+                        "stream": "error"
+                      },
+                      "moment": {
+                        "input_hash": "-3625518438076122494",
+                        "vtime": "398.4898056755774"
+                      }
+                    }
+                  },
+                  "slow_request_log": {
+                    "summary": "A slow request warning log line",
+                    "value": {
+                      "output_text": "{\"level\":\"warn\",\"ts\":\"2026-03-26T01:41:30.289731Z\",\"caller\":\"txn/util.go:93\",\"msg\":\"apply request took too long\",\"took\":\"200.69629ms\",\"expected-duration\":\"100ms\",\"prefix\":\"read-only range \",\"request\":\"key:\\\"key\\\" \",\"response\":\"\",\"error\":\"context deadline exceeded\"}",
+                      "source": {
+                        "container": "etcd1",
+                        "name": "etcd1",
+                        "stream": "error"
+                      },
+                      "moment": {
+                        "input_hash": "-8212366801093655922",
+                        "vtime": "313.15126806590706"
+                      }
+                    }
+                  },
+                  "watch_channel_log": {
+                    "summary": "A watch channel closed log line",
+                    "value": {
+                      "output_text": "{\"level\":\"info\",\"ts\":1774489067.310644,\"caller\":\"client/watch.go:101\",\"msg\":\"Watch channel closed\"}",
+                      "source": {
+                        "container": "client",
+                        "name": "antithesis/pods/client/commands/robustness/singleton_driver_traffic.err",
+                        "pid": 45,
+                        "stream": "error"
+                      },
+                      "moment": {
+                        "input_hash": "-3704286174724581163",
+                        "vtime": "90.17225814750418"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v0/runs/{run_id}/build_logs": {
+      "get": {
+        "operationId": "getRunBuildLogs",
+        "summary": "Stream build logs",
+        "description": "Streams the build logs for a run as newline-delimited JSON (NDJSON). Each line contains a timestamp, a stream indicator, and the log text. The response is streamed — the connection remains open until all matching log lines have been sent.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Unique identifier of the run to retrieve build logs for.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A stream of build log lines in NDJSON format.",
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/Build_Log_Line"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v0/runs/{run_id}/properties": {
+      "get": {
+        "operationId": "listRunProperties",
+        "summary": "List run properties",
+        "description": "Returns a paginated list of property results for a run, including both passing and failing properties by default. Use the `status` parameter to filter by a specific status.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Unique identifier of the run to retrieve properties for.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter properties by status. When omitted, properties of all statuses are returned.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Property_Status"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return. Server-capped at 100.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Cursor for pagination. Pass the `next_cursor` value from a previous response to fetch the next page.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of property results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Property_List_Response"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v0/runs/{run_id}/events": {
+      "get": {
+        "operationId": "searchRunEvents",
+        "summary": "Search run events",
+        "description": "Searches events in a run for the given query string. The search matches against output text, assertion messages, function names, and test composer commands. Results are streamed as newline-delimited JSON (NDJSON). Each line is a self-contained JSON object representing an event.",
+        "tags": ["Test runs"],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Unique identifier of the run to search.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "The search term. Matches events where this string is contained in the output text, assertion message, function name, or test composer command.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A stream of matching events in NDJSON format. Each line is a JSON object.",
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/launch/{launcher_name}": {
+      "post": {
+        "operationId": "launchTest",
+        "summary": "Launch a test",
+        "description": "Kicks off a test using the specified launcher (e.g. `basic_test` or `basic_k8s_test`). Fetches the relevant container images specified in configuration files and in `antithesis.images`, builds the test environment, and runs the test for the duration set in `antithesis.duration`. Returns an HTTP status code indicating whether the test was successfully started (not the test result itself).",
+        "tags": ["Launch"],
+        "parameters": [
+          {
+            "name": "launcher_name",
+            "in": "path",
+            "description": "Name of the launcher to use. Use `basic_test` for Docker Compose orchestration or `basic_k8s_test` for Kubernetes orchestration.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "basic_test"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Launch_Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Test successfully launched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Launch_Response"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/launch/debugging": {
+      "post": {
+        "operationId": "launchMvd",
+        "summary": "Launch a debugging session",
+        "description": "Kicks off a multiverse debugging session that'll be available for six hours. Returns an HTTP status code indicating whether the debugging session request was successfully accepted and the session is getting ready.",
+        "tags": ["Launch"],
+        "parameters": [
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Launch_MVD_Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Debugging session launcher successfully started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Launch_Response"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error_Response": {
+        "type": "object",
+        "description": "Standard error envelope returned by all error responses.",
+        "required": ["message"],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A human-readable explanation of what went wrong.",
+            "example": "limit must be between 1 and 100"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Run_List_Response": {
+        "type": "object",
+        "description": "A page of test run summaries returned by the list endpoint. Use `next_cursor` to iterate through all available results.",
+        "required": ["data"],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Run_Summary"
+            }
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Opaque pagination cursor. Pass as the `after` query parameter to fetch the next page. Null if no more pages."
+          }
+        }
+      },
+      "Run_Summary": {
+        "type": "object",
+        "required": ["run_id", "status", "created_at", "launcher"],
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "description": "Unique identifier for the run.",
+            "example": "9325f006ffd3a399a8497bc888878b97-50-1"
+          },
+          "status": {
+            "$ref": "#/components/schemas/Run_Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the run was created (ISO 8601)."
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when the run started executing. Null if the run has not yet started."
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when the run finished. Null if the run is still in progress or has not started."
+          },
+          "creator": {
+            "type": "object",
+            "nullable": true,
+            "description": "Information about who or what created this run. Null if the creator is unknown.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Creator_Info"
+              }
+            ]
+          },
+          "launcher": {
+            "type": "string",
+            "description": "The name of the launcher that kicked off this run.",
+            "example": "Payments Nightly"
+          },
+          "parameters": {
+            "type": "object",
+            "nullable": true,
+            "description": "Run parameters. Null if no parameters were specified.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Params"
+              }
+            ]
+          },
+          "links": {
+            "type": "object",
+            "nullable": true,
+            "description": "Relevant links for this run. Null if no links are available yet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Run_Links"
+              }
+            ]
+          }
+        }
+      },
+      "Run_Detail": {
+        "description": "Full details of a test run. Extends Run_Summary with run information, results, and environment metadata.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Run_Summary"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Aggregate results for the run. Structure varies by run type. May be absent or partial for runs that have not yet completed."
+              },
+              "failure_moment": {
+                "type": "object",
+                "nullable": true,
+                "description": "The moment at which the run became incomplete. Populated only when the run is incomplete. Pass this moment's `vtime` and `input_hash` to the logs endpoint to retrieve logs around the event that caused the run to become incomplete.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Moment"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Launch_Response": {
+        "type": "object",
+        "description": "Response returned when a test is successfully launched.",
+        "required": ["runId", "statusCode"],
+        "properties": {
+          "runId": {
+            "type": "string",
+            "description": "Unique identifier for the launched run.",
+            "example": "c8d2f4a6e0b3197d5f8a2c4e6b0d3f79-49-1"
+          },
+          "statusCode": {
+            "type": "integer",
+            "description": "HTTP status code indicating whether the test was successfully started.",
+            "example": 200
+          }
+        },
+        "additionalProperties": false
+      },
+      "Launch_Request": {
+        "type": "object",
+        "description": "Request body for launching a test.",
+        "required": ["params"],
+        "properties": {
+          "params": {
+            "description": "Launch parameters. All parameters are optional.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Params"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Launch_MVD_Request": {
+        "type": "object",
+        "description": "Request body for launching a multiverse debugging session.",
+        "required": ["params"],
+        "properties": {
+          "params": {
+            "description": "Launch parameters. All parameters are optional.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MVD_Params"
+              }
+            ]
+          }
+        },
+        "additionalProperties": true
+      },
+      "Params": {
+        "type": "object",
+        "description": "Key-value pairs of run parameters. Used both when launching a test and when inspecting a run's configuration. All properties are optional.",
+        "properties": {
+          "antithesis.config_image": {
+            "type": "string",
+            "description": "The image version of your config image. This should be a single image version formatted in the same way as those in the `antithesis.images` parameter.",
+            "example": "my-config:latest"
+          },
+          "antithesis.description": {
+            "type": "string",
+            "description": "A description of the test run. Appears in report headers and any emails triggered by the run.",
+            "example": "basic_test on main"
+          },
+          "antithesis.duration": {
+            "type": "string",
+            "description": "Desired duration of the test run in minutes.",
+            "example": "30"
+          },
+          "antithesis.images": {
+            "type": "string",
+            "description": "A semicolon-delimited list of container image versions needed in the testing environment. Each entry in the format `[REGISTRY/]NAME(:TAG|@DIGEST)`. In most cases, images are parsed from the orchestration configuration (e.g. `docker-compose.yaml` or `/manifests`) and do not need to be specified here. It is recommended to use a digest over a tag. Images specified by digest will be tagged as `latest` within the Antithesis environment. The default registry is `us-central1-docker.pkg.dev/molten-verve-216720/$TENANT_NAME-repository/`. When images mentioned in the config are also passed via this parameter, the value here overwrites the config. We recommend only using this parameter for images not already mentioned in the config files.",
+            "example": "registry/container_1:tag1; registry/container_2:latest"
+          },
+          "antithesis.is_ephemeral": {
+            "type": "string",
+            "nullable": true,
+            "enum": ["true", "false"],
+            "description": "A boolean (represented as `\"true\"` or `\"false\"`) that indicates whether or not the run's results should be reflected in future reports as a historic result. Set to `\"true\"` when kicking off one-off, exploratory runs. Defaults to `\"false\"`."
+          },
+          "antithesis.report.recipients": {
+            "type": "string",
+            "description": "A semicolon-delimited list of email addresses to receive the triage report link. If not specified, emails are sent to the default users configured for the endpoint.",
+            "example": "user1@example.com; user2@example.com"
+          },
+          "antithesis.source": {
+            "type": "string",
+            "description": "An identifier used to separate property history in reports. Each property's history is generated from all previous runs sharing the same source value. Useful for tracking test history per branch.",
+            "example": "main"
+          }
+        },
+        "additionalProperties": {
+          "type": "string",
+          "description": "Additional parameters including tooling integration parameters (e.g. `antithesis.integrations.<type>.callback_url`, `antithesis.integrations.<type>.token` where type is `github`, `discord`, or `slack`)."
+        }
+      },
+      "MVD_Params": {
+        "type": "object",
+        "description": "Key-value pairs of multiverse debugging session parameters. Used when launching a debugging session.",
+        "required": [
+          "antithesis.debugging.input_hash",
+          "antithesis.debugging.session_id",
+          "antithesis.debugging.vtime"
+        ],
+        "properties": {
+          "antithesis.debugging.session_id": {
+            "type": "string",
+            "description": "The session ID of the test run you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+            "example": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1"
+          },
+          "antithesis.debugging.input_hash": {
+            "type": "string",
+            "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+            "example": "-9067336385060865277"
+          },
+          "antithesis.debugging.vtime": {
+            "type": "string",
+            "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+            "example": "45.334635781589895"
+          },
+          "antithesis.event_description": {
+            "type": "string",
+            "description": "A description of the debugging event or session.",
+            "example": "Investigate the failed assertion at this moment"
+          },
+          "antithesis.report.recipients": {
+            "type": "string",
+            "description": "A semicolon-delimited list of email addresses that receive the link to the debugging session when ready. If not specified, emails are sent to the default users configured for the endpoint.",
+            "example": "user1@example.com; user2@example.com"
+          }
+        }
+      },
+      "Event": {
+        "type": "object",
+        "description": "A single event. Each event includes its moment information. Fields vary by event source.",
+        "required": ["moment"],
+        "properties": {
+          "moment": {
+            "$ref": "#/components/schemas/Moment"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Moment": {
+        "type": "object",
+        "description": "Identifies a specific moment in the run's execution timeline.",
+        "required": ["input_hash", "vtime"],
+        "properties": {
+          "input_hash": {
+            "type": "string",
+            "description": "The input hash value identifying the moment.",
+            "example": "-3625518438076122494"
+          },
+          "vtime": {
+            "type": "string",
+            "description": "The virtual time value identifying the moment.",
+            "example": "398.4898056755774"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Build_Log_Line": {
+        "type": "object",
+        "description": "A single build log line.",
+        "required": ["timestamp", "text"],
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp of the log line (ISO 8601).",
+            "example": "2025-03-20T02:01:12Z"
+          },
+          "stream": {
+            "type": "string",
+            "enum": ["stdout", "stderr"],
+            "description": "Whether this line is from standard output or standard error."
+          },
+          "text": {
+            "type": "string",
+            "description": "The log line text.",
+            "example": "Building image payments-service..."
+          }
+        },
+        "additionalProperties": true
+      },
+      "Property_List_Response": {
+        "type": "object",
+        "description": "A page of property results returned by the properties endpoint. Use `next_cursor` to iterate through all available results.",
+        "required": ["data"],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Property"
+            }
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Opaque pagination cursor. Pass as the `after` query parameter to fetch the next page. Null if no more pages."
+          }
+        }
+      },
+      "Property_Base": {
+        "type": "object",
+        "description": "Shared fields for all property results. A property result from a test run. Properties with `is_group` set to true represent a group property that contain other individual properties; individual properties within that group reference it via the `group` field.",
+        "required": ["name", "status", "is_event"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the property."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the property."
+          },
+          "status": {
+            "$ref": "#/components/schemas/Property_Status"
+          },
+          "is_event": {
+            "type": "boolean",
+            "description": "Whether this property is event-based. When true, examples and counterexamples are Event objects; when false, they may have any shape."
+          },
+          "is_group": {
+            "type": "boolean",
+            "description": "When true, this property represents a group property that contains other properties. Individual properties belonging to this group will reference it by name via the `group` field."
+          },
+          "group": {
+            "type": "string",
+            "description": "The name of the group this property belongs to. Present only for properties that are part of a group."
+          },
+          "example_count": {
+            "type": "integer",
+            "format": "uint32",
+            "description": "Total number of examples observed."
+          },
+          "counterexample_count": {
+            "type": "integer",
+            "format": "uint32",
+            "description": "Total number of counterexamples observed."
+          }
+        },
+        "additionalProperties": true
+      },
+      "Event_Property": {
+        "description": "A property where `is_event` is true. Examples and counterexamples are Event objects.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Property_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "examples": {
+                "type": "array",
+                "description": "A sample of example events that satisfy the property. This is not an exhaustive list.",
+                "items": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              },
+              "counterexamples": {
+                "type": "array",
+                "description": "A sample of counterexample events that violate the property. This is not an exhaustive list.",
+                "items": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Non_Event_Property": {
+        "description": "A property where `is_event` is false. Examples and counterexamples are arbitrary JSON values whose shape varies by property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Property_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "examples": {
+                "type": "array",
+                "description": "A sample of example instances that satisfy the property. This is not an exhaustive list.",
+                "items": {}
+              },
+              "counterexamples": {
+                "type": "array",
+                "description": "A sample of counterexample instances that violate the property. This is not an exhaustive list.",
+                "items": {}
+              }
+            }
+          }
+        ]
+      },
+      "Property": {
+        "description": "A property result from a test run. When `is_event` is true, examples and counterexamples are Event objects; otherwise, they may have any shape.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Event_Property"
+          },
+          {
+            "$ref": "#/components/schemas/Non_Event_Property"
+          }
+        ]
+      },
+      "Property_Status": {
+        "type": "string",
+        "enum": ["Passing", "Failing"],
+        "description": "Whether the property is currently passing or failing."
+      },
+      "Run_Status": {
+        "type": "string",
+        "enum": ["starting", "in_progress", "completed", "cancelled", "incomplete", "unknown"],
+        "description": "Current lifecycle status of a run. `starting` — the run is being set up. `in_progress` — the run is actively running. `completed` — the run finished successfully. `cancelled` — the run was cancelled before completion. `incomplete` — the run did not complete successfully. `unknown` — the status of the run is unknown."
+      },
+      "Creator_Info": {
+        "type": "object",
+        "description": "Information about who or what created this run. Distinguishes between CI-triggered runs, manual user-initiated runs, and agent-driven runs.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the creator.",
+            "example": "demo"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of creator (e.g. \"ci\", \"user\", \"agent\").",
+            "example": "ci"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Run_Links": {
+        "type": "object",
+        "description": "Relevant links for this run, providing direct access to the triage report.",
+        "properties": {
+          "triage_report": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the triage report for this run."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request — likely missing or invalid parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "limit must be between 1 and 100"
+            }
+          }
+        }   
+      },
+      "Unauthorized": {
+        "description": "Unauthorized — invalid or missing authentication credentials.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "Invalid or expired bearer token."
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden — the authenticated user does not have permission to access this resource.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "You do not have permission to access this resource."
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource was not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "Run not found: 9325f006ffd3a399a8497bc888878b97-48-1"
+            }
+          }
+        }
+      },
+      "MethodNotAllowed": {
+        "description": "Method not allowed — the HTTP method is not supported for this endpoint.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "Resource not found"
+            }
+          }
+        }
+      },
+      "NotAcceptable": {
+        "description": "Not acceptable — the requested content type in the Accept header is not supported by this endpoint.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "This endpoint does not support the requested Accept type."
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded. The response includes a `Retry-After` header indicating the number of seconds to wait before retrying.\n\nWe recommend implementing a retry mechanism to handle rate limiting. Follow an exponential backoff schedule to reduce request volume when necessary, and add randomness (jitter) to the backoff schedule to avoid thundering-herd retries.",
+        "headers": {
+          "Retry-After": {
+            "description": "The number of seconds to wait before retrying the request.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "example": 30
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "Too many requests. Retry after 30 seconds."
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Unknown internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error_Response"
+            },
+            "example": {
+              "message": "An unexpected error occurred. Please try again later."
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key provided by your Antithesis forward deployment engineer. Pass the key in the Authorization header as `Authorization: Bearer <api_key>`."
+      }
+    }
+  }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -319,13 +319,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_debugging_params_missing_required() {
-        let args = ["--antithesis.debugging.input_hash", "abc123"];
-        let params = Params::from_args(args).unwrap();
-        assert!(params.validate_debugging_params().is_err());
-    }
-
-    #[test]
     fn validate_debugging_params_rejects_custom_props() {
         let args = [
             "--antithesis.debugging.input_hash",

--- a/src/params_schema.json
+++ b/src/params_schema.json
@@ -87,6 +87,10 @@
         "antithesis.debugging.vtime": {
           "type": "string",
           "description": "The vtime at which to start debugging, from the copy moment button in triage report"
+        },
+        "antithesis.event_description": {
+          "type": "string",
+          "description": "Description for the debugging event/session"
         }
       },
       "required": [

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -14,11 +14,11 @@ use crate::api::{
 use crate::api::{Event, EventProperty, Moment, NonEventProperty};
 use crate::cli::{RunsCommands, RunsListArgs};
 
-pub async fn cmd_runs(command: Option<RunsCommands>, json: bool) -> Result<()> {
+pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) -> Result<()> {
     match command {
-        None => cmd_runs_list(RunsListArgs::default(), json).await,
-        Some(RunsCommands::List(args)) => cmd_runs_list(args, json).await,
-        Some(RunsCommands::Show { run_id }) => cmd_runs_show(&run_id, json).await,
+        None => cmd_runs_list(RunsListArgs::default(), json, verbose).await,
+        Some(RunsCommands::List(args)) => cmd_runs_list(args, json, verbose).await,
+        Some(RunsCommands::Show { run_id }) => cmd_runs_show(&run_id, json, verbose).await,
         Some(RunsCommands::Properties {
             run_id,
             passing,
@@ -31,9 +31,11 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool) -> Result<()> {
             } else {
                 None
             };
-            cmd_runs_properties(&run_id, status, json).await
+            cmd_runs_properties(&run_id, status, json, verbose).await
         }
-        Some(RunsCommands::BuildLogs { run_id }) => cmd_runs_build_logs(&run_id, json).await,
+        Some(RunsCommands::BuildLogs { run_id }) => {
+            cmd_runs_build_logs(&run_id, json, verbose).await
+        }
         Some(RunsCommands::Logs {
             run_id,
             input_hash,
@@ -48,19 +50,20 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool) -> Result<()> {
                 begin_input_hash.as_deref(),
                 begin_vtime.as_deref(),
                 json,
+                verbose,
             )
             .await
         }
         Some(RunsCommands::Events { run_id, query }) => {
-            cmd_runs_events(&run_id, &query, json).await
+            cmd_runs_events(&run_id, &query, json, verbose).await
         }
     }
 }
 
-async fn cmd_runs_list(args: RunsListArgs, json: bool) -> Result<()> {
+async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<()> {
     debug!("listing runs");
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
 
     let status = args
         .status
@@ -121,10 +124,10 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_runs_show(run_id: &str, json: bool) -> Result<()> {
+async fn cmd_runs_show(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     debug!("showing run: {}", run_id);
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let run = api.get_run(run_id).await?;
 
     if json {
@@ -140,10 +143,11 @@ async fn cmd_runs_properties(
     run_id: &str,
     status: Option<PropertyStatus>,
     json: bool,
+    verbose: bool,
 ) -> Result<()> {
     debug!("listing properties for run: {}", run_id);
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let mut properties = api
         .stream_run_properties(run_id, status)
         .try_collect::<Vec<_>>()
@@ -218,10 +222,10 @@ fn print_run_detail(run: &RunDetail) {
     }
 }
 
-async fn cmd_runs_build_logs(run_id: &str, json: bool) -> Result<()> {
+async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let stream = api.get_run_build_logs(run_id).await?.into_inner();
     let mut stdout = std::io::stdout().lock();
 
@@ -247,10 +251,10 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool) -> Result<()> {
     }
 }
 
-async fn cmd_runs_events(run_id: &str, query: &[String], json: bool) -> Result<()> {
+async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let stream = api
         .search_run_events(run_id, &query.join(" "))
         .await?
@@ -296,10 +300,11 @@ async fn cmd_runs_logs(
     begin_input_hash: Option<&str>,
     begin_vtime: Option<&str>,
     json: bool,
+    verbose: bool,
 ) -> Result<()> {
     debug!("streaming logs for run: {}", run_id);
 
-    let api = AntithesisApi::from_env()?;
+    let api = AntithesisApi::from_env(verbose)?;
     let stream = api
         .get_run_logs(run_id, input_hash, vtime, begin_input_hash, begin_vtime)
         .await?

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -264,17 +264,12 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool) -> Result<(
         })
         .await
     } else {
-        let mut saw_rows = false;
+        writeln!(
+            stdout,
+            "{:<22}  {:<22}  {:<20}  OUTPUT",
+            "HASH", "VTIME", "SOURCE"
+        )?;
         stream_ndjson_lines(stream, |line| {
-            if !saw_rows {
-                writeln!(
-                    stdout,
-                    "{:<22}  {:<22}  {:<20}  OUTPUT",
-                    "HASH", "VTIME", "SOURCE"
-                )?;
-                saw_rows = true;
-            }
-
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let input_hash = rendered.input_hash;
@@ -290,13 +285,7 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool) -> Result<(
             }
             Ok(())
         })
-        .await?;
-
-        if !saw_rows {
-            writeln!(stdout, "No matching events found.")?;
-        }
-
-        Ok(())
+        .await
     }
 }
 

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,0 +1,1312 @@
+use std::io::Write;
+use std::path::Path;
+
+use color_eyre::eyre::{Result, eyre};
+use futures_util::{StreamExt, TryStreamExt};
+use log::debug;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::api::{
+    AntithesisApi, Property, PropertyStatus, RunDetail, RunStatus, RunSummary, RunsFilterOptions,
+};
+#[cfg(test)]
+use crate::api::{Event, EventProperty, Moment, NonEventProperty};
+use crate::cli::{RunsCommands, RunsListArgs};
+
+pub async fn cmd_runs(command: Option<RunsCommands>, json: bool) -> Result<()> {
+    match command {
+        None => cmd_runs_list(RunsListArgs::default(), json).await,
+        Some(RunsCommands::List(args)) => cmd_runs_list(args, json).await,
+        Some(RunsCommands::Show { run_id }) => cmd_runs_show(&run_id, json).await,
+        Some(RunsCommands::Properties {
+            run_id,
+            passing,
+            failing,
+        }) => {
+            let status = if passing {
+                Some(PropertyStatus::Passing)
+            } else if failing {
+                Some(PropertyStatus::Failing)
+            } else {
+                None
+            };
+            cmd_runs_properties(&run_id, status, json).await
+        }
+        Some(RunsCommands::BuildLogs { run_id }) => cmd_runs_build_logs(&run_id, json).await,
+        Some(RunsCommands::Logs {
+            run_id,
+            input_hash,
+            vtime,
+            begin_vtime,
+            begin_input_hash,
+        }) => {
+            cmd_runs_logs(
+                &run_id,
+                &input_hash,
+                &vtime,
+                begin_input_hash.as_deref(),
+                begin_vtime.as_deref(),
+                json,
+            )
+            .await
+        }
+        Some(RunsCommands::Events { run_id, query }) => {
+            cmd_runs_events(&run_id, &query, json).await
+        }
+    }
+}
+
+async fn cmd_runs_list(args: RunsListArgs, json: bool) -> Result<()> {
+    debug!("listing runs");
+
+    let api = AntithesisApi::from_env()?;
+
+    let status = args
+        .status
+        .as_deref()
+        .map(|s| s.parse::<RunStatus>())
+        .transpose()
+        .map_err(|_| {
+            eyre!(
+                "invalid status: '{}'\nvalid values: starting, in_progress, completed, cancelled, incomplete, unknown",
+                args.status.as_deref().unwrap_or_default()
+            )
+        })?;
+
+    let opts = RunsFilterOptions {
+        status,
+        launcher: args.launcher,
+        created_after: args
+            .created_after
+            .as_deref()
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(|e| eyre!("invalid --created-after timestamp: {e}"))?,
+        created_before: args
+            .created_before
+            .as_deref()
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(|e| eyre!("invalid --created-before timestamp: {e}"))?,
+    };
+
+    // Server returns runs newest-first; .take(limit) short-circuits pagination
+    // so we don't materialise the entire run history just to drop most of it.
+    let mut runs: Vec<RunSummary> = api
+        .stream_runs_filtered(&opts)
+        .take(args.limit)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    runs.sort_by(|a, b| {
+        b.created_at
+            .cmp(&a.created_at)
+            .then(a.status.cmp(&b.status))
+    });
+
+    if json {
+        for run in &runs {
+            println!("{}", serde_json::to_string(run)?);
+        }
+        return Ok(());
+    }
+
+    if runs.is_empty() {
+        println!("No runs found.");
+        return Ok(());
+    }
+
+    println!("{}", render_runs_table(&runs));
+    Ok(())
+}
+
+async fn cmd_runs_show(run_id: &str, json: bool) -> Result<()> {
+    debug!("showing run: {}", run_id);
+
+    let api = AntithesisApi::from_env()?;
+    let run = api.get_run(run_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&run)?);
+    } else {
+        print_run_detail(&run);
+    }
+
+    Ok(())
+}
+
+async fn cmd_runs_properties(
+    run_id: &str,
+    status: Option<PropertyStatus>,
+    json: bool,
+) -> Result<()> {
+    debug!("listing properties for run: {}", run_id);
+
+    let api = AntithesisApi::from_env()?;
+    let mut properties = api
+        .stream_run_properties(run_id, status)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    properties.sort_by(|a, b| {
+        property_status_rank(a.status())
+            .cmp(&property_status_rank(b.status()))
+            .then(a.name().cmp(b.name()))
+    });
+
+    if json {
+        for property in &properties {
+            println!("{}", serde_json::to_string(property)?);
+        }
+    } else if properties.is_empty() {
+        println!("No properties found.");
+    } else {
+        let event_rows = flatten_property_events(&properties);
+        let non_event_rows = flatten_non_event_property_values(&properties);
+
+        let mut sections = Vec::new();
+        if !event_rows.is_empty() {
+            sections.push(render_property_events_table(&event_rows));
+        }
+        if !non_event_rows.is_empty() {
+            sections.push(render_property_values_table(&non_event_rows));
+        }
+        println!("{}", sections.join("\n\n"));
+    }
+
+    Ok(())
+}
+
+fn print_run_detail(run: &RunDetail) {
+    let mut rows: Vec<(&str, String)> = vec![
+        ("Run ID", run.run_id.clone()),
+        ("Status", run.status.to_string()),
+    ];
+
+    rows.push(("Created", run.created_at.to_rfc3339()));
+
+    if let Some(ref t) = run.started_at {
+        rows.push(("Started", t.to_rfc3339()));
+    }
+    if let Some(ref t) = run.completed_at {
+        rows.push(("Completed", t.to_rfc3339()));
+    }
+
+    rows.push(("Launcher", run.launcher.clone()));
+
+    if let Some(ref moment) = run.failure_moment {
+        rows.push(("Failure VTime", moment.vtime.clone()));
+        rows.push(("Failure Hash", moment.input_hash.clone()));
+    }
+
+    if let Some(ref links) = run.links
+        && let Some(ref url) = links.triage_report
+    {
+        rows.push(("Report", url.clone()));
+    }
+
+    if let Some(ref creator) = run.creator
+        && let Some(ref name) = creator.name
+    {
+        rows.push(("Creator", name.clone()));
+    }
+
+    let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
+    for (label, value) in &rows {
+        println!("{label:label_width$}  {}", sanitize(value));
+    }
+}
+
+async fn cmd_runs_build_logs(run_id: &str, json: bool) -> Result<()> {
+    debug!("streaming build logs for run: {}", run_id);
+
+    let api = AntithesisApi::from_env()?;
+    let stream = api.get_run_build_logs(run_id).await?.into_inner();
+    let mut stdout = std::io::stdout().lock();
+
+    if json {
+        stream_ndjson_lines(stream, |line| {
+            writeln!(stdout, "{line}")?;
+            Ok(())
+        })
+        .await
+    } else {
+        stream_ndjson_lines(stream, |line| {
+            if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
+                let ts = entry["timestamp"].as_str().unwrap_or("");
+                let stream = entry["stream"].as_str().unwrap_or("out");
+                let text = sanitize(entry["text"].as_str().unwrap_or(""));
+                writeln!(stdout, "{ts} [{stream}] {text}")?;
+            } else {
+                writeln!(stdout, "{line}")?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+
+async fn cmd_runs_events(run_id: &str, query: &[String], json: bool) -> Result<()> {
+    debug!("searching events for run: {}", run_id);
+
+    let api = AntithesisApi::from_env()?;
+    let stream = api
+        .search_run_events(run_id, &query.join(" "))
+        .await?
+        .into_inner();
+
+    let mut stdout = std::io::stdout().lock();
+    if json {
+        stream_ndjson_lines(stream, |line| {
+            writeln!(stdout, "{line}")?;
+            Ok(())
+        })
+        .await
+    } else {
+        let mut saw_rows = false;
+        stream_ndjson_lines(stream, |line| {
+            if !saw_rows {
+                writeln!(
+                    stdout,
+                    "{:<22}  {:<22}  {:<20}  OUTPUT",
+                    "HASH", "VTIME", "SOURCE"
+                )?;
+                saw_rows = true;
+            }
+
+            if let Ok(entry) = serde_json::from_str::<Value>(line) {
+                let rendered = render_event_entry(&entry);
+                let input_hash = rendered.input_hash;
+                let vtime = rendered.vtime;
+                let source = rendered.source;
+                let output = rendered.output;
+                writeln!(
+                    stdout,
+                    "{input_hash:<22}  {vtime:<22}  {source:<20}  {output}"
+                )?;
+            } else {
+                writeln!(stdout, "{:<22}  {:<22}  {:<20}  {line}", "", "", "")?;
+            }
+            Ok(())
+        })
+        .await?;
+
+        if !saw_rows {
+            writeln!(stdout, "No matching events found.")?;
+        }
+
+        Ok(())
+    }
+}
+
+async fn cmd_runs_logs(
+    run_id: &str,
+    input_hash: &str,
+    vtime: &str,
+    begin_input_hash: Option<&str>,
+    begin_vtime: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    debug!("streaming logs for run: {}", run_id);
+
+    let api = AntithesisApi::from_env()?;
+    let stream = api
+        .get_run_logs(run_id, input_hash, vtime, begin_input_hash, begin_vtime)
+        .await?
+        .into_inner();
+
+    let mut stdout = std::io::stdout().lock();
+    if json {
+        stream_ndjson_lines(stream, |line| {
+            writeln!(stdout, "{line}")?;
+            Ok(())
+        })
+        .await
+    } else {
+        writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
+        stream_ndjson_lines(stream, |line| {
+            if let Ok(entry) = serde_json::from_str::<Value>(line) {
+                let rendered = render_event_entry(&entry);
+                let vtime = rendered.vtime;
+                let source = rendered.source;
+                let output = rendered.output;
+                writeln!(stdout, "{vtime:<22}  {source:<20}  {output}")?;
+            } else {
+                writeln!(stdout, "{line}")?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+
+async fn stream_ndjson_lines<S, C>(
+    mut stream: S,
+    mut process_line: impl FnMut(&str) -> Result<()>,
+) -> Result<()>
+where
+    S: futures_util::Stream<Item = reqwest::Result<C>> + Unpin,
+    C: AsRef<[u8]>,
+{
+    use futures_util::StreamExt;
+
+    let mut buf = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        let text = std::str::from_utf8(chunk.as_ref())
+            .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
+        buf.push_str(text);
+
+        while let Some(pos) = buf.find('\n') {
+            let line = &buf[..pos];
+            if !line.is_empty() {
+                process_line(line)?;
+            }
+            buf.drain(..=pos);
+        }
+    }
+
+    // Process any remaining data without a trailing newline
+    if !buf.is_empty() {
+        process_line(&buf)?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RenderedEventEntry {
+    input_hash: String,
+    vtime: String,
+    source: String,
+    output: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AssertionPayload {
+    hit: Option<bool>,
+    condition: Option<bool>,
+    #[serde(default)]
+    must_hit: bool,
+    message: Option<String>,
+    assert_type: Option<String>,
+    display_type: Option<String>,
+    #[serde(default)]
+    location: Option<AssertionLocation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AssertionLocation {
+    file: Option<String>,
+    function: Option<String>,
+    begin_line: Option<serde_json::Number>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AssertionSummary {
+    label: String,
+    status: AssertionStatus,
+    message: String,
+    must_hit: bool,
+    location: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AssertionStatus {
+    Pass,
+    Fail,
+    Unhit,
+}
+
+impl AssertionStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Fail => "FAIL",
+            Self::Unhit => "UNHIT",
+        }
+    }
+}
+
+impl TryFrom<AssertionPayload> for AssertionSummary {
+    type Error = ();
+
+    fn try_from(payload: AssertionPayload) -> std::result::Result<Self, Self::Error> {
+        let hit = payload.hit.ok_or(())?;
+        let condition = payload.condition.ok_or(())?;
+        let message = payload
+            .message
+            .map(|message| message.trim().to_string())
+            .filter(|message| !message.is_empty())
+            .ok_or(())?;
+        let label = payload
+            .display_type
+            .map(|label| label.trim().to_string())
+            .filter(|label| !label.is_empty())
+            .or_else(|| {
+                payload
+                    .assert_type
+                    .map(|label| label.trim().to_string())
+                    .filter(|label| !label.is_empty())
+            })
+            .ok_or(())?;
+
+        let status = if !hit {
+            AssertionStatus::Unhit
+        } else if condition {
+            AssertionStatus::Pass
+        } else {
+            AssertionStatus::Fail
+        };
+
+        Ok(Self {
+            label,
+            status,
+            message,
+            must_hit: payload.must_hit,
+            location: payload.location.and_then(render_assertion_location),
+        })
+    }
+}
+
+fn render_event_entry(entry: &Value) -> RenderedEventEntry {
+    let input_hash = entry["moment"]["input_hash"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    let vtime = entry["moment"]["vtime"].as_str().unwrap_or("").to_string();
+    let container = entry["source"]["container"].as_str().unwrap_or("");
+    let name = entry["source"]["name"].as_str().unwrap_or("");
+    let stream = entry["source"]["stream"].as_str().unwrap_or("");
+
+    if let Some(summary) = parse_assertion_summary(entry) {
+        return RenderedEventEntry {
+            input_hash,
+            vtime,
+            source: render_source(container, name, Some("assert")),
+            output: render_assertion_summary(&summary),
+        };
+    }
+
+    RenderedEventEntry {
+        input_hash,
+        vtime,
+        source: render_source(container, name, (!stream.is_empty()).then_some(stream)),
+        output: render_event_output(entry),
+    }
+}
+
+fn render_event_output(entry: &Value) -> String {
+    if let Some(rendered) = render_known_event(entry) {
+        return rendered;
+    }
+    if let Some(output_text) = entry.get("output_text").and_then(Value::as_str) {
+        return sanitize(output_text);
+    }
+    sanitize(&serde_json::to_string(entry).unwrap_or_default())
+}
+
+struct EventKind {
+    source_name: &'static str,
+    fields: &'static [&'static str],
+}
+
+const EVENT_KINDS: &[EventKind] = &[
+    EventKind {
+        source_name: "antithesis_test_composer",
+        fields: &[
+            "task_status",
+            "command",
+            "container_id",
+            "command_return_code",
+            "command_runtime",
+            "additional_stderr",
+            "added_task",
+            "got_pid_back",
+            "tasks_len",
+            "weight",
+            "weight_type",
+        ],
+    },
+    EventKind {
+        source_name: "fault_injector",
+        fields: &[
+            "fault.name",
+            "fault.type",
+            "fault.details.disruption_type",
+            "fault.affected_nodes",
+            "fault.max_duration",
+        ],
+    },
+];
+
+fn render_known_event(entry: &Value) -> Option<String> {
+    let source_name = entry["source"]["name"].as_str()?;
+    let kind = EVENT_KINDS
+        .iter()
+        .find(|kind| kind.source_name == source_name)?;
+
+    let parts: Vec<String> = kind
+        .fields
+        .iter()
+        .filter_map(|path| {
+            let value = lookup_path(entry, path)?;
+            let rendered = format_event_value(value)?;
+            Some(format!("{path}={rendered}"))
+        })
+        .collect();
+
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
+
+fn lookup_path<'a>(entry: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .try_fold(entry, |current, segment| current.get(segment))
+}
+
+fn format_event_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) if s.is_empty() => None,
+        Value::String(s) => Some(sanitize(s)),
+        Value::Array(items) => {
+            let scalars: Option<Vec<String>> = items
+                .iter()
+                .map(|item| match item {
+                    Value::Null => Some(String::new()),
+                    Value::Bool(b) => Some(b.to_string()),
+                    Value::Number(n) => Some(n.to_string()),
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect();
+            let scalars = scalars?;
+            if scalars.is_empty() {
+                return None;
+            }
+            Some(sanitize(&scalars.join(",")))
+        }
+        Value::Object(_) => None,
+    }
+}
+
+fn parse_assertion_summary(entry: &Value) -> Option<AssertionSummary> {
+    let assertion = entry.get("antithesis_assert")?;
+    let payload: AssertionPayload = serde_json::from_value(assertion.clone()).ok()?;
+    AssertionSummary::try_from(payload).ok()
+}
+
+fn render_source(container: &str, name: &str, stream: Option<&str>) -> String {
+    let label = if !container.trim().is_empty() {
+        sanitize(container)
+    } else {
+        sanitize(name.trim().strip_prefix("antithesis_").unwrap_or(name))
+    };
+    let stream = stream.map(sanitize).filter(|stream| !stream.is_empty());
+
+    match (label.is_empty(), stream) {
+        (false, Some(stream)) => format!("[{label}:{stream}]"),
+        (false, None) => format!("[{label}]"),
+        (true, Some(stream)) => format!("[{stream}]"),
+        (true, None) => "[]".to_string(),
+    }
+}
+
+fn render_assertion_summary(summary: &AssertionSummary) -> String {
+    let mut output = format!(
+        "{} {} \"{}\"",
+        summary.status.as_str(),
+        sanitize(&summary.label),
+        sanitize(&summary.message),
+    );
+
+    if summary.must_hit {
+        output.push_str(" must-hit");
+    }
+
+    if let Some(location) = &summary.location {
+        output.push_str(" @ ");
+        output.push_str(location);
+    }
+
+    output
+}
+
+fn render_assertion_location(location: AssertionLocation) -> Option<String> {
+    let file = location.file.as_deref().and_then(file_basename);
+    let function = location
+        .function
+        .as_deref()
+        .map(str::trim)
+        .filter(|function| !function.is_empty())
+        .map(sanitize);
+    let line = location.begin_line.map(|line| line.to_string());
+
+    let mut rendered = String::new();
+
+    if let Some(file) = file {
+        rendered.push_str(&sanitize(file));
+    }
+    if let Some(function) = function {
+        if !rendered.is_empty() {
+            rendered.push(':');
+        }
+        rendered.push_str(&function);
+    }
+    if let Some(line) = line {
+        if !rendered.is_empty() {
+            rendered.push(':');
+        }
+        rendered.push_str(&line);
+    }
+
+    (!rendered.is_empty()).then_some(rendered)
+}
+
+fn file_basename(file: &str) -> Option<&str> {
+    let trimmed = file.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .or(Some(trimmed))
+}
+
+fn render_runs_table(runs: &[RunSummary]) -> String {
+    let headers = vec![
+        "RUN ID".to_string(),
+        "STATUS".to_string(),
+        "CREATED AT".to_string(),
+        "LAUNCHER".to_string(),
+    ];
+    let rows = runs
+        .iter()
+        .map(|run| {
+            vec![
+                sanitize(&run.run_id),
+                run.status.to_string(),
+                run.created_at.to_rfc3339(),
+                sanitize(&run.launcher),
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    render_table(&headers, &rows)
+}
+
+struct PropertyEventRow<'a> {
+    example: &'static str,
+    hash: &'a str,
+    vtime: &'a str,
+    name: &'a str,
+}
+
+struct PropertyValueRow<'a> {
+    example: &'static str,
+    name: &'a str,
+    value: String,
+}
+
+fn flatten_property_events(properties: &[Property]) -> Vec<PropertyEventRow<'_>> {
+    let mut rows = Vec::new();
+    for property in properties {
+        let start = rows.len();
+        for event in property.event_counterexamples() {
+            rows.push(PropertyEventRow {
+                example: "Failing",
+                hash: &event.moment.input_hash,
+                vtime: &event.moment.vtime,
+                name: property.name(),
+            });
+        }
+        for event in property.event_examples() {
+            rows.push(PropertyEventRow {
+                example: "Passing",
+                hash: &event.moment.input_hash,
+                vtime: &event.moment.vtime,
+                name: property.name(),
+            });
+        }
+        rows[start..].sort_by(|a, b| {
+            example_rank(a.example)
+                .cmp(&example_rank(b.example))
+                .then_with(|| compare_vtime(a.vtime, b.vtime))
+        });
+    }
+    rows
+}
+
+fn example_rank(example: &str) -> u8 {
+    match example {
+        "Failing" => 0,
+        _ => 1,
+    }
+}
+
+fn compare_vtime(a: &str, b: &str) -> std::cmp::Ordering {
+    match (a.parse::<f64>(), b.parse::<f64>()) {
+        (Ok(a), Ok(b)) => a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal),
+        _ => a.cmp(b),
+    }
+}
+
+fn render_property_events_table(rows: &[PropertyEventRow]) -> String {
+    let headers = vec![
+        "EXAMPLE".to_string(),
+        "HASH".to_string(),
+        "VTIME".to_string(),
+        "NAME".to_string(),
+    ];
+    let table_rows = rows
+        .iter()
+        .map(|row| {
+            vec![
+                row.example.to_string(),
+                sanitize(row.hash),
+                sanitize(row.vtime),
+                sanitize(row.name),
+            ]
+        })
+        .collect::<Vec<_>>();
+    render_table(&headers, &table_rows)
+}
+
+fn flatten_non_event_property_values(properties: &[Property]) -> Vec<PropertyValueRow<'_>> {
+    let mut rows = Vec::new();
+    for property in properties {
+        let Property::NonEventProperty(p) = property else {
+            continue;
+        };
+        let mut emitted = false;
+        for value in &p.counterexamples {
+            rows.push(PropertyValueRow {
+                example: "Failing",
+                name: &p.name,
+                value: serde_json::to_string(value).unwrap_or_default(),
+            });
+            emitted = true;
+        }
+        for value in &p.examples {
+            rows.push(PropertyValueRow {
+                example: "Passing",
+                name: &p.name,
+                value: serde_json::to_string(value).unwrap_or_default(),
+            });
+            emitted = true;
+        }
+        if !emitted {
+            rows.push(PropertyValueRow {
+                example: "-",
+                name: &p.name,
+                value: "-".to_string(),
+            });
+        }
+    }
+    rows
+}
+
+fn render_property_values_table(rows: &[PropertyValueRow]) -> String {
+    let headers = vec![
+        "EXAMPLE".to_string(),
+        "NAME".to_string(),
+        "VALUE".to_string(),
+    ];
+    let table_rows = rows
+        .iter()
+        .map(|row| {
+            vec![
+                row.example.to_string(),
+                sanitize(row.name),
+                sanitize(&row.value),
+            ]
+        })
+        .collect::<Vec<_>>();
+    render_table(&headers, &table_rows)
+}
+
+fn render_table(headers: &[String], rows: &[Vec<String>]) -> String {
+    let mut widths = headers
+        .iter()
+        .map(|header| header.len())
+        .collect::<Vec<_>>();
+    for row in rows {
+        for (index, cell) in row.iter().enumerate() {
+            widths[index] = widths[index].max(cell.len());
+        }
+    }
+
+    let mut output = String::new();
+    push_table_row(&mut output, headers, &widths);
+    for row in rows {
+        push_table_row(&mut output, row, &widths);
+    }
+
+    output.trim_end().to_string()
+}
+
+fn push_table_row(output: &mut String, row: &[String], widths: &[usize]) {
+    let last = row.len().saturating_sub(1);
+    for (index, cell) in row.iter().enumerate() {
+        if index > 0 {
+            output.push_str("  ");
+        }
+        if index == last {
+            output.push_str(cell);
+        } else {
+            output.push_str(&format!("{cell:<width$}", width = widths[index]));
+        }
+    }
+    output.push('\n');
+}
+
+fn property_status_rank(status: PropertyStatus) -> u8 {
+    match status {
+        PropertyStatus::Failing => 0,
+        PropertyStatus::Passing => 1,
+    }
+}
+
+fn sanitize(s: &str) -> String {
+    let mut escaped = String::new();
+    for ch in s.chars() {
+        match ch {
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push('\t'),
+            '\0'..='\u{08}' | '\u{0B}'..='\u{1F}' | '\u{7F}' => {
+                escaped.push_str(&format!(r"\x{:02X}", ch as u32));
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn renders_assertion_records_in_compact_form() {
+        let entry = json!({
+            "antithesis_assert": {
+                "assert_type": "always",
+                "condition": false,
+                "details": null,
+                "display_type": "AlwaysOrUnreachable",
+                "hit": false,
+                "id": "Counter's value retrieved",
+                "location": {
+                    "begin_column": 0,
+                    "begin_line": 87,
+                    "class": "",
+                    "file": "/go/src/antithesis/control/control.go",
+                    "function": "get"
+                },
+                "message": "Counter's value retrieved",
+                "must_hit": false
+            },
+            "source": {
+                "container": "control",
+                "name": "control",
+                "pid": 1
+            },
+            "moment": {
+                "input_hash": "-4735081784258020614",
+                "vtime": "311.8487535319291"
+            }
+        });
+
+        assert_eq!(
+            render_event_entry(&entry),
+            RenderedEventEntry {
+                input_hash: "-4735081784258020614".to_string(),
+                vtime: "311.8487535319291".to_string(),
+                source: "[control:assert]".to_string(),
+                output:
+                    "UNHIT AlwaysOrUnreachable \"Counter's value retrieved\" @ control.go:get:87"
+                        .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn falls_back_to_plain_output_for_non_assertion_records() {
+        let entry = json!({
+            "output_text": "starting",
+            "source": {
+                "container": "app",
+                "stream": "out"
+            },
+            "moment": {
+                "vtime": "1.0"
+            }
+        });
+
+        assert_eq!(
+            render_event_entry(&entry),
+            RenderedEventEntry {
+                input_hash: "".to_string(),
+                vtime: "1.0".to_string(),
+                source: "[app:out]".to_string(),
+                output: "starting".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn ignores_schema_valid_but_incomplete_assertions() {
+        let entry = json!({
+            "antithesis_assert": {},
+            "output_text": "raw log line",
+            "source": {
+                "container": "control"
+            },
+            "moment": {
+                "vtime": "5.0"
+            }
+        });
+
+        assert_eq!(
+            render_event_entry(&entry),
+            RenderedEventEntry {
+                input_hash: "".to_string(),
+                vtime: "5.0".to_string(),
+                source: "[control]".to_string(),
+                output: "raw log line".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn renders_must_hit_and_partial_location_details() {
+        let summary = AssertionSummary::try_from(AssertionPayload {
+            hit: Some(false),
+            condition: Some(false),
+            must_hit: true,
+            message: Some("setup reached".to_string()),
+            assert_type: Some("reachability".to_string()),
+            display_type: Some("SetupReached".to_string()),
+            location: Some(AssertionLocation {
+                file: None,
+                function: Some("run_setup".to_string()),
+                begin_line: Some(serde_json::Number::from(42)),
+            }),
+        })
+        .unwrap();
+
+        assert_eq!(
+            render_assertion_summary(&summary),
+            "UNHIT SetupReached \"setup reached\" must-hit @ run_setup:42"
+        );
+    }
+
+    #[test]
+    fn prefers_display_type_but_falls_back_to_assert_type() {
+        let summary = AssertionSummary::try_from(AssertionPayload {
+            hit: Some(true),
+            condition: Some(true),
+            must_hit: false,
+            message: Some("first_setup ran".to_string()),
+            assert_type: Some("sometimes".to_string()),
+            display_type: Some("".to_string()),
+            location: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            render_assertion_summary(&summary),
+            "PASS sometimes \"first_setup ran\""
+        );
+    }
+
+    #[test]
+    fn source_without_stream_omits_trailing_colon() {
+        assert_eq!(render_source("control", "", None), "[control]");
+    }
+
+    #[test]
+    fn source_falls_back_to_name_when_container_empty() {
+        assert_eq!(
+            render_source("", "fault_injector", None),
+            "[fault_injector]"
+        );
+    }
+
+    #[test]
+    fn source_strips_antithesis_prefix_from_name() {
+        assert_eq!(
+            render_source("", "antithesis_test_composer", None),
+            "[test_composer]"
+        );
+    }
+
+    #[test]
+    fn source_prefers_container_over_name() {
+        assert_eq!(render_source("client1", "python3.11", None), "[client1]");
+    }
+
+    #[test]
+    fn source_combines_name_fallback_with_stream() {
+        assert_eq!(
+            render_source("", "antithesis_test_composer", Some("info")),
+            "[test_composer:info]"
+        );
+    }
+
+    #[test]
+    fn renders_test_composer_event_with_name_fallback() {
+        let entry = json!({
+            "added_task": "parallel_driver_fetch",
+            "tasks_len": "1",
+            "source": {
+                "name": "antithesis_test_composer",
+                "pid": 974
+            },
+            "moment": {
+                "input_hash": "5181922178177328213",
+                "vtime": "315.41654103668407"
+            }
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).source,
+            "[test_composer]".to_string()
+        );
+    }
+
+    #[test]
+    fn renders_started_task_as_key_value_pairs() {
+        let entry = json!({
+            "command": "core/parallel_driver_fetch",
+            "container_id": "d700ef3d05a263877d0d0c175f2954bdc8bc098faf501211b34bb20ba09f4435",
+            "started_task": "d700ef3d_parallel_driver_fetch",
+            "task_status": "started",
+            "tasks_len": "1",
+            "source": {"name": "antithesis_test_composer"},
+            "moment": {"vtime": "1.0"}
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).output,
+            "task_status=started command=core/parallel_driver_fetch container_id=d700ef3d05a263877d0d0c175f2954bdc8bc098faf501211b34bb20ba09f4435 tasks_len=1"
+        );
+    }
+
+    #[test]
+    fn renders_finished_task_omitting_empty_stderr() {
+        let entry = json!({
+            "additional_stderr": "",
+            "additional_stdout": "",
+            "command": "core/parallel_driver_fetch",
+            "command_return_code": "0",
+            "command_runtime": "2.1254637241363525",
+            "finished_task": "abc",
+            "task_status": "finished",
+            "source": {"name": "antithesis_test_composer"},
+            "moment": {"vtime": "2.0"}
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).output,
+            "task_status=finished command=core/parallel_driver_fetch command_return_code=0 command_runtime=2.1254637241363525"
+        );
+    }
+
+    #[test]
+    fn renders_weight_event_as_key_value_pairs() {
+        let entry = json!({
+            "command": "abc_/opt/antithesis/test/v1/core/parallel_driver_fetch",
+            "weight": "0.157917609630634",
+            "weight_type": "masked_for_step",
+            "source": {"name": "antithesis_test_composer"},
+            "moment": {"vtime": "7.0"}
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).output,
+            "command=abc_/opt/antithesis/test/v1/core/parallel_driver_fetch weight=0.157917609630634 weight_type=masked_for_step"
+        );
+    }
+
+    #[test]
+    fn renders_fault_event_with_nested_paths_and_array() {
+        let entry = json!({
+            "fault": {
+                "name": "clog",
+                "type": "network",
+                "details": {"disruption_type": "Stopped"},
+                "affected_nodes": ["client2", "setup"],
+                "max_duration": 0.267319258
+            },
+            "source": {"name": "fault_injector"},
+            "moment": {"vtime": "3.0"}
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).output,
+            "fault.name=clog fault.type=network fault.details.disruption_type=Stopped fault.affected_nodes=client2,setup fault.max_duration=0.267319258"
+        );
+    }
+
+    #[test]
+    fn renders_fault_event_with_empty_affected_nodes() {
+        let entry = json!({
+            "fault": {
+                "name": "clog",
+                "type": "network",
+                "details": {"disruption_type": "Stopped"},
+                "affected_nodes": [],
+                "max_duration": 0.259267334
+            },
+            "source": {"name": "fault_injector"},
+            "moment": {"vtime": "4.0"}
+        });
+
+        assert_eq!(
+            render_event_entry(&entry).output,
+            "fault.name=clog fault.type=network fault.details.disruption_type=Stopped fault.max_duration=0.259267334"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_json_dump_for_unknown_source() {
+        let entry = json!({
+            "antithesis_sdk": {"sdk_version": "0.2.0"},
+            "source": {"container": "client1", "name": "python3.11"},
+            "moment": {"vtime": "6.0"}
+        });
+
+        // source.name is not in EVENT_KINDS; no output_text; fall back to JSON.
+        let output = render_event_entry(&entry).output;
+        assert!(output.starts_with('{'), "expected JSON dump, got: {output}");
+        assert!(output.contains("antithesis_sdk"));
+    }
+
+    fn event(input_hash: &str, vtime: &str) -> Event {
+        Event {
+            moment: Moment {
+                input_hash: input_hash.to_string(),
+                vtime: vtime.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn renders_flattened_property_events_table() {
+        let properties = vec![
+            Property::EventProperty(EventProperty {
+                counterexample_count: Some(3),
+                counterexamples: vec![event("-100", "5.0"), event("-200", "10.0")],
+                description: None,
+                example_count: Some(12),
+                examples: vec![event("-300", "15.0")],
+                group: Some("Safety".to_string()),
+                is_event: true,
+                is_group: None,
+                name: "Counter value stays below limit".to_string(),
+                status: PropertyStatus::Failing,
+            }),
+            Property::EventProperty(EventProperty {
+                counterexample_count: Some(0),
+                counterexamples: Vec::new(),
+                description: None,
+                example_count: Some(1),
+                examples: vec![event("-400", "1.0")],
+                group: None,
+                is_event: true,
+                is_group: None,
+                name: "Setup completes".to_string(),
+                status: PropertyStatus::Passing,
+            }),
+        ];
+
+        let rows = flatten_property_events(&properties);
+        let table = render_property_events_table(&rows);
+
+        assert!(table.contains("EXAMPLE"));
+        assert!(table.contains("HASH"));
+        assert!(table.contains("VTIME"));
+        assert!(table.contains("NAME"));
+
+        let lines: Vec<&str> = table.lines().collect();
+        // Header + 2 Failing rows + 2 Passing rows = 5 lines
+        assert_eq!(lines.len(), 5);
+
+        // Failing rows come first, sorted by vtime numerically (5.0 < 10.0)
+        assert!(
+            lines[1].contains("Failing")
+                && lines[1].contains("-100")
+                && lines[1].contains("5.0")
+                && lines[1].contains("Counter value stays below limit")
+        );
+        assert!(
+            lines[2].contains("Failing")
+                && lines[2].contains("-200")
+                && lines[2].contains("10.0")
+                && lines[2].contains("Counter value stays below limit")
+        );
+
+        // Passing rows come after, grouped by property (Counter value first, then Setup completes)
+        assert!(
+            lines[3].contains("Passing")
+                && lines[3].contains("-300")
+                && lines[3].contains("15.0")
+                && lines[3].contains("Counter value stays below limit")
+        );
+        assert!(
+            lines[4].contains("Passing")
+                && lines[4].contains("-400")
+                && lines[4].contains("1.0")
+                && lines[4].contains("Setup completes")
+        );
+    }
+
+    #[test]
+    fn flatten_returns_empty_when_no_sampled_events() {
+        let properties = vec![Property::NonEventProperty(NonEventProperty {
+            counterexample_count: Some(0),
+            counterexamples: Vec::new(),
+            description: None,
+            example_count: Some(0),
+            examples: Vec::new(),
+            group: None,
+            is_event: false,
+            is_group: None,
+            name: "No events property".to_string(),
+            status: PropertyStatus::Passing,
+        })];
+
+        let rows = flatten_property_events(&properties);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn sanitize_preserves_printable_unicode_and_punctuation() {
+        assert_eq!(
+            sanitize("Grüße λ 😸 \"quoted\" C:\\temp\tok"),
+            "Grüße λ 😸 \"quoted\" C:\\temp\tok"
+        );
+    }
+
+    #[test]
+    fn sanitize_escapes_newline_and_carriage_return() {
+        assert_eq!(sanitize("one\ntwo\rthree"), "one\\ntwo\\rthree");
+    }
+
+    #[test]
+    fn sanitize_escapes_non_printable_ascii_except_tab() {
+        assert_eq!(
+            sanitize("a\u{0001}b\u{000B}c\u{007F}d\te"),
+            r"a\x01b\x0Bc\x7Fd	e"
+        );
+    }
+}

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -351,26 +351,27 @@ where
 {
     use futures_util::StreamExt;
 
-    let mut buf = String::new();
+    let mut buf: Vec<u8> = Vec::new();
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
-        let text = std::str::from_utf8(chunk.as_ref())
-            .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-        buf.push_str(text);
+        buf.extend_from_slice(chunk.as_ref());
 
-        while let Some(pos) = buf.find('\n') {
-            let line = &buf[..pos];
-            if !line.is_empty() {
+        while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+            let line_bytes = &buf[..pos];
+            if !line_bytes.is_empty() {
+                let line = std::str::from_utf8(line_bytes)
+                    .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
                 process_line(line)?;
             }
             buf.drain(..=pos);
         }
     }
 
-    // Process any remaining data without a trailing newline
     if !buf.is_empty() {
-        process_line(&buf)?;
+        let line = std::str::from_utf8(&buf)
+            .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
+        process_line(line)?;
     }
 
     Ok(())

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,7 +1,8 @@
+use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::container::{ContainerRuntime, DockerRuntime, PodmanRuntime, is_podman_in_disguise};
@@ -265,6 +266,341 @@ pub fn filtered_path_without_binary(binary: &str) -> Option<String> {
 
 fn directory_contains_binary(dir: &Path, binary: &str) -> bool {
     dir.join(binary).is_file()
+}
+
+/// A mock Antithesis API server for development and testing.
+///
+/// Handles:
+/// - `GET  /api/v0/runs` — paginated run listing
+/// - `GET  /api/v0/runs/{run_id}` — run detail (keyed by run id; 404 unknown)
+/// - `POST /api/v1/launch/{launcher_name}` — returns a mock launch response
+pub struct MockApiServer {
+    url: String,
+    token: String,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockApiServer {
+    /// Start a mock server with sample run data (two runs, paginated).
+    pub fn start() -> Self {
+        Self::start_inner(false)
+    }
+
+    /// Start a mock server with no runs.
+    pub fn start_empty() -> Self {
+        Self::start_inner(true)
+    }
+
+    /// Return the base URL of the mock server (e.g. `http://127.0.0.1:12345`).
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Return the token the server expects in Authorization headers.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Block until the server thread stops.
+    pub fn wait(mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+
+    fn start_inner(empty: bool) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+        let token = MOCK_API_TOKEN.to_string();
+        let expected_token = MOCK_API_TOKEN.to_string();
+
+        let handle = thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 8192];
+                let bytes_read = match stream.read(&mut buf) {
+                    Ok(n) => n,
+                    Err(_) => continue,
+                };
+                let request = String::from_utf8_lossy(&buf[..bytes_read]);
+
+                let (status, body, content_type) = if !mock_check_auth(&request, &expected_token) {
+                    (
+                        401,
+                        r#"{"message":"Invalid or expired bearer token."}"#.to_string(),
+                        "application/json",
+                    )
+                } else {
+                    let (method, path) = mock_parse_request_line(&request);
+                    mock_route(&method, &path, empty)
+                };
+
+                let response = format!(
+                    "HTTP/1.1 {} OK\r\nContent-Type: {}\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+                    status,
+                    content_type,
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        Self {
+            url,
+            token,
+            handle: Some(handle),
+        }
+    }
+}
+
+const MOCK_API_TOKEN: &str = "snouty-mock-api-token";
+
+fn mock_check_auth(request: &str, expected_token: &str) -> bool {
+    let expected = format!("Bearer {expected_token}");
+    request.lines().any(|line| {
+        let line = line.trim();
+        line.strip_prefix("Authorization:")
+            .or_else(|| line.strip_prefix("authorization:"))
+            .is_some_and(|val| val.trim() == expected)
+    })
+}
+
+/// Parse the first line of an HTTP request into (method, path).
+fn mock_parse_request_line(request: &str) -> (String, String) {
+    let first_line = request.lines().next().unwrap_or("");
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+    (method, path)
+}
+
+/// Route a request and return (status_code, response_body, content_type).
+fn mock_route(method: &str, path: &str, empty: bool) -> (u16, String, &'static str) {
+    // Split path and query string
+    let (path_part, query) = match path.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (path, None),
+    };
+
+    let json = "application/json";
+    let ndjson = "application/x-ndjson";
+
+    match (method, path_part) {
+        ("GET", "/api/v0/runs") => {
+            let (s, b) = mock_route_list_runs(query, empty);
+            (s, b, json)
+        }
+        ("GET", p) if p.starts_with("/api/v0/runs/") => {
+            let rest = &p["/api/v0/runs/".len()..];
+            if let Some(run_id) = rest.strip_suffix("/build_logs") {
+                let (s, b) = mock_route_get_run_build_logs(run_id);
+                (s, b, ndjson)
+            } else if let Some(run_id) = rest.strip_suffix("/logs") {
+                let (s, b) = mock_route_get_run_logs(run_id);
+                (s, b, ndjson)
+            } else if let Some(run_id) = rest.strip_suffix("/properties") {
+                let (s, b) = mock_route_list_run_properties(run_id, query);
+                (s, b, json)
+            } else if let Some(run_id) = rest.strip_suffix("/events") {
+                let (s, b) = mock_route_search_run_events(run_id, query);
+                (s, b, ndjson)
+            } else {
+                let (s, b) = mock_route_get_run(rest);
+                (s, b, json)
+            }
+        }
+        ("POST", p) if p.starts_with("/api/v1/launch/") => {
+            let (s, b) = mock_route_launch();
+            (s, b, json)
+        }
+        _ => (404, r#"{"message":"not found"}"#.to_string(), json),
+    }
+}
+
+fn mock_query_param<'a>(query: Option<&'a str>, key: &str) -> Option<&'a str> {
+    query.and_then(|q| {
+        q.split('&').find_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            (k == key).then_some(v)
+        })
+    })
+}
+
+const MOCK_RUNS: &[(&str, &str, &str, &str)] = &[
+    ("run-1", "completed", "2025-03-20T02:00:00Z", "nightly"),
+    ("run-2", "in_progress", "2025-03-19T14:00:00Z", "debug"),
+    ("run-3", "incomplete", "2025-03-18T08:00:00Z", "nightly"),
+];
+
+fn mock_route_list_runs(query: Option<&str>, empty: bool) -> (u16, String) {
+    if empty {
+        return (200, r#"{"data":[],"next_cursor":null}"#.to_string());
+    }
+
+    let after = mock_query_param(query, "after");
+    let status_filter = mock_query_param(query, "status");
+    let launcher_filter = mock_query_param(query, "launcher");
+
+    // Determine which runs to consider based on cursor position.
+    let start = match after {
+        Some("cursor-1") => 1,
+        _ => 0,
+    };
+
+    let mut runs = Vec::new();
+    for &(id, status, created, launcher) in &MOCK_RUNS[start..] {
+        if let Some(f) = status_filter
+            && status != f
+        {
+            continue;
+        }
+        if let Some(f) = launcher_filter
+            && launcher != f
+        {
+            continue;
+        }
+        runs.push(format!(
+            r#"{{"run_id":"{id}","status":"{status}","created_at":"{created}","launcher":"{launcher}"}}"#,
+        ));
+    }
+
+    // Paginate: return one run per page when no filters are active and starting from the beginning.
+    let (data, next_cursor) =
+        if status_filter.is_none() && launcher_filter.is_none() && start == 0 && runs.len() > 1 {
+            (vec![runs[0].clone()], Some("cursor-1"))
+        } else {
+            (runs, None)
+        };
+
+    let data_json = data.join(",");
+    let cursor_json = match next_cursor {
+        Some(c) => format!("\"{c}\""),
+        None => "null".to_string(),
+    };
+    (
+        200,
+        format!(r#"{{"data":[{data_json}],"next_cursor":{cursor_json}}}"#),
+    )
+}
+
+fn mock_route_get_run(run_id: &str) -> (u16, String) {
+    let Some(&(_, status, created, launcher)) = MOCK_RUNS.iter().find(|(id, ..)| *id == run_id)
+    else {
+        return (404, format!(r#"{{"message":"run not found: {run_id}"}}"#));
+    };
+
+    let mut fields = vec![
+        format!(r#""run_id":"{run_id}""#),
+        format!(r#""status":"{status}""#),
+        format!(r#""created_at":"{created}""#),
+    ];
+    if status == "completed" || status == "incomplete" {
+        fields.push(r#""started_at":"2025-03-20T02:01:12Z""#.to_string());
+        fields.push(r#""completed_at":"2025-03-20T02:31:45Z""#.to_string());
+    }
+    fields.push(format!(r#""launcher":"{launcher}""#));
+    fields.push(format!(
+        r#""links":{{"triage_report":"https://demo.antithesis.com/reports/{run_id}"}}"#
+    ));
+    if status == "incomplete" {
+        fields.push(
+            r#""failure_moment":{"input_hash":"-3625518438076122494","vtime":"398.4898056755774"}"#
+                .to_string(),
+        );
+    }
+
+    (200, format!("{{{}}}", fields.join(",")))
+}
+
+fn mock_route_get_run_build_logs(_run_id: &str) -> (u16, String) {
+    let lines = [
+        r#"{"timestamp":"2025-03-20T02:01:12Z","stream":"stdout","text":"Building image payments-service..."}"#,
+        r#"{"timestamp":"2025-03-20T02:01:15Z","stream":"stderr","text":"Warning: deprecated feature"}"#,
+        r#"{"timestamp":"2025-03-20T02:01:20Z","stream":"stdout","text":"Build complete"}"#,
+    ];
+    (200, lines.join("\n") + "\n")
+}
+
+fn mock_route_get_run_logs(_run_id: &str) -> (u16, String) {
+    let lines = [
+        r#"{"output_text":"{\"level\":\"info\",\"msg\":\"starting\"}","source":{"container":"app","name":"app","stream":"out"},"moment":{"input_hash":"-123","vtime":"1.0","session_id":"sess-1"}}"#,
+        r#"{"output_text":"{\"level\":\"warn\",\"msg\":\"slow request\"}","source":{"container":"app","name":"app","stream":"error"},"moment":{"input_hash":"-456","vtime":"2.0","session_id":"sess-1"}}"#,
+        // Record whose output_text contains a JSON-escaped newline (\n).
+        // Verifies that --json emits this as a single output line.
+        r#"{"output_text":"line one\nline two","source":{"container":"app","name":"app","stream":"out"},"moment":{"input_hash":"-789","vtime":"3.0"}}"#,
+        r#"{"IPT_bytes_out":563000,"output_text":"W0320 15:07:26.913251       1 control.go:315] Error setting vault 10.0.1.123:8003 value to 64: Post \"http://10.0.1.123:8003/\": dial tcp 10.0.1.123:8003: i/o timeout (Client.Timeout exceeded while awaiting headers)","source":{"container":"control","name":"service_control","stream":"error"},"moment":{"input_hash":"-7835669064649885519","vtime":"73.94233945617452"}}"#,
+        r#"{"antithesis_assert":{"assert_type":"always","condition":false,"details":null,"display_type":"AlwaysOrUnreachable","hit":false,"id":"Counter's value retrieved","location":{"begin_column":0,"begin_line":87,"class":"","file":"/go/src/antithesis/control/control.go","function":"get"},"message":"Counter's value retrieved","must_hit":false},"IPT_bytes_out":1837376,"source":{"container":"control","name":"control","pid":1},"moment":{"input_hash":"-4735081784258020614","vtime":"311.8487535319291"}}"#,
+        // Platform events with no container; source.name is used as the
+        // bracketed label and curated fields render as <path>=<value> pairs.
+        r#"{"started_task":"abc_parallel_driver_fetch","task_status":"started","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"400.5"}}"#,
+        r#"{"fault":{"name":"clog","type":"network","details":{"disruption_type":"Stopped"},"affected_nodes":["client2","setup"],"max_duration":0.267},"source":{"name":"fault_injector","pid":1086},"moment":{"input_hash":"5181922178177328213","vtime":"401.5"}}"#,
+    ];
+    (200, lines.join("\n") + "\n")
+}
+
+fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, String) {
+    if run_id == "run-empty" {
+        return (200, r#"{"data":[],"next_cursor":null}"#.to_string());
+    }
+
+    if run_id == "run-no-events" {
+        return (
+            200,
+            r#"{"data":[{"name":"No events property","status":"Passing","is_event":false,"example_count":0,"counterexample_count":0}],"next_cursor":null}"#.to_string(),
+        );
+    }
+
+    let status = mock_query_param(query, "status");
+    let after = mock_query_param(query, "after");
+
+    let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"15.0"}}],"counterexamples":[{"moment":{"input_hash":"-100","vtime":"5.0"}},{"moment":{"input_hash":"-200","vtime":"10.0"}}]}"#.to_string();
+    let passing = r#"{"name":"Setup completes","description":"Setup eventually succeeds","status":"Passing","is_event":false,"example_count":1,"counterexample_count":0,"examples":[{"final_counter":42}]}"#.to_string();
+
+    let (data, next_cursor) = match (status, after) {
+        (Some("Failing"), _) => (vec![failing], None),
+        (Some("Passing"), _) => (vec![passing], None),
+        (None, None) => (vec![failing], Some("props-cursor-1")),
+        (None, Some("props-cursor-1")) => (vec![passing], None),
+        (None, _) => (vec![], None),
+        _ => (vec![], None),
+    };
+
+    let data_json = data.join(",");
+    let cursor_json = match next_cursor {
+        Some(cursor) => format!("\"{cursor}\""),
+        None => "null".to_string(),
+    };
+    (
+        200,
+        format!(r#"{{"data":[{data_json}],"next_cursor":{cursor_json}}}"#),
+    )
+}
+
+fn mock_route_search_run_events(run_id: &str, query: Option<&str>) -> (u16, String) {
+    let Some(query) = mock_query_param(query, "q") else {
+        return (400, r#"{"message":"missing q"}"#.to_string());
+    };
+
+    let (_, logs) = mock_route_get_run_logs(run_id);
+    let query = query.to_ascii_lowercase();
+    let matches = logs
+        .lines()
+        .filter(|line| line.to_ascii_lowercase().contains(&query))
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        (200, String::new())
+    } else {
+        (200, matches.join("\n") + "\n")
+    }
+}
+
+fn mock_route_launch() -> (u16, String) {
+    (
+        200,
+        r#"{"runId":"mock-run-id","statusCode":200}"#.to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -324,7 +324,13 @@ impl MockApiServer {
                 };
                 let request = String::from_utf8_lossy(&buf[..bytes_read]);
 
-                let (status, body, content_type) = if !mock_check_auth(&request, &expected_token) {
+                let (status, body, content_type) = if !mock_check_user_agent(&request) {
+                    (
+                        400,
+                        r#"{"message":"Missing User-Agent header."}"#.to_string(),
+                        "application/json",
+                    )
+                } else if !mock_check_auth(&request, &expected_token) {
                     (
                         401,
                         r#"{"message":"Invalid or expired bearer token."}"#.to_string(),
@@ -363,6 +369,15 @@ fn mock_check_auth(request: &str, expected_token: &str) -> bool {
         line.strip_prefix("Authorization:")
             .or_else(|| line.strip_prefix("authorization:"))
             .is_some_and(|val| val.trim() == expected)
+    })
+}
+
+fn mock_check_user_agent(request: &str) -> bool {
+    request.lines().any(|line| {
+        let Some((name, value)) = line.split_once(':') else {
+            return false;
+        };
+        name.eq_ignore_ascii_case("user-agent") && !value.trim().is_empty()
     })
 }
 
@@ -622,6 +637,19 @@ mod tests {
         assert_eq!(mock_query_param(q, "other"), Some("a&b".to_string()));
         assert_eq!(mock_query_param(q, "missing"), None);
         assert_eq!(mock_query_param(None, "q"), None);
+    }
+
+    #[test]
+    fn mock_check_user_agent_requires_non_empty_header() {
+        let with = "GET /api/v0/runs HTTP/1.1\r\nUser-Agent: snouty/0.0.0\r\n\r\n";
+        let lowercase = "GET /api/v0/runs HTTP/1.1\r\nuser-agent: snouty/0.0.0\r\n\r\n";
+        let empty = "GET /api/v0/runs HTTP/1.1\r\nUser-Agent:   \r\n\r\n";
+        let missing = "GET /api/v0/runs HTTP/1.1\r\n\r\n";
+
+        assert!(mock_check_user_agent(with));
+        assert!(mock_check_user_agent(lowercase));
+        assert!(!mock_check_user_agent(empty));
+        assert!(!mock_check_user_agent(missing));
     }
 
     #[test]

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -418,13 +418,10 @@ fn mock_route(method: &str, path: &str, empty: bool) -> (u16, String, &'static s
     }
 }
 
-fn mock_query_param<'a>(query: Option<&'a str>, key: &str) -> Option<&'a str> {
-    query.and_then(|q| {
-        q.split('&').find_map(|pair| {
-            let (k, v) = pair.split_once('=')?;
-            (k == key).then_some(v)
-        })
-    })
+fn mock_query_param(query: Option<&str>, key: &str) -> Option<String> {
+    form_urlencoded::parse(query?.as_bytes())
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.into_owned())
 }
 
 const MOCK_RUNS: &[(&str, &str, &str, &str)] = &[
@@ -443,19 +440,19 @@ fn mock_route_list_runs(query: Option<&str>, empty: bool) -> (u16, String) {
     let launcher_filter = mock_query_param(query, "launcher");
 
     // Determine which runs to consider based on cursor position.
-    let start = match after {
+    let start = match after.as_deref() {
         Some("cursor-1") => 1,
         _ => 0,
     };
 
     let mut runs = Vec::new();
     for &(id, status, created, launcher) in &MOCK_RUNS[start..] {
-        if let Some(f) = status_filter
+        if let Some(f) = status_filter.as_deref()
             && status != f
         {
             continue;
         }
-        if let Some(f) = launcher_filter
+        if let Some(f) = launcher_filter.as_deref()
             && launcher != f
         {
             continue;
@@ -557,7 +554,7 @@ fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, St
     let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"15.0"}}],"counterexamples":[{"moment":{"input_hash":"-100","vtime":"5.0"}},{"moment":{"input_hash":"-200","vtime":"10.0"}}]}"#.to_string();
     let passing = r#"{"name":"Setup completes","description":"Setup eventually succeeds","status":"Passing","is_event":false,"example_count":1,"counterexample_count":0,"examples":[{"final_counter":42}]}"#.to_string();
 
-    let (data, next_cursor) = match (status, after) {
+    let (data, next_cursor) = match (status.as_deref(), after.as_deref()) {
         (Some("Failing"), _) => (vec![failing], None),
         (Some("Passing"), _) => (vec![passing], None),
         (None, None) => (vec![failing], Some("props-cursor-1")),
@@ -616,6 +613,26 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn mock_query_param_decodes_form_encoded_value() {
+        // reqwest form-encodes spaces as '+' and other bytes as %XX.
+        let q = Some("q=slow+request&other=a%26b");
+        assert_eq!(mock_query_param(q, "q"), Some("slow request".to_string()));
+        assert_eq!(mock_query_param(q, "other"), Some("a&b".to_string()));
+        assert_eq!(mock_query_param(q, "missing"), None);
+        assert_eq!(mock_query_param(None, "q"), None);
+    }
+
+    #[test]
+    fn mock_route_search_run_events_matches_after_decoding() {
+        let (status, body) = mock_route_search_run_events("run-1", Some("q=slow+request"));
+        assert_eq!(status, 200);
+        assert!(
+            body.contains("slow request"),
+            "expected match for decoded query, got: {body}"
+        );
+    }
 
     #[test]
     fn directory_contains_plain_binary() {

--- a/tests/cli_docs.rs
+++ b/tests/cli_docs.rs
@@ -39,7 +39,7 @@ fn docs_update_sets_custom_user_agent() {
 
     assert_eq!(
         mock_server.user_agent().as_deref(),
-        Some(expected_docs_user_agent().as_str()),
+        Some(snouty::user_agent().as_str()),
     );
 }
 

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -28,7 +28,6 @@ fn help_shows_subcommands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("launch"))
-        .stdout(predicate::str::contains("runs"))
         .stdout(predicate::str::contains("debug"))
         .stdout(predicate::str::contains("version"));
 }

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -28,6 +28,7 @@ fn help_shows_subcommands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("launch"))
+        .stdout(predicate::str::contains("runs"))
         .stdout(predicate::str::contains("debug"))
         .stdout(predicate::str::contains("version"));
 }
@@ -66,8 +67,32 @@ fn validate_help_documents_compose_and_kubernetes() {
 }
 
 #[test]
+fn runs_lists_all_pages() {
+    let mock = start_runs_server(false);
+
+    snouty_with_mock_server(&mock)
+        .arg("runs")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RUN ID"))
+        .stdout(predicate::str::contains("run-1"))
+        .stdout(predicate::str::contains("run-2"));
+}
+
+#[test]
+fn runs_prints_empty_state() {
+    let mock = start_runs_server(true);
+
+    snouty_with_mock_server(&mock)
+        .arg("runs")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No runs found."));
+}
+
+#[test]
 fn launch_with_typed_flags() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -110,7 +135,7 @@ fn launch_with_typed_flags() {
 
 #[test]
 fn launch_with_ephemeral_flag() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -130,7 +155,7 @@ fn launch_with_ephemeral_flag() {
 
 #[test]
 fn launch_without_source_sets_ephemeral() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "30"])
@@ -146,7 +171,7 @@ fn launch_without_source_sets_ephemeral() {
 
 #[test]
 fn launch_with_source_omits_ephemeral() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -166,7 +191,7 @@ fn launch_with_source_omits_ephemeral() {
 
 #[test]
 fn launch_with_param_flag() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -190,7 +215,7 @@ fn launch_with_param_flag() {
 
 #[test]
 fn launch_param_cannot_override_typed_flag() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -218,7 +243,7 @@ fn launch_duration_rejects_non_numeric() {
 
 #[test]
 fn launch_duration_accepts_fractional() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "0.05"])
@@ -266,7 +291,7 @@ fn launch_fails_without_parameters() {
 
 #[test]
 fn launch_reports_api_errors() {
-    let mock_url = start_mock_server(r#"{"error": "bad request"}"#, 400);
+    let mock_url = start_mock_server(r#"{"message":"bad request"}"#, 400);
 
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "30"])
@@ -286,7 +311,7 @@ fn launch_fails_without_credentials() {
 
 #[test]
 fn api_webhook_with_cli_args() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -329,7 +354,7 @@ fn api_webhook_with_cli_args() {
 
 #[test]
 fn api_webhook_with_stdin_json() {
-    let mock_url = start_mock_server(r#"{"launched": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args(["api", "webhook", "-w", "basic_test", "--stdin"])
@@ -344,7 +369,7 @@ fn api_webhook_with_stdin_json() {
 
 #[test]
 fn api_webhook_with_custom_properties() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -364,7 +389,7 @@ fn api_webhook_with_custom_properties() {
 
 #[test]
 fn api_webhook_stdin_flag_required_for_stdin_input() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -384,7 +409,7 @@ fn api_webhook_stdin_flag_required_for_stdin_input() {
 
 #[test]
 fn api_webhook_with_k8s_webhook() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -401,7 +426,7 @@ fn api_webhook_with_k8s_webhook() {
 
 #[test]
 fn api_webhook_with_custom_webhook() {
-    let mock_url = start_mock_server(r#"{"status": "ok"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -469,7 +494,7 @@ fn api_webhook_fails_without_webhook() {
 
 #[test]
 fn api_webhook_reports_api_errors() {
-    let mock_url = start_mock_server(r#"{"error": "bad request"}"#, 400);
+    let mock_url = start_mock_server(r#"{"message":"bad request"}"#, 400);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -514,7 +539,7 @@ fn api_webhook_fails_without_parameters() {
 
 #[test]
 fn api_webhook_merges_stdin_json_with_cli_args() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -540,7 +565,7 @@ fn api_webhook_merges_stdin_json_with_cli_args() {
 
 #[test]
 fn api_webhook_cli_args_override_stdin_json() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -563,7 +588,7 @@ fn api_webhook_cli_args_override_stdin_json() {
 
 #[test]
 fn api_webhook_success_outputs_valid_json() {
-    let mock_url = start_mock_server(r#"{"session_id": "abc123", "status": "launched"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     let output = snouty_with_mock(&mock_url)
         .args([
@@ -584,11 +609,13 @@ fn api_webhook_success_outputs_valid_json() {
     let parsed: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
     assert!(parsed.is_object());
+    assert_eq!(parsed["runId"], "run-123");
+    assert_eq!(parsed["statusCode"], 200);
 }
 
 #[test]
 fn api_webhook_error_outputs_string_on_stderr() {
-    let mock_url = start_mock_server(r#"{"error": "something went wrong"}"#, 500);
+    let mock_url = start_mock_server(r#"{"message":"something went wrong"}"#, 500);
 
     snouty_with_mock(&mock_url)
         .args([
@@ -607,7 +634,7 @@ fn api_webhook_error_outputs_string_on_stderr() {
 
 #[test]
 fn run_prints_deprecation_warning() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args(["run", "-w", "basic_test", "--duration", "30"])
@@ -637,28 +664,67 @@ fn api_webhook_no_config_flag() {
 
 #[test]
 fn debug_with_cli_args() {
-    let mock_url = start_mock_server(r#"{"session": "started"}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId": "run-abc-1-1", "statusCode": 202}"#, 200);
 
     snouty_with_mock(&mock_url)
         .args([
             "debug",
-            "--antithesis.debugging.input_hash",
+            "--input-hash",
             "abc123",
-            "--antithesis.debugging.session_id",
+            "--session-id",
             "sess-456",
-            "--antithesis.debugging.vtime",
+            "--vtime",
             "1234567890",
+            "--description",
+            "debug this moment",
+            "--recipients",
+            "team@example.com",
         ])
         .assert()
         .success()
         .stderr(predicate::str::contains(
             r#""antithesis.debugging.input_hash": "abc123""#,
+        ))
+        .stderr(predicate::str::contains(
+            r#""antithesis.debugging.session_id": "sess-456""#,
+        ))
+        .stderr(predicate::str::contains(
+            r#""antithesis.debugging.vtime": "1234567890""#,
+        ))
+        .stderr(predicate::str::contains(
+            r#""antithesis.event_description": "debug this moment""#,
+        ))
+        .stderr(predicate::str::contains(
+            r#""antithesis.report.recipients": "[REDACTED]""#,
+        ))
+        .stdout(predicate::str::contains(
+            "Debugging session started: run_id run-abc-1-1",
         ));
 }
 
 #[test]
+fn debug_with_json_flag() {
+    let mock_url = start_mock_server(r#"{"runId": "run-abc-1-1", "statusCode": 202}"#, 200);
+
+    snouty_with_mock(&mock_url)
+        .args([
+            "--json",
+            "debug",
+            "--input-hash",
+            "abc123",
+            "--session-id",
+            "sess-456",
+            "--vtime",
+            "1234567890",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""runId": "run-abc-1-1""#));
+}
+
+#[test]
 fn debug_with_moment_from_format() {
-    let mock_url = start_mock_server(r#"{"debugging": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId": "run-1", "statusCode": 202}"#, 200);
     let moment_input = r#"Moment.from({ session_id: "f89d5c11f5e3bf5e4bb3641809800cee-44-22", input_hash: "6057726200491963783", vtime: 329.8037810830865 })"#;
 
     snouty_with_mock(&mock_url)
@@ -679,7 +745,7 @@ fn debug_with_moment_from_format() {
 
 #[test]
 fn debug_with_stdin_json() {
-    let mock_url = start_mock_server(r#"{"ok": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId": "run-1", "statusCode": 202}"#, 200);
     let json = r#"{
          "antithesis.debugging.input_hash": "abc",
          "antithesis.debugging.session_id": "sess",
@@ -701,17 +767,15 @@ fn debug_fails_missing_required_fields() {
     let mock_url = start_mock_server(r#"{}"#, 200);
 
     snouty_with_mock(&mock_url)
-        .args(["debug", "--antithesis.debugging.input_hash", "abc"])
+        .args(["debug", "--input-hash", "abc"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("validation failed"));
 }
 
 #[test]
-fn debug_rejects_custom_properties() {
-    let mock_url = start_mock_server(r#"{}"#, 200);
-
-    snouty_with_mock(&mock_url)
+fn debug_rejects_old_raw_args() {
+    snouty()
         .args([
             "debug",
             "--antithesis.debugging.input_hash",
@@ -720,12 +784,10 @@ fn debug_rejects_custom_properties() {
             "sess",
             "--antithesis.debugging.vtime",
             "123",
-            "--my.custom.prop",
-            "value",
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("validation failed"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -749,14 +811,16 @@ fn completions_unsupported_shell_fails() {
 
 #[test]
 fn debug_merges_moment_with_cli_args() {
-    let mock_url = start_mock_server(r#"{"debugging": true}"#, 200);
+    let mock_url = start_mock_server(r#"{"runId": "run-1", "statusCode": 202}"#, 200);
     let moment_input = r#"Moment.from({ session_id: "f89d5c11f5e3bf5e4bb3641809800cee-44-22", input_hash: "6057726200491963783", vtime: 329.8037810830865 })"#;
 
     snouty_with_mock(&mock_url)
         .args([
             "debug",
             "--stdin",
-            "--antithesis.report.recipients",
+            "--input-hash",
+            "override",
+            "--recipients",
             "team@example.com",
         ])
         .write_stdin(moment_input)
@@ -766,7 +830,7 @@ fn debug_merges_moment_with_cli_args() {
             r#""antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22""#,
         ))
         .stderr(predicate::str::contains(
-            r#""antithesis.debugging.input_hash": "6057726200491963783""#,
+            r#""antithesis.debugging.input_hash": "override""#,
         ))
         .stderr(predicate::str::contains(
             r#""antithesis.debugging.vtime": "329.8037810830865""#,

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -1,5 +1,5 @@
 use snouty::testutils::{
-    OCIRegistry, available_runtimes, filtered_path_without_binary, skip_or_fail,
+    MockApiServer, OCIRegistry, available_runtimes, filtered_path_without_binary, skip_or_fail,
 };
 use std::cell::RefCell;
 use std::io::{Read, Write};
@@ -62,8 +62,9 @@ fn cmd_snouty(
     args: &[String],
 ) -> testscript_rs::Result<()> {
     let start = std::time::Instant::now();
-    let label = args.join(" ");
-    let mut cmd = snouty_cmd(env, args);
+    let expanded: Vec<String> = args.iter().map(|a| env.substitute_env_vars(a)).collect();
+    let label = expanded.join(" ");
+    let mut cmd = snouty_cmd(env, &expanded);
     if env.next_stdin.is_some() {
         cmd.stdin(Stdio::piped());
     }
@@ -102,6 +103,12 @@ fn cmd_mock_server(
     if args.len() < 2 {
         return Err(err("mock-server requires <status> <body>".to_string()));
     }
+
+    if is_staging() {
+        propagate_antithesis_env(env)?;
+        return Ok(());
+    }
+
     let status: u16 = args[0]
         .parse()
         .map_err(|e| err(format!("invalid status code: {e}")))?;
@@ -132,6 +139,132 @@ fn cmd_mock_server(
     env.set_env_var("ANTITHESIS_USERNAME", "testuser");
     env.set_env_var("ANTITHESIS_PASSWORD", "testpass");
     env.set_env_var("ANTITHESIS_TENANT", "testtenant");
+    Ok(())
+}
+
+fn cmd_env_from_json(
+    env: &mut testscript_rs::TestEnvironment,
+    args: &[String],
+) -> testscript_rs::Result<()> {
+    // Usage: env_from_json <line_index> <json_key>
+    // Parses the previous command's stdout as NDJSON, extracts <json_key>
+    // from line <line_index> (0-based) and stores it as $R_<json_key>.
+    if args.len() != 2 {
+        return Err(err(
+            "env_from_json requires <line_index> <json_key>".to_string()
+        ));
+    }
+    let line_idx: usize = args[0]
+        .parse()
+        .map_err(|_| err("line_index must be a non-negative integer".to_string()))?;
+    let key = &args[1];
+
+    let output = env
+        .last_output
+        .as_ref()
+        .ok_or_else(|| err("no previous command output".to_string()))?;
+    let stdout = std::str::from_utf8(&output.stdout)
+        .map_err(|e| err(format!("stdout is not valid UTF-8: {e}")))?;
+    let lines: Vec<&str> = stdout.lines().collect();
+    let line = lines.get(line_idx).ok_or_else(|| {
+        err(format!(
+            "stdout has only {} line(s); cannot read line {}",
+            lines.len(),
+            line_idx
+        ))
+    })?;
+    let value: serde_json::Value =
+        serde_json::from_str(line).map_err(|e| err(format!("parse JSON line: {e}")))?;
+    let extracted = match value.get(key) {
+        Some(serde_json::Value::Null) | None => {
+            return Err(err(format!("key '{key}' not found in JSON")));
+        }
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    };
+    env.set_env_var(&format!("R_{key}"), &extracted);
+    Ok(())
+}
+
+fn cmd_mock_runs_server(
+    env: &mut testscript_rs::TestEnvironment,
+    args: &[String],
+) -> testscript_rs::Result<()> {
+    let empty = match args {
+        [] => false,
+        [mode] if mode == "empty" => true,
+        _ => {
+            return Err(err(
+                "mock-runs-server accepts either no arguments or 'empty'".to_string(),
+            ));
+        }
+    };
+
+    if is_staging() {
+        if empty {
+            return Err(err(
+                "mock-runs-server empty is not supported against staging; gate the block with [!staging]".to_string(),
+            ));
+        }
+        propagate_antithesis_env(env)?;
+        return Ok(());
+    }
+
+    let server = if empty {
+        MockApiServer::start_empty()
+    } else {
+        MockApiServer::start()
+    };
+    env.set_env_var("ANTITHESIS_BASE_URL", server.url());
+    env.set_env_var("ANTITHESIS_API_KEY", server.token());
+    env.set_env_var("ANTITHESIS_TENANT", "testtenant");
+    env.last_output = Some(std::process::Output {
+        status: std::process::ExitStatus::default(),
+        stdout: format!("{}\n", server.token()).into_bytes(),
+        stderr: Vec::new(),
+    });
+    std::mem::forget(server);
+    Ok(())
+}
+
+fn is_staging() -> bool {
+    std::env::var("SNOUTY_STAGING")
+        .ok()
+        .is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+fn propagate_antithesis_env(env: &mut testscript_rs::TestEnvironment) -> testscript_rs::Result<()> {
+    let tenant = std::env::var("ANTITHESIS_TENANT")
+        .map_err(|_| err("SNOUTY_STAGING is set but ANTITHESIS_TENANT is not".to_string()))?;
+    let has_bearer = std::env::var("ANTITHESIS_API_KEY").is_ok();
+    let has_basic = std::env::var("ANTITHESIS_USERNAME").is_ok()
+        && std::env::var("ANTITHESIS_PASSWORD").is_ok();
+    if !has_bearer && !has_basic {
+        return Err(err(
+            "SNOUTY_STAGING is set but no credentials found (set ANTITHESIS_API_KEY or ANTITHESIS_USERNAME+ANTITHESIS_PASSWORD)"
+                .to_string(),
+        ));
+    }
+    for var in [
+        "ANTITHESIS_BASE_URL",
+        "ANTITHESIS_API_KEY",
+        "ANTITHESIS_USERNAME",
+        "ANTITHESIS_PASSWORD",
+        "ANTITHESIS_TENANT",
+    ] {
+        env.env_vars.remove(var);
+    }
+    env.set_env_var("ANTITHESIS_TENANT", &tenant);
+    for var in [
+        "ANTITHESIS_BASE_URL",
+        "ANTITHESIS_API_KEY",
+        "ANTITHESIS_USERNAME",
+        "ANTITHESIS_PASSWORD",
+    ] {
+        if let Ok(v) = std::env::var(var) {
+            env.set_env_var(var, &v);
+        }
+    }
     Ok(())
 }
 
@@ -261,6 +394,7 @@ fn run_engine_spec_case(runtime_name: &'static str, case: EngineSpecCase) {
         })
         .command("snouty", cmd_snouty)
         .command("mock-server", cmd_mock_server)
+        .command("env_from_json", cmd_env_from_json)
         .command("build-image", cmd_build_image)
         .execute();
 
@@ -277,55 +411,75 @@ fn run_engine_spec_case(runtime_name: &'static str, case: EngineSpecCase) {
 
 #[test]
 fn spec_tests() {
-    let result = testscript::run("specs")
-        .setup(|env| {
-            env.set_env_var("RUST_LOG", "debug");
-            if let Some(path) = filtered_path_without_binary("snouty-update") {
-                env.set_env_var("PATH", &path);
-            }
-            Ok(())
-        })
-        .command("snouty", cmd_snouty)
-        .command("mock-server", cmd_mock_server)
-        .command("set-env", |env, args| {
-            // Usage: set-env KEY value...
-            // Interpolates ${VAR} references in value using env.env_vars.
-            if args.len() < 2 {
-                return Err(err("set-env requires KEY and value".to_string()));
-            }
-            let key = &args[0];
-            let raw_value = args[1..].join(" ");
-            let value = env.substitute_env_vars(&raw_value);
-            env.set_env_var(key, &value);
-            Ok(())
-        })
-        .command("snouty-bg", |env, args| {
-            let child = snouty_cmd(env, args)
-                .spawn()
-                .map_err(|e| err(format!("spawn snouty-bg: {e}")))?;
-            env.background_processes.insert("snouty".to_string(), child);
-            Ok(())
-        })
-        .command("setup-docs-db", |env, args| {
-            // Usage: setup-docs-db
-            // Copies the fixture docs.db into the workdir and sets ANTITHESIS_DOCS_DB_PATH.
-            let fixture =
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/docs.db");
-            let dest = env.work_dir.join("docs.db");
-            std::fs::copy(&fixture, &dest)
-                .map_err(|e| err(format!("failed to copy fixture docs.db: {e}")))?;
-            let var_name = if args.is_empty() {
-                "ANTITHESIS_DOCS_DB_PATH"
-            } else {
-                &args[0]
-            };
-            env.set_env_var(var_name, dest.to_str().unwrap());
-            Ok(())
-        })
-        .execute();
+    let staging = is_staging();
+    let specs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("specs");
+    let mut files: Vec<String> = std::fs::read_dir(&specs_dir)
+        .expect("read specs/")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    files.sort();
 
-    if let Err(e) = result {
-        panic!("\n{e}");
+    for file in files {
+        let result = testscript::run("specs")
+            .files([file.clone()])
+            .condition("staging", staging)
+            .setup(|env| {
+                env.set_env_var("RUST_LOG", "debug");
+                if let Some(path) = filtered_path_without_binary("snouty-update") {
+                    env.set_env_var("PATH", &path);
+                }
+                Ok(())
+            })
+            .command("snouty", cmd_snouty)
+            .command("mock-server", cmd_mock_server)
+            .command("mock-runs-server", cmd_mock_runs_server)
+            .command("env_from_json", cmd_env_from_json)
+            .command("set-env", |env, args| {
+                // Usage: set-env KEY value...
+                // Interpolates ${VAR} references in value using env.env_vars.
+                if args.len() < 2 {
+                    return Err(err("set-env requires KEY and value".to_string()));
+                }
+                let key = &args[0];
+                let raw_value = args[1..].join(" ");
+                let value = env.substitute_env_vars(&raw_value);
+                env.set_env_var(key, &value);
+                Ok(())
+            })
+            .command("snouty-bg", |env, args| {
+                let child = snouty_cmd(env, args)
+                    .spawn()
+                    .map_err(|e| err(format!("spawn snouty-bg: {e}")))?;
+                env.background_processes.insert("snouty".to_string(), child);
+                Ok(())
+            })
+            .command("setup-docs-db", |env, args| {
+                // Usage: setup-docs-db
+                // Copies the fixture docs.db into the workdir and sets ANTITHESIS_DOCS_DB_PATH.
+                let fixture =
+                    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/docs.db");
+                let dest = env.work_dir.join("docs.db");
+                std::fs::copy(&fixture, &dest)
+                    .map_err(|e| err(format!("failed to copy fixture docs.db: {e}")))?;
+                let var_name = if args.is_empty() {
+                    "ANTITHESIS_DOCS_DB_PATH"
+                } else {
+                    &args[0]
+                };
+                env.set_env_var(var_name, dest.to_str().unwrap());
+                Ok(())
+            })
+            .execute();
+
+        match result {
+            Ok(()) => {}
+            Err(e) if e.to_string().contains("SKIP:") => {
+                eprintln!("skipping {file}");
+            }
+            Err(e) => panic!("\n{e}"),
+        }
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -168,16 +168,6 @@ pub(crate) fn start_mock_server(response_body: &'static str, status: u16) -> Str
     url
 }
 
-pub(crate) fn expected_docs_user_agent() -> String {
-    format!(
-        "snouty/{} ({}; {}; rust{})",
-        env!("CARGO_PKG_VERSION"),
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-        env!("SNOUTY_RUSTC_VERSION")
-    )
-}
-
 pub(crate) fn cached_docs_db_path(cache_dir: &TempDir) -> PathBuf {
     cache_dir.path().join("snouty").join("docs.db")
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -220,11 +220,38 @@ pub(crate) fn docs_search_json(query_args: &[&str]) -> Vec<serde_json::Value> {
         .clone()
 }
 
+pub(crate) struct MockServer {
+    pub url: String,
+    pub token: String,
+}
+
+pub(crate) fn start_runs_server(empty: bool) -> MockServer {
+    let server = if empty {
+        snouty::testutils::MockApiServer::start_empty()
+    } else {
+        snouty::testutils::MockApiServer::start()
+    };
+    let mock = MockServer {
+        url: server.url().to_string(),
+        token: server.token().to_string(),
+    };
+    std::mem::forget(server);
+    mock
+}
+
 pub(crate) fn snouty_with_mock(mock_url: &str) -> Command {
     let mut cmd = snouty();
     cmd.env("ANTITHESIS_USERNAME", "testuser")
         .env("ANTITHESIS_PASSWORD", "testpass")
         .env("ANTITHESIS_TENANT", "testtenant")
         .env("ANTITHESIS_BASE_URL", mock_url);
+    cmd
+}
+
+pub(crate) fn snouty_with_mock_server(mock: &MockServer) -> Command {
+    let mut cmd = snouty();
+    cmd.env("ANTITHESIS_API_KEY", &mock.token)
+        .env("ANTITHESIS_TENANT", "testtenant")
+        .env("ANTITHESIS_BASE_URL", &mock.url);
     cmd
 }


### PR DESCRIPTION
Generate the API client from the OpenAPI spec at build time instead of maintaining bindings by hand. Building on that:

- add a `snouty runs` subcommand for listing and inspecting runs
- add an HTTP cache layer that honors Cache-Control and ETag so repeated reads can be served from disk or revalidated cheaply
- add a mock API harness so end-to-end tests can run offline, with `SNOUTY_STAGING=1` switching the same specs to hit a real backend

Existing CLI commands and their spec snapshots are updated to align with the generated types.