### PR TITLE
Port fault annotation from skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "http-cache-reqwest",
+ "indexmap",
  "json5",
  "jsonschema",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ color-eyre = { version = "0.6", default-features = false }
 futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util", "io-std", "signal"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
 console = "0.15"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util", "io-std", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-indexmap = { version = "2.2.3" }
+indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }
 console = "0.15"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util", "io-std", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+indexmap = { version = "2.2.3" }
 rusqlite = { version = "0.34", features = ["bundled"] }
 console = "0.15"
 dirs = "6"

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -184,7 +184,7 @@ stdout '311\.8487535319291.*\[control:assert\].*UNHIT AlwaysOrUnreachable "Count
 stdout '400\.5.*\[test_composer\].*task_status=started command=core/parallel_driver_fetch container_id=d700ef3d05a263 tasks_len=1'
 stdout '401\.5.*\[fault_injector\].*fault\.name=clog fault\.type=network fault\.details\.disruption_type=Stopped fault\.affected_nodes=client2,setup fault\.max_duration=0\.267'
 
-# `snouty --json runs logs` outputs raw NDJSON and annotates faults.
+# `snouty --json runs logs` outputs NDJSON with faults annotated.
 mock-runs-server
 snouty --json runs logs run-1 -123 1.0
 stdout 'output_text.*starting'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -186,7 +186,7 @@ stdout '401\.5.*\[fault_injector\].*fault\.name=clog fault\.type=network fault\.
 
 # `snouty --json runs logs` outputs raw NDJSON.
 mock-runs-server
-snouty --json runs logs run-1 -123 1.0
+snouty --json --annotate-faults runs logs run-1 -123 1.0
 stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -190,6 +190,8 @@ snouty --json runs logs run-1 -123 1.0
 stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
+stdout ''
+stdout '"active_faults".*"network_clog"'
 
 # `snouty --json runs logs` emits a record whose output_text contains
 # a JSON-escaped newline on a single output line.

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -184,13 +184,21 @@ stdout '311\.8487535319291.*\[control:assert\].*UNHIT AlwaysOrUnreachable "Count
 stdout '400\.5.*\[test_composer\].*task_status=started command=core/parallel_driver_fetch container_id=d700ef3d05a263 tasks_len=1'
 stdout '401\.5.*\[fault_injector\].*fault\.name=clog fault\.type=network fault\.details\.disruption_type=Stopped fault\.affected_nodes=client2,setup fault\.max_duration=0\.267'
 
-# `snouty --json runs logs` outputs raw NDJSON.
+# `snouty --json runs logs` outputs raw NDJSON and annotates faults.
 mock-runs-server
-snouty runs logs --json --annotate-faults run-1 -123 1.0
+snouty --json runs logs run-1 -123 1.0
 stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
 stdout '"active_faults".*"network_clog"'
+
+# NDJSON output fault annotation can be disabled.
+mock-runs-server
+snouty runs logs --json --disable-fault-annotation run-1 -123 1.0
+stdout 'output_text.*starting'
+stdout 'output_text.*slow request'
+stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
+! stdout '"active_faults".*"network_clog"'
 
 # `snouty --json runs logs` emits a record whose output_text contains
 # a JSON-escaped newline on a single output line.

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -190,7 +190,9 @@ snouty --json runs logs run-1 -123 1.0
 stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
-stdout '"active_faults".*"network_clog"'
+stdout '"vtime_seconds":401.5,"active_faults":\{"network_clog":\{"vtime":401.5\}\}'
+stdout '"vtime_seconds":401.75,"active_faults":\{"network_clog":\{"vtime":401.5\}\}'
+stdout '"vtime_seconds":402.0,"active_faults":\{\}'
 
 # NDJSON output fault annotation can be disabled.
 mock-runs-server

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -186,11 +186,10 @@ stdout '401\.5.*\[fault_injector\].*fault\.name=clog fault\.type=network fault\.
 
 # `snouty --json runs logs` outputs raw NDJSON.
 mock-runs-server
-snouty --json --annotate-faults runs logs run-1 -123 1.0
+snouty runs logs --json --annotate-faults run-1 -123 1.0
 stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
-stdout ''
 stdout '"active_faults".*"network_clog"'
 
 # `snouty --json runs logs` emits a record whose output_text contains

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,7 +352,7 @@ pub enum RunsCommands {
         run_id: String,
 
         /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, default_value_t = true)]
+        #[arg(long, default_value_t = false, requires = "json" )]
         annotate_faults: bool,
     },
 
@@ -377,7 +377,7 @@ pub enum RunsCommands {
         begin_input_hash: Option<String>,
 
         /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, default_value_t = true)]
+        #[arg(long, default_value_t = false, requires = "json" )]
         annotate_faults: bool,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,10 +389,6 @@ pub enum RunsCommands {
         /// Search query
         #[arg(required = true, num_args = 1..)]
         query: Vec<String>,
-
-        /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, default_value_t = true)]
-        annotate_faults: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,6 +350,10 @@ pub enum RunsCommands {
     BuildLogs {
         /// Run ID
         run_id: String,
+
+        /// Whether to annotate faults that appear in individual log lines
+        #[arg(long, default_value_t = true)]
+        annotate_faults: bool,
     },
 
     /// Stream moment logs for a run
@@ -371,6 +375,10 @@ pub enum RunsCommands {
         /// Start streaming from this input hash (optimization; must be paired with --begin-vtime)
         #[arg(long, allow_hyphen_values = true, requires = "begin_vtime")]
         begin_input_hash: Option<String>,
+
+        /// Whether to annotate faults that appear in individual log lines
+        #[arg(long, default_value_t = true)]
+        annotate_faults: bool,
     },
 
     /// Search events in a run
@@ -381,6 +389,10 @@ pub enum RunsCommands {
         /// Search query
         #[arg(required = true, num_args = 1..)]
         query: Vec<String>,
+
+        /// Whether to annotate faults that appear in individual log lines
+        #[arg(long, default_value_t = true)]
+        annotate_faults: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,10 +350,6 @@ pub enum RunsCommands {
     BuildLogs {
         /// Run ID
         run_id: String,
-
-        /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, requires = "json")]
-        annotate_faults: bool,
     },
 
     /// Stream moment logs for a run
@@ -376,9 +372,9 @@ pub enum RunsCommands {
         #[arg(long, allow_hyphen_values = true, requires = "begin_vtime")]
         begin_input_hash: Option<String>,
 
-        /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, requires = "json")]
-        annotate_faults: bool,
+        /// Whether to disable fault annotation (tracking of which faults are active for any given log line)
+        #[arg(long)]
+        disable_fault_annotation: bool,
     },
 
     /// Search events in a run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -372,7 +372,7 @@ pub enum RunsCommands {
         #[arg(long, allow_hyphen_values = true, requires = "begin_vtime")]
         begin_input_hash: Option<String>,
 
-        /// Whether to disable fault annotation (tracking of which faults are active for any given log line)
+        /// Whether to disable fault annotation (tracking of which faults are active for any given log line). Fault annotation only applies to NDJSON output, so this flag has no effect unless combined with `--json` (which annotates faults by default).
         #[arg(long)]
         disable_fault_annotation: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,7 +352,7 @@ pub enum RunsCommands {
         run_id: String,
 
         /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, default_value_t = false, requires = "json" )]
+        #[arg(long, requires = "json")]
         annotate_faults: bool,
     },
 
@@ -377,7 +377,7 @@ pub enum RunsCommands {
         begin_input_hash: Option<String>,
 
         /// Whether to annotate faults that appear in individual log lines
-        #[arg(long, default_value_t = false, requires = "json" )]
+        #[arg(long, requires = "json")]
         annotate_faults: bool,
     },
 

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -37,19 +37,8 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             };
             cmd_runs_properties(&run_id, status, json, verbose).await
         }
-        Some(RunsCommands::BuildLogs {
-            run_id,
-            annotate_faults,
-        }) => {
-            cmd_runs_build_logs(
-                &run_id,
-                LogOutputOptions {
-                    json,
-                    verbose,
-                    annotate_faults,
-                },
-            )
-            .await
+        Some(RunsCommands::BuildLogs { run_id }) => {
+            cmd_runs_build_logs(&run_id, json, verbose).await
         }
         Some(RunsCommands::Logs {
             run_id,
@@ -57,7 +46,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             vtime,
             begin_vtime,
             begin_input_hash,
-            annotate_faults,
+            disable_fault_annotation,
         }) => {
             cmd_runs_logs(
                 &run_id,
@@ -68,7 +57,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
                 LogOutputOptions {
                     json,
                     verbose,
-                    annotate_faults,
+                    annotate_faults: !disable_fault_annotation,
                 },
             )
             .await
@@ -247,14 +236,7 @@ struct LogOutputOptions {
     annotate_faults: bool,
 }
 
-async fn cmd_runs_build_logs(
-    run_id: &str,
-    LogOutputOptions {
-        json,
-        verbose,
-        annotate_faults,
-    }: LogOutputOptions,
-) -> Result<()> {
+async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;
@@ -262,26 +244,11 @@ async fn cmd_runs_build_logs(
     let mut stdout = std::io::stdout().lock();
 
     if json {
-        if annotate_faults {
-            stream_ndjson_lines(
-                stream,
-                FaultAnnotator {
-                    active_fault_windows: LinkedList::new(),
-                    active_faults: json!({}),
-                },
-                |line| {
-                    writeln!(stdout, "{line}")?;
-                    Ok(())
-                },
-            )
-            .await
-        } else {
-            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-                writeln!(stdout, "{line}")?;
-                Ok(())
-            })
-            .await
-        }
+        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+            writeln!(stdout, "{line}")?;
+            Ok(())
+        })
+        .await
     } else {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -439,8 +439,9 @@ impl LineTransformer for FaultAnnotator {
             let vtime_node = entry["moment"]["vtime"]
                 .as_str()
                 .and_then(|seconds_string| seconds_string.parse::<f64>().ok());
-            let event_vtime_ticks = vtime_ticks_node
-                .or_else(|| vtime_node.map(|seconds| (seconds * TICKS_PER_SECOND) as u64))
+            let event_vtime_ticks = vtime_node
+                .map(|seconds| (seconds * TICKS_PER_SECOND) as u64)
+                .or(vtime_ticks_node)
                 .unwrap_or(0);
             let fault_name = entry["fault"]["name"].as_str();
             let is_fault_injector = entry["source"]["name"]
@@ -476,7 +477,7 @@ impl LineTransformer for FaultAnnotator {
             if is_fault_injector && let Some(fault_name) = fault_name {
                 let max_duration_ticks = entry["fault"]["max_duration"]
                     .as_f64()
-                    .filter(|d| *d >= 0.0)
+                    .filter(|d| *d > 0.0)
                     .map(|d| (d * TICKS_PER_SECOND) as u64);
                 let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
                 let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
@@ -534,9 +535,11 @@ impl LineTransformer for FaultAnnotator {
             if vtime_ticks_node.is_some() || vtime_node.is_some() {
                 entry["vtime_seconds"] = json!((event_vtime_ticks as f64) / TICKS_PER_SECOND);
             }
-            entry["active_faults"] = self.active_faults.clone();
 
-            return Some(format!("{}", entry));
+            if entry.is_object() {
+                entry["active_faults"] = self.active_faults.clone();
+                return Some(format!("{}", entry));
+            }
         }
 
         None

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -469,7 +469,11 @@ impl LineTransformer for FaultAnnotator {
         if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
             let mut update_faults;
 
-            let event_vtime_ticks = entry["moment"]["_vtime_ticks"].as_u64().unwrap_or(0);
+            let vtime_ticks_node = entry["moment"]["_vtime_ticks"].as_u64();
+            let vtime_node = entry["moment"]["vtime"].as_f64();
+            let event_vtime_ticks = vtime_ticks_node
+                .or_else(|| vtime_node.map(|seconds| (seconds * TICKS_PER_SECOND) as u64))
+                .unwrap_or(0);
             let fault_name = entry["fault"]["name"].as_str();
             let is_fault_injector = entry["source"]["name"]
                 .as_str()
@@ -511,6 +515,9 @@ impl LineTransformer for FaultAnnotator {
 
             if let Some(output_text) = entry["output_text"].as_str() {
                 entry["output_text"] = Value::String(strip_ansi(output_text));
+            }
+            if vtime_ticks_node.is_some() || vtime_node.is_some() {
+                entry["vtime_seconds"] = json!((event_vtime_ticks as f64) / TICKS_PER_SECOND);
             }
             entry["active_faults"] = self.active_faults.clone();
 
@@ -724,7 +731,10 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
     }
 
     for entry in network_fault_starts {
-        result.insert(entry.0, json!((entry.1 as f64) / TICKS_PER_SECOND));
+        result.insert(
+            entry.0,
+            json!({"vtime": (entry.1 as f64) / TICKS_PER_SECOND}),
+        );
     }
 
     for entry in node_faults {
@@ -1764,13 +1774,16 @@ mod tests {
                     "max_duration": 10
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"],\"max_duration\":10},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"],\"max_duration\":10},\"vtime_seconds\":1.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0}}}".to_string())
         );
 
         // Another log message; should retain active window state since the log message had no timestamp
         assert_eq!(
             transformer.try_transform("{\"foo\":\"bar\"}"),
-            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0}}".to_string())
+            Some(
+                "{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":{\"vtime\":1.0}}}"
+                    .to_string()
+            )
         );
 
         // Open a node throttled fault window
@@ -1789,7 +1802,7 @@ mod tests {
                     "max_duration": 9
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"],\"max_duration\":9},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"],\"max_duration\":9},\"vtime_seconds\":2.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Another non-fault injector message; should retain state
@@ -1800,7 +1813,7 @@ mod tests {
                 },
                 "foo": "bar"
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":47244640256},\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":47244640256},\"foo\":\"bar\",\"vtime_seconds\":11.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Expire both windows
@@ -1815,7 +1828,7 @@ mod tests {
                 })
             )),
             Some(
-                "{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"active_faults\":{}}"
+                "{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"vtime_seconds\":11.00000000023283,\"active_faults\":{}}"
                     .to_string()
             )
         );
@@ -1843,7 +1856,7 @@ mod tests {
                     "affected_nodes": ["a", "b"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"vtime_seconds\":1.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0}}}".to_string())
         );
 
         // Open a node throttled fault window
@@ -1861,7 +1874,7 @@ mod tests {
                     "affected_nodes": ["c"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"vtime_seconds\":2.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Open a network clog fault window
@@ -1879,13 +1892,13 @@ mod tests {
                     "affected_nodes": ["b", "c"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"vtime_seconds\":3.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"network_clog\":{\"vtime\":3.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Verify that state is retained for a non-control log message
         assert_eq!(
             transformer.try_transform(&format!("{}", json!({"foo": "bar"}))),
-            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"network_clog\":{\"vtime\":3.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Send a network restore message
@@ -1925,7 +1938,7 @@ mod tests {
                     "affected_nodes": ["a", "b"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"vtime_seconds\":1.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0}}}".to_string())
         );
 
         // Open a node throttled fault window
@@ -1943,7 +1956,7 @@ mod tests {
                     "affected_nodes": ["c"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"vtime_seconds\":2.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Open a network clog fault window
@@ -1961,7 +1974,7 @@ mod tests {
                     "affected_nodes": ["b", "c"]
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"vtime_seconds\":3.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"network_clog\":{\"vtime\":3.0},\"node_throttle\":{\"c\":2.0}}}".to_string())
         );
 
         // Open a clock fault window
@@ -1981,13 +1994,13 @@ mod tests {
                     }
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":17179869184},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":17179869184},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"vtime_seconds\":4.0,\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"network_clog\":{\"vtime\":3.0},\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
         );
 
         // Verify that state is retained for a non-control log message
         assert_eq!(
             transformer.try_transform(&format!("{}", json!({"foo": "bar"}))),
-            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
+            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":{\"vtime\":1.0},\"network_clog\":{\"vtime\":3.0},\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
         );
 
         // Send a fault injector pause message
@@ -2031,7 +2044,7 @@ mod tests {
                     }
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":1.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"vtime_seconds\":1.0,\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":1.0}}}".to_string())
         );
 
         // Open a node throttled fault window
@@ -2051,7 +2064,7 @@ mod tests {
                     }
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":0.1}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.6,\"vtime\":2.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":0.1}},\"vtime_seconds\":2.0,\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.6,\"vtime\":2.0}}}".to_string())
         );
 
         // Open a network clog fault window
@@ -2071,7 +2084,7 @@ mod tests {
                     }
                 }
             }))),
-            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":-2.3}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":8.3,\"vtime\":3.0}}}".to_string())
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":-2.3}},\"vtime_seconds\":3.0,\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":8.3,\"vtime\":3.0}}}".to_string())
         );
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -61,10 +61,9 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             )
             .await
         }
-        Some(RunsCommands::Events {
-            run_id,
-            query,
-        }) => cmd_runs_events(&run_id, &query, json, verbose).await,
+        Some(RunsCommands::Events { run_id, query }) => {
+            cmd_runs_events(&run_id, &query, json, verbose).await
+        }
     }
 }
 
@@ -279,12 +278,7 @@ async fn cmd_runs_build_logs(
     }
 }
 
-async fn cmd_runs_events(
-    run_id: &str,
-    query: &[String],
-    json: bool,
-    verbose: bool,
-) -> Result<()> {
+async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -2087,4 +2087,776 @@ mod tests {
             Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":-2.3}},\"vtime_seconds\":3.0,\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":8.3,\"vtime\":3.0}}}".to_string())
         );
     }
+
+    #[test]
+    fn empty_affected_nodes_does_not_open_network_window() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // Open a real window first
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "clog",
+                    "type": "network",
+                    "affected_nodes": ["node-1"],
+                    "max_duration": 100
+                }
+            })
+        ));
+
+        // Empty affected_nodes: try_get_fault_window_definition returns None,
+        // so no new window is pushed and the existing one is unchanged.
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 2u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": {
+                        "name": "clog",
+                        "type": "network",
+                        "affected_nodes": []
+                    }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":8589934592},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"clog","type":"network","affected_nodes":[]},"#,
+                    r#""vtime_seconds":2.0,"active_faults":{"network_clog":{"vtime":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn missing_affected_nodes_does_not_open_network_window() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // Open a real window first
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 100
+                }
+            })
+        ));
+
+        // No affected_nodes field at all: same result — no new window
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 2u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": {
+                        "name": "partition",
+                        "type": "network"
+                    }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":8589934592},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"partition","type":"network"},"#,
+                    r#""vtime_seconds":2.0,"active_faults":{"network_partition":{"vtime":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: untracked fault names produce no window
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn untracked_fault_names_produce_empty_active_faults() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 1u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": { "name": "kill" }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":4294967296},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"kill"},"#,
+                    r#""vtime_seconds":1.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 2u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": { "name": "stop" }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":8589934592},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"stop"},"#,
+                    r#""vtime_seconds":2.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn restore_after_only_untracked_faults_is_noop() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": { "name": "kill" }
+            })
+        ));
+
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 2u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": {
+                        "name": "restore",
+                        "type": "network",
+                        "affected_nodes": ["ALL"]
+                    }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":8589934592},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"restore","type":"network","affected_nodes":["ALL"]},"#,
+                    r#""vtime_seconds":2.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: non-fault_injector sources do not open windows
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fault_fields_from_non_fault_injector_source_are_ignored() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "some_other_source" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"]
+                }
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":4294967296},"source":{"name":"some_other_source"},"#,
+                r#""fault":{"name":"partition","type":"network","affected_nodes":["ALL"]},"#,
+                r#""vtime_seconds":1.0,"active_faults":{}}"#
+            ).to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: event without _vtime_ticks still gets active_faults
+    // (and does not get vtime_seconds)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn event_without_vtime_ticks_still_gets_active_faults() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // Open a partition window at a known vtime
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"]
+                }
+            })
+        ));
+
+        // Event with no moment at all: no expiry check, no vtime_seconds, but active_faults injected
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({"output_text": "no moment here"}))),
+            Some(
+                concat!(
+                    r#"{"output_text":"no moment here","#,
+                    r#""active_faults":{"network_partition":{"vtime":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: natural expiration — boundary semantics
+    //
+    // is_expired uses strict less-than: end_vtime < latest_vtime.
+    // So at exactly end_vtime ticks the window is still active; it expires
+    // only when the next message arrives with a strictly greater vtime.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fault_window_active_at_exact_end_vtime_expires_one_tick_later() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // partition at 5<<32, max_duration=5s → end_vtime = (5+5)<<32 = 10<<32
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 5u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 5
+                }
+            })
+        ));
+
+        // At exactly end_vtime (10<<32): window is still active (end < latest is false when equal)
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 10u64 << 32 },
+                    "output_text": "at exact end"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":42949672960},"output_text":"at exact end","#,
+                    r#""vtime_seconds":10.0,"active_faults":{"network_partition":{"vtime":5.0}}}"#
+                )
+                .to_string()
+            )
+        );
+
+        // One tick past end_vtime: now expired
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": (10u64 << 32) + 1 },
+                    "output_text": "just past end"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":42949672961},"output_text":"just past end","#,
+                    r#""vtime_seconds":10.00000000023283,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: partition without max_duration never expires naturally
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn partition_without_max_duration_never_expires() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"]
+                    // no max_duration → end_vtime = None → is_expired always false
+                }
+            })
+        ));
+
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 1000u64 << 32 },
+                    "output_text": "much later"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":4294967296000},"output_text":"much later","#,
+                    r#""vtime_seconds":1000.0,"active_faults":{"network_partition":{"vtime":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: restore before natural expiration clears network faults
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn restore_before_natural_expiration_clears_network_faults() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 100
+                }
+            })
+        ));
+
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 5u64 << 32 },
+                    "source": { "name": "fault_injector" },
+                    "fault": {
+                        "name": "restore",
+                        "type": "network",
+                        "affected_nodes": ["ALL"]
+                    }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":21474836480},"source":{"name":"fault_injector"},"#,
+                    r#""fault":{"name":"restore","type":"network","affected_nodes":["ALL"]},"#,
+                    r#""vtime_seconds":5.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: partition and clog expire independently
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn partition_and_clog_expire_independently() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // Partition at vtime 5, max_duration=20 → expires after 25<<32
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 5u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 20
+                }
+            })
+        ));
+
+        // Clog at vtime 10, max_duration=3 → expires after 13<<32
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 10u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "clog",
+                    "type": "network",
+                    "affected_nodes": ["A"],
+                    "max_duration": 3
+                }
+            })
+        ));
+
+        // At vtime 14: clog's end_vtime (13<<32) < 14<<32, so it expires; partition still active
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 14u64 << 32 },
+                    "output_text": "clog expired, partition still active"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":60129542144},"#,
+                    r#""output_text":"clog expired, partition still active","#,
+                    r#""vtime_seconds":14.0,"active_faults":{"network_partition":{"vtime":5.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: non-overlapping windows — first expires, new one
+    // starts fresh with the new start_vtime
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn non_overlapping_windows_start_fresh_after_expiry() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // First window: vtime 1, max_duration=3 → expires after 4<<32
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 3
+                }
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":4294967296},"source":{"name":"fault_injector"},"#,
+                r#""fault":{"name":"partition","type":"network","affected_nodes":["ALL"],"max_duration":3},"#,
+                r#""vtime_seconds":1.0,"active_faults":{"network_partition":{"vtime":1.0}}}"#
+            ).to_string())
+        );
+
+        // Second window at vtime 5, after the first has expired (5<<32 > 4<<32):
+        // the old window is pruned before the new one is pushed, so the snapshot
+        // reflects only the new window's start_vtime.
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 5u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 3
+                }
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":21474836480},"source":{"name":"fault_injector"},"#,
+                r#""fault":{"name":"partition","type":"network","affected_nodes":["ALL"],"max_duration":3},"#,
+                r#""vtime_seconds":5.0,"active_faults":{"network_partition":{"vtime":5.0}}}"#
+            ).to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: overlapping same-name windows — active_fault_dictionary
+    // reports the earliest start_vtime among all live windows
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn overlapping_windows_report_earliest_start_vtime() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // First partition at vtime 10, max_duration=5 → expires after 15<<32
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 10u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 5
+                }
+            })
+        ));
+
+        // Second partition at vtime 14 (overlapping), max_duration=5 → expires after 19<<32
+        // Both windows are alive; active_fault_dictionary picks the min start_vtime (10)
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 14u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 5
+                }
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":60129542144},"source":{"name":"fault_injector"},"#,
+                r#""fault":{"name":"partition","type":"network","affected_nodes":["ALL"],"max_duration":5},"#,
+                r#""vtime_seconds":14.0,"active_faults":{"network_partition":{"vtime":10.0}}}"#
+            ).to_string())
+        );
+
+        // At vtime 16: first window expired (15<<32 < 16<<32), second still alive (19<<32 not < 16<<32)
+        // Now only the second window remains; start_vtime becomes 14
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 16u64 << 32 },
+                "output_text": "after first window expired"
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":68719476736},"output_text":"after first window expired","#,
+                r#""vtime_seconds":16.0,"active_faults":{"network_partition":{"vtime":14.0}}}"#
+            ).to_string())
+        );
+
+        // At vtime 20: second window also expired (19<<32 < 20<<32)
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 20u64 << 32 },
+                    "output_text": "after both expired"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":85899345920},"output_text":"after both expired","#,
+                    r#""vtime_seconds":20.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: pause preserves clock windows
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fault_injector_pause_preserves_clock_windows() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "skip",
+                    "type": "clock",
+                    "details": { "offset": 10.0 }
+                }
+            })
+        ));
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 2u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["ALL"],
+                    "max_duration": 100
+                }
+            })
+        ));
+
+        // Pause clears network and node windows; clock survives
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "source": { "name": "fault_injector" },
+                    "info": {
+                        "message": "status",
+                        "details": { "paused": true }
+                    }
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"source":{"name":"fault_injector"},"#,
+                    r#""info":{"message":"status","details":{"paused":true}},"#,
+                    r#""active_faults":{"clock_skip":{"cumulative_offset":10.0,"vtime":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: multiple node containers tracked simultaneously
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multiple_containers_paused_simultaneously() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "pause",
+                    "type": "node",
+                    "affected_nodes": ["A"],
+                    "max_duration": 100
+                }
+            })
+        ));
+
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": { "_vtime_ticks": 2u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "pause",
+                    "type": "node",
+                    "affected_nodes": ["B"],
+                    "max_duration": 100
+                }
+            }))),
+            Some(concat!(
+                r#"{"moment":{"_vtime_ticks":8589934592},"source":{"name":"fault_injector"},"#,
+                r#""fault":{"name":"pause","type":"node","affected_nodes":["B"],"max_duration":100},"#,
+                r#""vtime_seconds":2.0,"active_faults":{"node_pause":{"A":1.0,"B":2.0}}}"#
+            ).to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // active_faults: node fault expires via max_duration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn node_fault_expires_via_max_duration() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
+
+        // Throttle C at vtime 1, max_duration=5 → expires after 6<<32
+        transformer.try_transform(&format!(
+            "{}",
+            json!({
+                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "source": { "name": "fault_injector" },
+                "fault": {
+                    "name": "throttle",
+                    "type": "node",
+                    "affected_nodes": ["C"],
+                    "max_duration": 5
+                }
+            })
+        ));
+
+        // Mid-window at vtime 3: still active
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 3u64 << 32 },
+                    "output_text": "mid-window"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":12884901888},"output_text":"mid-window","#,
+                    r#""vtime_seconds":3.0,"active_faults":{"node_throttle":{"C":1.0}}}"#
+                )
+                .to_string()
+            )
+        );
+
+        // After expiry at vtime 7 (6<<32 < 7<<32): empty
+        assert_eq!(
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": { "_vtime_ticks": 7u64 << 32 },
+                    "output_text": "after expiry"
+                })
+            )),
+            Some(
+                concat!(
+                    r#"{"moment":{"_vtime_ticks":30064771072},"output_text":"after expiry","#,
+                    r#""vtime_seconds":7.0,"active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,4 +1,3 @@
-use std::collections::LinkedList;
 use std::path::Path;
 use std::{io::Write, sync::OnceLock};
 
@@ -333,7 +332,7 @@ async fn cmd_runs_logs(
             stream_ndjson_lines(
                 stream,
                 FaultAnnotator {
-                    active_fault_windows: LinkedList::new(),
+                    active_fault_windows: Vec::new(),
                     active_faults: json!({}),
                 },
                 |line| {
@@ -427,7 +426,7 @@ impl LineTransformer for NoOpTransformer {
 }
 
 struct FaultAnnotator {
-    active_fault_windows: LinkedList<FaultWindow>,
+    active_fault_windows: Vec<FaultWindow>,
     active_faults: Value,
 }
 
@@ -437,7 +436,9 @@ impl LineTransformer for FaultAnnotator {
             let mut update_faults;
 
             let vtime_ticks_node = entry["moment"]["_vtime_ticks"].as_u64();
-            let vtime_node = entry["moment"]["vtime"].as_f64();
+            let vtime_node = entry["moment"]["vtime"]
+                .as_str()
+                .and_then(|seconds_string| seconds_string.parse::<f64>().ok());
             let event_vtime_ticks = vtime_ticks_node
                 .or_else(|| vtime_node.map(|seconds| (seconds * TICKS_PER_SECOND) as u64))
                 .unwrap_or(0);
@@ -459,20 +460,28 @@ impl LineTransformer for FaultAnnotator {
 
             // clear any fault windows that are expired or mooted by fault injector pauses
             let length_before_cleanup = self.active_fault_windows.len();
-            self.active_fault_windows
-                .extract_if(|w| {
-                    w.is_expired(event_vtime_ticks)
-                        || (faults_were_paused && (w.is_network_fault() || w.is_node_fault()))
-                        || (is_restore_event && w.is_network_fault())
-                })
-                .for_each(drop);
+            self.active_fault_windows.retain(|w| {
+                if w.is_expired(event_vtime_ticks) {
+                    return false;
+                }
+
+                if faults_were_paused && (w.is_network_fault() || w.is_node_fault()) {
+                    return false;
+                }
+
+                if is_restore_event && w.is_network_fault() {
+                    return false;
+                }
+
+                true
+            });
             update_faults = length_before_cleanup != self.active_fault_windows.len();
 
             if is_fault_injector
                 && let Some(new_window) =
                     try_get_fault_window_definition(&entry, event_vtime_ticks, fault_name)
             {
-                self.active_fault_windows.push_back(new_window);
+                self.active_fault_windows.push(new_window);
                 update_faults = true;
             }
 
@@ -645,7 +654,7 @@ fn strip_ansi(text: &str) -> String {
     ansi_re().replace_all(text, "").to_string()
 }
 
-fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
+fn active_fault_dictionary(open_windows: &Vec<FaultWindow>) -> Value {
     let mut result = Map::new();
     let mut offset_sum = 0f64;
     let mut max_clock_fault_start: Option<u64> = None;
@@ -1715,7 +1724,7 @@ mod tests {
     #[test]
     fn tracks_which_faults_are_active_based_on_vtime_and_max_duration() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -1804,7 +1813,7 @@ mod tests {
     #[test]
     fn restore_closes_network_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -1886,7 +1895,7 @@ mod tests {
     #[test]
     fn fault_injector_pause_clears_network_and_node_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -1990,7 +1999,7 @@ mod tests {
     #[test]
     fn clock_offsets_are_combined() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2058,7 +2067,7 @@ mod tests {
     #[test]
     fn empty_affected_nodes_does_not_open_network_window() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2106,7 +2115,7 @@ mod tests {
     #[test]
     fn missing_affected_nodes_does_not_open_network_window() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2156,7 +2165,7 @@ mod tests {
     #[test]
     fn untracked_fault_names_produce_empty_active_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2202,7 +2211,7 @@ mod tests {
     #[test]
     fn restore_after_only_untracked_faults_is_noop() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2246,7 +2255,7 @@ mod tests {
     #[test]
     fn fault_fields_from_non_fault_injector_source_are_ignored() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2276,7 +2285,7 @@ mod tests {
     #[test]
     fn event_without_vtime_ticks_still_gets_active_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2318,7 +2327,7 @@ mod tests {
     #[test]
     fn fault_window_active_at_exact_end_vtime_expires_one_tick_later() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2381,7 +2390,7 @@ mod tests {
     #[test]
     fn partition_without_max_duration_never_expires() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2424,7 +2433,7 @@ mod tests {
     #[test]
     fn restore_before_natural_expiration_clears_network_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2473,7 +2482,7 @@ mod tests {
     #[test]
     fn partition_and_clog_expire_independently() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2535,7 +2544,7 @@ mod tests {
     #[test]
     fn non_overlapping_windows_start_fresh_after_expiry() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2588,7 +2597,7 @@ mod tests {
     #[test]
     fn overlapping_windows_report_earliest_start_vtime() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2666,7 +2675,7 @@ mod tests {
     #[test]
     fn fault_injector_pause_preserves_clock_windows() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2727,7 +2736,7 @@ mod tests {
     #[test]
     fn multiple_containers_paused_simultaneously() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2771,7 +2780,7 @@ mod tests {
     #[test]
     fn node_fault_expires_via_max_duration() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: LinkedList::new(),
+            active_fault_windows: Vec::new(),
             active_faults: json!({}),
         };
 
@@ -2779,7 +2788,7 @@ mod tests {
         transformer.try_transform(&format!(
             "{}",
             json!({
-                "moment": { "_vtime_ticks": 1u64 << 32 },
+                "moment": { "vtime": "1" },
                 "source": { "name": "fault_injector" },
                 "fault": {
                     "name": "throttle",
@@ -2795,13 +2804,13 @@ mod tests {
             transformer.try_transform(&format!(
                 "{}",
                 json!({
-                    "moment": { "_vtime_ticks": 3u64 << 32 },
+                    "moment": { "vtime": "3.0" },
                     "output_text": "mid-window"
                 })
             )),
             Some(
                 concat!(
-                    r#"{"moment":{"_vtime_ticks":12884901888},"output_text":"mid-window","#,
+                    r#"{"moment":{"vtime":"3.0"},"output_text":"mid-window","#,
                     r#""vtime_seconds":3.0,"active_faults":{"node_throttle":{"C":1.0}}}"#
                 )
                 .to_string()

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -484,7 +484,7 @@ impl LineTransformer for FaultAnnotator {
                 && entry["info"]["details"]["paused"]
                     .as_bool()
                     .unwrap_or(false);
-            let is_restore_event = fault_name.map(|n| n.eq("restore")).unwrap_or(false);
+            let is_restore_event = is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false);
 
             // clear any fault windows that are expired or mooted by fault injector pauses
             let length_before_cleanup = self.active_fault_windows.len();
@@ -499,7 +499,7 @@ impl LineTransformer for FaultAnnotator {
 
             if is_fault_injector
                 && let Some(new_window) =
-                    try_get_fault_window_defintion(&entry, event_vtime_ticks, fault_name)
+                    try_get_fault_window_definition(&entry, event_vtime_ticks, fault_name)
             {
                 self.active_fault_windows.push_back(new_window);
                 update_faults = true;
@@ -521,7 +521,7 @@ impl LineTransformer for FaultAnnotator {
     }
 }
 
-fn try_get_fault_window_defintion(
+fn try_get_fault_window_definition(
     entry: &Value,
     event_vtime_ticks: u64,
     maybe_fault_name: Option<&str>,

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,6 +1,6 @@
-use std::collections::{LinkedList};
-use std::{io::Write, sync::OnceLock};
+use std::collections::LinkedList;
 use std::path::Path;
+use std::{io::Write, sync::OnceLock};
 
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
@@ -37,9 +37,10 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             };
             cmd_runs_properties(&run_id, status, json, verbose).await
         }
-        Some(RunsCommands::BuildLogs { run_id, annotate_faults }) => {
-            cmd_runs_build_logs(&run_id, json, verbose, annotate_faults).await
-        }
+        Some(RunsCommands::BuildLogs {
+            run_id,
+            annotate_faults,
+        }) => cmd_runs_build_logs(&run_id, json, verbose, annotate_faults).await,
         Some(RunsCommands::Logs {
             run_id,
             input_hash,
@@ -60,9 +61,11 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             )
             .await
         }
-        Some(RunsCommands::Events { run_id, query, annotate_faults }) => {
-            cmd_runs_events(&run_id, &query, json, verbose, annotate_faults).await
-        }
+        Some(RunsCommands::Events {
+            run_id,
+            query,
+            annotate_faults,
+        }) => cmd_runs_events(&run_id, &query, json, verbose, annotate_faults).await,
     }
 }
 
@@ -228,7 +231,12 @@ fn print_run_detail(run: &RunDetail) {
     }
 }
 
-async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool, annotate_faults: bool) -> Result<()> {
+async fn cmd_runs_build_logs(
+    run_id: &str,
+    json: bool,
+    verbose: bool,
+    annotate_faults: bool,
+) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;
@@ -237,10 +245,17 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool, annotate_f
 
     if json {
         if annotate_faults {
-            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
-                writeln!(stdout, "{line}")?;
-                Ok(())
-            })
+            stream_ndjson_lines(
+                stream,
+                FaultAnnotator {
+                    active_fault_windows: LinkedList::new(),
+                    active_faults: json!({}),
+                },
+                |line| {
+                    writeln!(stdout, "{line}")?;
+                    Ok(())
+                },
+            )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
@@ -265,7 +280,13 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool, annotate_f
     }
 }
 
-async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool, annotate_faults: bool) -> Result<()> {
+async fn cmd_runs_events(
+    run_id: &str,
+    query: &[String],
+    json: bool,
+    verbose: bool,
+    annotate_faults: bool,
+) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;
@@ -277,10 +298,17 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
     let mut stdout = std::io::stdout().lock();
     if json {
         if annotate_faults {
-            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
-                writeln!(stdout, "{line}")?;
-                Ok(())
-            })
+            stream_ndjson_lines(
+                stream,
+                FaultAnnotator {
+                    active_fault_windows: LinkedList::new(),
+                    active_faults: json!({}),
+                },
+                |line| {
+                    writeln!(stdout, "{line}")?;
+                    Ok(())
+                },
+            )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
@@ -323,7 +351,7 @@ async fn cmd_runs_logs(
     begin_vtime: Option<&str>,
     json: bool,
     verbose: bool,
-    annotate_faults: bool
+    annotate_faults: bool,
 ) -> Result<()> {
     debug!("streaming logs for run: {}", run_id);
 
@@ -336,10 +364,17 @@ async fn cmd_runs_logs(
     let mut stdout = std::io::stdout().lock();
     if json {
         if annotate_faults {
-            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
-                writeln!(stdout, "{line}")?;
-                Ok(())
-            })
+            stream_ndjson_lines(
+                stream,
+                FaultAnnotator {
+                    active_fault_windows: LinkedList::new(),
+                    active_faults: json!({}),
+                },
+                |line| {
+                    writeln!(stdout, "{line}")?;
+                    Ok(())
+                },
+            )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
@@ -436,23 +471,36 @@ impl LineTransformer for FaultAnnotator {
             let mut update_faults;
 
             let event_vtime_ticks = entry["moment"]["_vtime_ticks"].as_u64().unwrap_or(0);
-            let fault_name =  entry["fault"]["name"].as_str();
-            let is_fault_injector = entry["source"]["name"].as_str().map(|source| source.eq("fault_injector")).unwrap_or(false);
-            let faults_were_paused = is_fault_injector && 
-                entry["info"]["message"].as_str().map(|message| message.eq("status")).unwrap_or(false) &&
-                entry["info"]["details"]["paused"].as_bool().unwrap_or(false);
+            let fault_name = entry["fault"]["name"].as_str();
+            let is_fault_injector = entry["source"]["name"]
+                .as_str()
+                .map(|source| source.eq("fault_injector"))
+                .unwrap_or(false);
+            let faults_were_paused = is_fault_injector
+                && entry["info"]["message"]
+                    .as_str()
+                    .map(|message| message.eq("status"))
+                    .unwrap_or(false)
+                && entry["info"]["details"]["paused"]
+                    .as_bool()
+                    .unwrap_or(false);
             let is_restore_event = fault_name.map(|n| n.eq("restore")).unwrap_or(false);
 
             // clear any fault windows that are expired or mooted by fault injector pauses
             let length_before_cleanup = self.active_fault_windows.len();
             self.active_fault_windows
-                .extract_if(|w| w.is_expired(event_vtime_ticks) ||
-                    (faults_were_paused && (w.is_network_fault() || w.is_node_fault())) ||
-                    (is_restore_event && w.is_network_fault()))
+                .extract_if(|w| {
+                    w.is_expired(event_vtime_ticks)
+                        || (faults_were_paused && (w.is_network_fault() || w.is_node_fault()))
+                        || (is_restore_event && w.is_network_fault())
+                })
                 .for_each(drop);
             update_faults = length_before_cleanup != self.active_fault_windows.len();
 
-            if is_fault_injector && let Some(new_window) = try_get_fault_window_defintion(&entry, event_vtime_ticks, fault_name) {
+            if is_fault_injector
+                && let Some(new_window) =
+                    try_get_fault_window_defintion(&entry, event_vtime_ticks, fault_name)
+            {
                 self.active_fault_windows.push_back(new_window);
                 update_faults = true;
             }
@@ -473,24 +521,52 @@ impl LineTransformer for FaultAnnotator {
     }
 }
 
-fn try_get_fault_window_defintion(entry: &Value, event_vtime_ticks: u64, maybe_fault_name: Option<&str>) -> Option<FaultWindow> {
+fn try_get_fault_window_defintion(
+    entry: &Value,
+    event_vtime_ticks: u64,
+    maybe_fault_name: Option<&str>,
+) -> Option<FaultWindow> {
     if let Some(fault_name) = maybe_fault_name {
-        let max_duration_ticks = entry["fault"]["max_duration"].as_f64().filter(|d| *d >= 0.0).map(|d| (d * TICKS_PER_SECOND) as u64);
+        let max_duration_ticks = entry["fault"]["max_duration"]
+            .as_f64()
+            .filter(|d| *d >= 0.0)
+            .map(|d| (d * TICKS_PER_SECOND) as u64);
         let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
         let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
 
-        if let Some(target) = entry["fault"]["affected_nodes"].as_array().and_then(|arr| arr.first()).and_then(|first| first.as_str()) {
+        if let Some(target) = entry["fault"]["affected_nodes"]
+            .as_array()
+            .and_then(|arr| arr.first())
+            .and_then(|first| first.as_str())
+        {
             if fault_name.eq("partition") || fault_name.eq("clog") {
-                return Some(FaultWindow::Network { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime });
-            } 
-            
+                return Some(FaultWindow::Network {
+                    name: fault_name.to_string(),
+                    start_vtime: event_vtime_ticks,
+                    end_vtime,
+                });
+            }
+
             if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
-                return Some(FaultWindow::Node { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime, container: target.to_string() });
+                return Some(FaultWindow::Node {
+                    name: fault_name.to_string(),
+                    start_vtime: event_vtime_ticks,
+                    end_vtime,
+                    container: target.to_string(),
+                });
             }
         }
 
-        if fault_name.eq("skip") && fault_type.eq("clock") && let Some(offset) = entry["fault"]["details"]["offset"].as_f64() {
-            return Some(FaultWindow::Clock { name: fault_name.to_string(), start_vtime: event_vtime_ticks, offset, end_vtime });
+        if fault_name.eq("skip")
+            && fault_type.eq("clock")
+            && let Some(offset) = entry["fault"]["details"]["offset"].as_f64()
+        {
+            return Some(FaultWindow::Clock {
+                name: fault_name.to_string(),
+                start_vtime: event_vtime_ticks,
+                offset,
+                end_vtime,
+            });
         }
     }
 
@@ -507,34 +583,73 @@ struct RenderedEventEntry {
 
 #[derive(Debug, PartialEq)]
 enum FaultWindow {
-    Network { name: String, start_vtime: u64, end_vtime: Option<u64> },
-    Node { name: String, start_vtime: u64, end_vtime: Option<u64>, container: String },
-    Clock { name: String, start_vtime: u64, offset: f64, end_vtime: Option<u64> }
+    Network {
+        name: String,
+        start_vtime: u64,
+        end_vtime: Option<u64>,
+    },
+    Node {
+        name: String,
+        start_vtime: u64,
+        end_vtime: Option<u64>,
+        container: String,
+    },
+    Clock {
+        name: String,
+        start_vtime: u64,
+        offset: f64,
+        end_vtime: Option<u64>,
+    },
 }
 
 impl FaultWindow {
     fn get_end_vtime(&self) -> &Option<u64> {
         match self {
-            Self::Network { name: _, start_vtime: _, end_vtime } => end_vtime,
-            Self::Node { name: _, start_vtime: _, end_vtime, container: _ } => end_vtime,
-            Self::Clock { name: _, start_vtime: _, offset: _, end_vtime } => end_vtime,
+            Self::Network {
+                name: _,
+                start_vtime: _,
+                end_vtime,
+            } => end_vtime,
+            Self::Node {
+                name: _,
+                start_vtime: _,
+                end_vtime,
+                container: _,
+            } => end_vtime,
+            Self::Clock {
+                name: _,
+                start_vtime: _,
+                offset: _,
+                end_vtime,
+            } => end_vtime,
         }
     }
 
     fn is_expired(&self, latest_vtime: u64) -> bool {
-        self.get_end_vtime().map(|t| t < latest_vtime).unwrap_or(false)
+        self.get_end_vtime()
+            .map(|t| t < latest_vtime)
+            .unwrap_or(false)
     }
 
     fn is_network_fault(&self) -> bool {
         match self {
-            Self::Network { name: _, start_vtime: _, end_vtime: _ } => true,
+            Self::Network {
+                name: _,
+                start_vtime: _,
+                end_vtime: _,
+            } => true,
             _ => false,
         }
     }
 
     fn is_node_fault(&self) -> bool {
         match self {
-            Self::Node { name: _, start_vtime: _, end_vtime: _, container: _ } => true,
+            Self::Node {
+                name: _,
+                start_vtime: _,
+                end_vtime: _,
+                container: _,
+            } => true,
             _ => false,
         }
     }
@@ -564,21 +679,47 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
     let mut node_faults = IndexMap::<String, Map<String, Value>>::new();
 
     for fault_window in open_windows {
-        if let FaultWindow::Clock { name: _, start_vtime, offset, end_vtime: _ } = fault_window {
-            max_clock_fault_start = max_clock_fault_start.map(|prev| prev.max(*start_vtime)).or(Some(*start_vtime));
+        if let FaultWindow::Clock {
+            name: _,
+            start_vtime,
+            offset,
+            end_vtime: _,
+        } = fault_window
+        {
+            max_clock_fault_start = max_clock_fault_start
+                .map(|prev| prev.max(*start_vtime))
+                .or(Some(*start_vtime));
             offset_sum += offset;
-        } else if let FaultWindow::Network { name, start_vtime, end_vtime: _ } = fault_window {
+        } else if let FaultWindow::Network {
+            name,
+            start_vtime,
+            end_vtime: _,
+        } = fault_window
+        {
             match network_fault_starts.entry(format!("network_{}", name)) {
-                Entry::Vacant(entry) => { entry.insert(*start_vtime); },
+                Entry::Vacant(entry) => {
+                    entry.insert(*start_vtime);
+                }
                 Entry::Occupied(mut entry) => {
                     if entry.get().ge(start_vtime) {
                         entry.insert(*start_vtime);
                     }
                 }
             }
-        } else if let FaultWindow::Node { name, start_vtime, end_vtime: _, container } = fault_window {
-            node_faults.entry(format!("node_{}", name)).or_insert_with(|| Map::new())
-                .insert(container.clone(), json!((*start_vtime as f64) / TICKS_PER_SECOND));
+        } else if let FaultWindow::Node {
+            name,
+            start_vtime,
+            end_vtime: _,
+            container,
+        } = fault_window
+        {
+            node_faults
+                .entry(format!("node_{}", name))
+                .or_insert_with(|| Map::new())
+                .insert(
+                    container.clone(),
+                    json!((*start_vtime as f64) / TICKS_PER_SECOND),
+                );
         }
     }
 
@@ -1522,7 +1663,7 @@ mod tests {
             r"a\x01b\x0Bc\x7Fd	e"
         );
     }
-        #[test]
+    #[test]
     fn ansi_sgr() {
         assert_eq!(strip_ansi("\x1b[1mbold\x1b[0m"), "bold");
         assert_eq!(strip_ansi("\x1b[38;5;196mred\x1b[0m"), "red");
@@ -1596,7 +1737,10 @@ mod tests {
 
     #[test]
     fn tracks_which_faults_are_active_based_on_vtime_and_max_duration() {
-        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
 
         // No faults yet
         assert_eq!(
@@ -1661,19 +1805,28 @@ mod tests {
 
         // Expire both windows
         assert_eq!(
-            transformer.try_transform(&format!("{}", json!({
-                "moment": {
-                    "_vtime_ticks": (11u64 << 32) + 1
-                },
-                "foo": "bar"
-            }))),
-            Some("{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"active_faults\":{}}".to_string())
+            transformer.try_transform(&format!(
+                "{}",
+                json!({
+                    "moment": {
+                        "_vtime_ticks": (11u64 << 32) + 1
+                    },
+                    "foo": "bar"
+                })
+            )),
+            Some(
+                "{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"active_faults\":{}}"
+                    .to_string()
+            )
         );
     }
 
     #[test]
     fn restore_closes_network_faults() {
-        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
 
         // Open a network partition fault window
         assert_eq!(
@@ -1752,7 +1905,10 @@ mod tests {
 
     #[test]
     fn fault_injector_pause_clears_network_and_node_faults() {
-        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
 
         // Open a network partition fault window
         assert_eq!(
@@ -1853,7 +2009,10 @@ mod tests {
 
     #[test]
     fn clock_offsets_are_combined() {
-        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: LinkedList::new(),
+            active_faults: json!({}),
+        };
 
         // Open a network partition fault window
         assert_eq!(

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,10 +1,11 @@
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, LinkedList};
+use std::collections::{LinkedList};
 use std::{io::Write, sync::OnceLock};
 use std::path::Path;
 
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
+use indexmap::IndexMap;
+use indexmap::map::Entry;
 use log::debug;
 use regex::Regex;
 use serde::Deserialize;
@@ -559,8 +560,8 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
     let mut result = Map::new();
     let mut offset_sum = 0f64;
     let mut max_clock_fault_start: Option<u64> = None;
-    let mut network_fault_starts = HashMap::<String, u64>::new();
-    let mut node_faults = HashMap::<String, Map<String, Value>>::new();
+    let mut network_fault_starts = IndexMap::<String, u64>::new();
+    let mut node_faults = IndexMap::<String, Map<String, Value>>::new();
 
     for fault_window in open_windows {
         if let FaultWindow::Clock { name: _, start_vtime, offset, end_vtime: _ } = fault_window {
@@ -590,7 +591,7 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
     }
 
     if let Some(latest_vtime) = max_clock_fault_start {
-        result["clock_skip"] = json!({"cumulative_offset": offset_sum, "vtime": (latest_vtime as f64) / TICKS_PER_SECOND});
+        result.insert("clock_skip".to_string(), json!({"cumulative_offset": offset_sum, "vtime": (latest_vtime as f64) / TICKS_PER_SECOND}));
     }
 
     return Value::Object(result);
@@ -1594,7 +1595,7 @@ mod tests {
     }
 
     #[test]
-    fn appends_faults() {
+    fn tracks_which_faults_are_active_based_on_vtime_and_max_duration() {
         let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
 
         // No faults yet
@@ -1622,7 +1623,7 @@ mod tests {
             Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"],\"max_duration\":10},\"active_faults\":{\"network_partition\":1.0}}".to_string())
         );
 
-        // Another log message; should retain active window state
+        // Another log message; should retain active window state since the log message had no timestamp
         assert_eq!(
             transformer.try_transform("{\"foo\":\"bar\"}"),
             Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0}}".to_string())
@@ -1667,6 +1668,251 @@ mod tests {
                 "foo": "bar"
             }))),
             Some("{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"active_faults\":{}}".to_string())
+        );
+    }
+
+    #[test]
+    fn restore_closes_network_faults() {
+        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+
+        // Open a network partition fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 1u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["a", "b"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+        );
+
+        // Open a node throttled fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 2u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "throttle",
+                    "type": "node",
+                    "affected_nodes": ["c"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Open a network clog fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 3u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "clog",
+                    "type": "network",
+                    "affected_nodes": ["b", "c"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Verify that state is retained for a non-control log message
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({"foo": "bar"}))),
+            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Send a network restore message
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "restore",
+                    "type": "network"
+                }
+            }))),
+            Some("{\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"restore\",\"type\":\"network\"},\"active_faults\":{\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+    }
+
+    #[test]
+    fn fault_injector_pause_clears_network_and_node_faults() {
+        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+
+        // Open a network partition fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 1u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["a", "b"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"]},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+        );
+
+        // Open a node throttled fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 2u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "throttle",
+                    "type": "node",
+                    "affected_nodes": ["c"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Open a network clog fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 3u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "clog",
+                    "type": "network",
+                    "affected_nodes": ["b", "c"]
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"clog\",\"type\":\"network\",\"affected_nodes\":[\"b\",\"c\"]},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Open a clock fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 4u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "skip",
+                    "type": "clock",
+                    "details": {
+                        "offset": 10.5
+                    }
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":17179869184},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
+        );
+
+        // Verify that state is retained for a non-control log message
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({"foo": "bar"}))),
+            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"network_clog\":3.0,\"node_throttle\":{\"c\":2.0},\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
+        );
+
+        // Send a fault injector pause message
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "source": {
+                    "name": "fault_injector"
+                },
+                "info": {
+                    "message": "status",
+                    "details": {
+                        "paused": true
+                    }
+                }
+            }))),
+            Some("{\"source\":{\"name\":\"fault_injector\"},\"info\":{\"message\":\"status\",\"details\":{\"paused\":true}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":4.0}}}".to_string())
+        );
+    }
+
+    #[test]
+    fn clock_offsets_are_combined() {
+        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+
+        // Open a network partition fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 1u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "skip",
+                    "type": "clock",
+                    "details": {
+                        "offset": 10.5
+                    }
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":10.5}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.5,\"vtime\":1.0}}}".to_string())
+        );
+
+        // Open a node throttled fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 2u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "skip",
+                    "type": "clock",
+                    "details": {
+                        "offset": 0.1
+                    }
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":0.1}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":10.6,\"vtime\":2.0}}}".to_string())
+        );
+
+        // Open a network clog fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 3u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "skip",
+                    "type": "clock",
+                    "details": {
+                        "offset": -2.3
+                    }
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":12884901888},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"skip\",\"type\":\"clock\",\"details\":{\"offset\":-2.3}},\"active_faults\":{\"clock_skip\":{\"cumulative_offset\":8.3,\"vtime\":3.0}}}".to_string())
         );
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -2133,7 +2133,7 @@ mod tests {
             })
         ));
 
-        // Empty affected_nodes: try_get_fault_window_definition returns None,
+        // Empty affected_nodes: network and node faults are only considered active if at least one node is affected,
         // so no new window is pushed and the existing one is unchanged.
         assert_eq!(
             transformer.try_transform(&format!(

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -235,13 +235,21 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool, annotate_f
     let mut stdout = std::io::stdout().lock();
 
     if json {
-        stream_ndjson_lines(stream, annotate_faults, |line| {
-            writeln!(stdout, "{line}")?;
-            Ok(())
-        })
-        .await
+        if annotate_faults {
+            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        } else {
+            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        }
     } else {
-        stream_ndjson_lines(stream, annotate_faults, |line| {
+        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
                 let ts = entry["timestamp"].as_str().unwrap_or("");
                 let stream = entry["stream"].as_str().unwrap_or("out");
@@ -267,18 +275,26 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        stream_ndjson_lines(stream, annotate_faults, |line| {
-            writeln!(stdout, "{line}")?;
-            Ok(())
-        })
-        .await
+        if annotate_faults {
+            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        } else {
+            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        }
     } else {
         writeln!(
             stdout,
             "{:<22}  {:<22}  {:<20}  OUTPUT",
             "HASH", "VTIME", "SOURCE"
         )?;
-        stream_ndjson_lines(stream, annotate_faults, |line| {
+        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let input_hash = rendered.input_hash;
@@ -318,14 +334,22 @@ async fn cmd_runs_logs(
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        stream_ndjson_lines(stream, annotate_faults, |line| {
-            writeln!(stdout, "{line}")?;
-            Ok(())
-        })
-        .await
+        if annotate_faults {
+            stream_ndjson_lines(stream, FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) }, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        } else {
+            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+                writeln!(stdout, "{line}")?;
+                Ok(())
+            })
+            .await
+        }
     } else {
         writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
-        stream_ndjson_lines(stream, annotate_faults, |line| {
+        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let vtime = rendered.vtime;
@@ -345,7 +369,7 @@ const TICKS_PER_SECOND: f64 = (1u64 << 32) as f64;
 
 async fn stream_ndjson_lines<S, C>(
     mut stream: S,
-    annotate_faults: bool,
+    mut line_transformer: impl LineTransformer,
     mut process_line: impl FnMut(&str) -> Result<()>,
 ) -> Result<()>
 where
@@ -355,9 +379,6 @@ where
     use futures_util::StreamExt;
 
     let mut buf: Vec<u8> = Vec::new();
-    let mut faults_need_updating;
-    let mut active_fault_windows = LinkedList::<FaultWindow>::new();
-    let mut active_faults: Option<Value> = None;
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
@@ -368,66 +389,8 @@ where
             if !line_bytes.is_empty() {
                 let line = std::str::from_utf8(line_bytes)
                     .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-                if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
-                    let mut rewrite_line = false;
-
-                    if annotate_faults {
-                        let event_vtime_ticks = entry["moment"]["_vtime_ticks"].as_u64().unwrap_or(0);
-                        let fault_name =  entry["fault"]["name"].as_str();
-                        let is_fault_injector = entry["source"]["name"].as_str().map(|source| source.eq("fault_injector")).unwrap_or(false);
-                        let faults_were_paused = is_fault_injector && 
-                            entry["info"]["message"].as_str().map(|message| message.eq("status")).unwrap_or(false) &&
-                            entry["info"]["details"]["paused"].as_bool().unwrap_or(false);
-                        let is_restore_event = fault_name.map(|n| n.eq("restore")).unwrap_or(false);
-
-                        let windows_before_scrubbing = active_fault_windows.len();
-                        // clear any fault windows that are expired or mooted by fault injector pauses
-                        active_fault_windows
-                            .extract_if(|w| w.is_expired(event_vtime_ticks) ||
-                                (faults_were_paused && (w.is_network_fault() || w.is_node_fault())) ||
-                                (is_restore_event && w.is_network_fault()))
-                            .for_each(drop);
-                        faults_need_updating = windows_before_scrubbing == active_fault_windows.len();
-
-                        if is_fault_injector && let Some(fault_name) = fault_name {
-                            let max_duration_ticks = entry["fault"]["max_duration"].as_f64().filter(|d| *d >= 0.0).map(|d| (d * TICKS_PER_SECOND) as u64);
-                            let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
-                            let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
-
-                            if let Some(target) = entry["fault"]["affected_nodes"].as_array().and_then(|arr| arr.first()).and_then(|first| first.as_str()) {
-                                if fault_name.eq("partition") || fault_name.eq("clog") {
-                                    active_fault_windows.push_back(FaultWindow::Network { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime });
-                                    faults_need_updating = true;
-                                } else if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
-                                    active_fault_windows.push_back(FaultWindow::Node { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime, container: target.to_string() });
-                                    faults_need_updating = true;
-                                }
-                            }
-
-                            if fault_name.eq("skip") && fault_type.eq("clock") && let Some(offset) = entry["fault"]["details"]["offset"].as_f64() {
-                                active_fault_windows.push_back(FaultWindow::Clock { name: fault_name.to_string(), start_vtime: event_vtime_ticks, offset, end_vtime });
-                                faults_need_updating = true;
-                            }
-                        }
-
-                        if faults_need_updating {
-                            active_faults = if active_fault_windows.is_empty() { None } else { Some(active_fault_dictionary(&active_fault_windows)) };
-                        }
-
-                        if let Some(output_text) = entry["output_text"].as_str() {
-                            entry["output_text"] = Value::String(strip_ansi(output_text));
-                            rewrite_line = true;
-                        }
-
-                        if let Some(ref faults_snapshot) = active_faults {
-                            entry["active_faults"] = faults_snapshot.clone();
-                            rewrite_line = true;
-                        }
-                    }
-
-                    let line_to_process = if rewrite_line { &format!("{}", entry) } else { line };
-
-                    process_line(line_to_process)?;
+                if let Some(transformed) = line_transformer.try_transform(line) {
+                    process_line(&transformed)?;
                 } else {
                     process_line(line)?;
                 }
@@ -439,10 +402,98 @@ where
     if !buf.is_empty() {
         let line = std::str::from_utf8(&buf)
             .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-        process_line(line)?;
+        if let Some(transformed) = line_transformer.try_transform(line) {
+            process_line(&transformed)?;
+        } else {
+            process_line(line)?;
+        }
     }
 
     Ok(())
+}
+
+trait LineTransformer {
+    fn try_transform(&mut self, line: &str) -> Option<String>;
+}
+
+struct NoOpTransformer {}
+
+impl LineTransformer for NoOpTransformer {
+    fn try_transform(&mut self, _: &str) -> Option<String> {
+        None
+    }
+}
+
+struct FaultAnnotator {
+    active_fault_windows: LinkedList<FaultWindow>,
+    active_faults: Value,
+}
+
+impl LineTransformer for FaultAnnotator {
+    fn try_transform(&mut self, line: &str) -> Option<String> {
+        if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
+            let mut update_faults;
+
+            let event_vtime_ticks = entry["moment"]["_vtime_ticks"].as_u64().unwrap_or(0);
+            let fault_name =  entry["fault"]["name"].as_str();
+            let is_fault_injector = entry["source"]["name"].as_str().map(|source| source.eq("fault_injector")).unwrap_or(false);
+            let faults_were_paused = is_fault_injector && 
+                entry["info"]["message"].as_str().map(|message| message.eq("status")).unwrap_or(false) &&
+                entry["info"]["details"]["paused"].as_bool().unwrap_or(false);
+            let is_restore_event = fault_name.map(|n| n.eq("restore")).unwrap_or(false);
+
+            // clear any fault windows that are expired or mooted by fault injector pauses
+            let length_before_cleanup = self.active_fault_windows.len();
+            self.active_fault_windows
+                .extract_if(|w| w.is_expired(event_vtime_ticks) ||
+                    (faults_were_paused && (w.is_network_fault() || w.is_node_fault())) ||
+                    (is_restore_event && w.is_network_fault()))
+                .for_each(drop);
+            update_faults = length_before_cleanup != self.active_fault_windows.len();
+
+            if is_fault_injector && let Some(new_window) = try_get_fault_window_defintion(&entry, event_vtime_ticks, fault_name) {
+                self.active_fault_windows.push_back(new_window);
+                update_faults = true;
+            }
+
+            if update_faults {
+                self.active_faults = active_fault_dictionary(&self.active_fault_windows);
+            }
+
+            if let Some(output_text) = entry["output_text"].as_str() {
+                entry["output_text"] = Value::String(strip_ansi(output_text));
+            }
+            entry["active_faults"] = self.active_faults.clone();
+
+            return Some(format!("{}", entry));
+        }
+
+        return None;
+    }
+}
+
+fn try_get_fault_window_defintion(entry: &Value, event_vtime_ticks: u64, maybe_fault_name: Option<&str>) -> Option<FaultWindow> {
+    if let Some(fault_name) = maybe_fault_name {
+        let max_duration_ticks = entry["fault"]["max_duration"].as_f64().filter(|d| *d >= 0.0).map(|d| (d * TICKS_PER_SECOND) as u64);
+        let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
+        let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
+
+        if let Some(target) = entry["fault"]["affected_nodes"].as_array().and_then(|arr| arr.first()).and_then(|first| first.as_str()) {
+            if fault_name.eq("partition") || fault_name.eq("clog") {
+                return Some(FaultWindow::Network { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime });
+            } 
+            
+            if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
+                return Some(FaultWindow::Node { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime, container: target.to_string() });
+            }
+        }
+
+        if fault_name.eq("skip") && fault_type.eq("clock") && let Some(offset) = entry["fault"]["details"]["offset"].as_f64() {
+            return Some(FaultWindow::Clock { name: fault_name.to_string(), start_vtime: event_vtime_ticks, offset, end_vtime });
+        }
+    }
+
+    return None;
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -531,11 +582,11 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
     }
 
     for entry in network_fault_starts {
-        result[&entry.0] = json!(entry.1);
+        result.insert(entry.0, json!((entry.1 as f64) / TICKS_PER_SECOND));
     }
 
     for entry in node_faults {
-        result[&entry.0] = Value::Object(entry.1);
+        result.insert(entry.0, Value::Object(entry.1));
     }
 
     if let Some(latest_vtime) = max_clock_fault_start {
@@ -1468,6 +1519,154 @@ mod tests {
         assert_eq!(
             sanitize("a\u{0001}b\u{000B}c\u{007F}d\te"),
             r"a\x01b\x0Bc\x7Fd	e"
+        );
+    }
+        #[test]
+    fn ansi_sgr() {
+        assert_eq!(strip_ansi("\x1b[1mbold\x1b[0m"), "bold");
+        assert_eq!(strip_ansi("\x1b[38;5;196mred\x1b[0m"), "red");
+        assert_eq!(strip_ansi("\x1b[38;2;255;0;0mred\x1b[0m"), "red");
+        assert_eq!(strip_ansi("\x1b[1;31;42mtext\x1b[0m"), "text");
+        assert_eq!(
+            strip_ansi(
+                "\x1b[2m2026-04-03T08:19:54Z\x1b[0m \x1b[32m INFO\x1b[0m \x1b[2mfoobar\x1b[0m\x1b[2m:\x1b[0m ready"
+            ),
+            "2026-04-03T08:19:54Z  INFO foobar: ready"
+        );
+    }
+
+    #[test]
+    fn ansi_csi_non_sgr() {
+        assert_eq!(strip_ansi("left\x1b[2Aright"), "leftright");
+        assert_eq!(strip_ansi("text\x1b[2K"), "text");
+        assert_eq!(strip_ansi("\x1b[?25hvisible"), "visible");
+        assert_eq!(strip_ansi("\x1b[?25l hidden"), " hidden");
+    }
+
+    #[test]
+    fn ansi_osc() {
+        assert_eq!(
+            strip_ansi("\x1b]0;my window title\x07text after"),
+            "text after"
+        );
+        assert_eq!(strip_ansi("\x1b]0;my title\x1b\\text after"), "text after");
+    }
+
+    #[test]
+    fn ansi_two_byte() {
+        assert_eq!(strip_ansi("\x1bcafter reset"), "after reset");
+        assert_eq!(strip_ansi("before\x1b7after"), "beforeafter");
+    }
+
+    #[test]
+    fn ansi_passthrough() {
+        let cases = [
+            "no escapes here",
+            r#"{"key": "value", "nested": {"a": [1,2,3]}}"#,
+            r#"{"url": "http://example.com/path?q=1&r=2", "count": 42}"#,
+            r#"Options { address: Some(0.0.0.0:3307), deployment: "mydb", mode: Standalone }"#,
+            r#"Config { inner: Inner { values: [1, 2, 3] }, name: "test" }"#,
+            "[2026-04-03] [INFO] [main] started",
+            r#"path: "/nix/store/abc-pkg/bin/cmd""#,
+            r#"{"msg": "he said \"hello\""}"#,
+        ];
+        for c in cases {
+            assert_eq!(strip_ansi(c), c, "passthrough failed: {c:?}");
+        }
+    }
+
+    #[test]
+    fn ansi_mixed() {
+        assert_eq!(
+            strip_ansi("\x1b[2m{\"key\": \"value\"}\x1b[0m"),
+            r#"{"key": "value"}"#
+        );
+        assert_eq!(
+            strip_ansi("\x1b[3mOptions { mode: Standalone }\x1b[0m"),
+            "Options { mode: Standalone }"
+        );
+        assert_eq!(
+            strip_ansi(
+                "\x1b[2m2026-04-03T00:00:00Z\x1b[0m \x1b[32m INFO\x1b[0m request completed {\"status\": 200, \"latency_ms\": 42}"
+            ),
+            r#"2026-04-03T00:00:00Z  INFO request completed {"status": 200, "latency_ms": 42}"#
+        );
+    }
+
+    #[test]
+    fn appends_faults() {
+        let mut transformer = FaultAnnotator { active_fault_windows: LinkedList::new(), active_faults: json!({}) };
+
+        // No faults yet
+        assert_eq!(
+            transformer.try_transform("{\"foo\":\"bar\"}"),
+            Some("{\"foo\":\"bar\",\"active_faults\":{}}".to_string())
+        );
+
+        // Open a network partition fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 1u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "partition",
+                    "type": "network",
+                    "affected_nodes": ["a", "b"],
+                    "max_duration": 10
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":4294967296},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"partition\",\"type\":\"network\",\"affected_nodes\":[\"a\",\"b\"],\"max_duration\":10},\"active_faults\":{\"network_partition\":1.0}}".to_string())
+        );
+
+        // Another log message; should retain active window state
+        assert_eq!(
+            transformer.try_transform("{\"foo\":\"bar\"}"),
+            Some("{\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0}}".to_string())
+        );
+
+        // Open a node throttled fault window
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 2u64 << 32
+                },
+                "source": {
+                    "name": "fault_injector"
+                },
+                "fault": {
+                    "name": "throttle",
+                    "type": "node",
+                    "affected_nodes": ["c"],
+                    "max_duration": 9
+                }
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":8589934592},\"source\":{\"name\":\"fault_injector\"},\"fault\":{\"name\":\"throttle\",\"type\":\"node\",\"affected_nodes\":[\"c\"],\"max_duration\":9},\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Another non-fault injector message; should retain state
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": 11u64 << 32
+                },
+                "foo": "bar"
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":47244640256},\"foo\":\"bar\",\"active_faults\":{\"network_partition\":1.0,\"node_throttle\":{\"c\":2.0}}}".to_string())
+        );
+
+        // Expire both windows
+        assert_eq!(
+            transformer.try_transform(&format!("{}", json!({
+                "moment": {
+                    "_vtime_ticks": (11u64 << 32) + 1
+                },
+                "foo": "bar"
+            }))),
+            Some("{\"moment\":{\"_vtime_ticks\":47244640257},\"foo\":\"bar\",\"active_faults\":{}}".to_string())
         );
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -40,7 +40,17 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
         Some(RunsCommands::BuildLogs {
             run_id,
             annotate_faults,
-        }) => cmd_runs_build_logs(&run_id, json, verbose, annotate_faults).await,
+        }) => {
+            cmd_runs_build_logs(
+                &run_id,
+                LogOutputOptions {
+                    json,
+                    verbose,
+                    annotate_faults,
+                },
+            )
+            .await
+        }
         Some(RunsCommands::Logs {
             run_id,
             input_hash,
@@ -55,9 +65,11 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
                 &vtime,
                 begin_input_hash.as_deref(),
                 begin_vtime.as_deref(),
-                json,
-                verbose,
-                annotate_faults,
+                LogOutputOptions {
+                    json,
+                    verbose,
+                    annotate_faults,
+                },
             )
             .await
         }
@@ -229,11 +241,19 @@ fn print_run_detail(run: &RunDetail) {
     }
 }
 
-async fn cmd_runs_build_logs(
-    run_id: &str,
+struct LogOutputOptions {
     json: bool,
     verbose: bool,
     annotate_faults: bool,
+}
+
+async fn cmd_runs_build_logs(
+    run_id: &str,
+    LogOutputOptions {
+        json,
+        verbose,
+        annotate_faults,
+    }: LogOutputOptions,
 ) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
@@ -326,9 +346,11 @@ async fn cmd_runs_logs(
     vtime: &str,
     begin_input_hash: Option<&str>,
     begin_vtime: Option<&str>,
-    json: bool,
-    verbose: bool,
-    annotate_faults: bool,
+    LogOutputOptions {
+        json,
+        verbose,
+        annotate_faults,
+    }: LogOutputOptions,
 ) -> Result<()> {
     debug!("streaming logs for run: {}", run_id);
 
@@ -495,7 +517,7 @@ impl LineTransformer for FaultAnnotator {
             return Some(format!("{}", entry));
         }
 
-        return None;
+        None
     }
 }
 
@@ -548,7 +570,7 @@ fn try_get_fault_window_definition(
         }
     }
 
-    return None;
+    None
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -610,26 +632,26 @@ impl FaultWindow {
     }
 
     fn is_network_fault(&self) -> bool {
-        match self {
+        matches!(
+            self,
             Self::Network {
                 name: _,
                 start_vtime: _,
                 end_vtime: _,
-            } => true,
-            _ => false,
-        }
+            }
+        )
     }
 
     fn is_node_fault(&self) -> bool {
-        match self {
+        matches!(
+            self,
             Self::Node {
                 name: _,
                 start_vtime: _,
                 end_vtime: _,
                 container: _,
-            } => true,
-            _ => false,
-        }
+            }
+        )
     }
 }
 
@@ -693,7 +715,7 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
         {
             node_faults
                 .entry(format!("node_{}", name))
-                .or_insert_with(|| Map::new())
+                .or_default()
                 .insert(
                     container.clone(),
                     json!((*start_vtime as f64) / TICKS_PER_SECOND),
@@ -713,7 +735,7 @@ fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
         result.insert("clock_skip".to_string(), json!({"cumulative_offset": offset_sum, "vtime": (latest_vtime as f64) / TICKS_PER_SECOND}));
     }
 
-    return Value::Object(result);
+    Value::Object(result)
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -332,7 +332,7 @@ async fn cmd_runs_logs(
             stream_ndjson_lines(
                 stream,
                 FaultAnnotator {
-                    active_fault_windows: Vec::new(),
+                    active_fault_windows: ActiveFaultWindows::new(),
                     active_faults: json!({}),
                 },
                 |line| {
@@ -426,14 +426,14 @@ impl LineTransformer for NoOpTransformer {
 }
 
 struct FaultAnnotator {
-    active_fault_windows: Vec<FaultWindow>,
+    active_fault_windows: ActiveFaultWindows,
     active_faults: Value,
 }
 
 impl LineTransformer for FaultAnnotator {
     fn try_transform(&mut self, line: &str) -> Option<String> {
         if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
-            let mut update_faults;
+            let mut update_faults = false;
 
             let vtime_ticks_node = entry["moment"]["_vtime_ticks"].as_u64();
             let vtime_node = entry["moment"]["vtime"]
@@ -447,46 +447,85 @@ impl LineTransformer for FaultAnnotator {
                 .as_str()
                 .map(|source| source.eq("fault_injector"))
                 .unwrap_or(false);
-            let faults_were_paused = is_fault_injector
+
+            // Clear network and node faults if the fault injector was paused
+            if is_fault_injector
                 && entry["info"]["message"]
                     .as_str()
                     .map(|message| message.eq("status"))
                     .unwrap_or(false)
                 && entry["info"]["details"]["paused"]
                     .as_bool()
-                    .unwrap_or(false);
-            let is_restore_event =
-                is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false);
-
-            // clear any fault windows that are expired or mooted by fault injector pauses
-            let length_before_cleanup = self.active_fault_windows.len();
-            self.active_fault_windows.retain(|w| {
-                if w.is_expired(event_vtime_ticks) {
-                    return false;
-                }
-
-                if faults_were_paused && (w.is_network_fault() || w.is_node_fault()) {
-                    return false;
-                }
-
-                if is_restore_event && w.is_network_fault() {
-                    return false;
-                }
-
-                true
-            });
-            update_faults = length_before_cleanup != self.active_fault_windows.len();
-
-            if is_fault_injector
-                && let Some(new_window) =
-                    try_get_fault_window_definition(&entry, event_vtime_ticks, fault_name)
+                    .unwrap_or(false)
             {
-                self.active_fault_windows.push(new_window);
-                update_faults = true;
+                update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
+                update_faults = self.active_fault_windows.clear_node_faults() || update_faults;
+            }
+
+            // Clear network faults if the network was restored
+            if is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false) {
+                update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
+            }
+
+            // Clear any expired faults
+            update_faults = self
+                .active_fault_windows
+                .clear_expired_faults(event_vtime_ticks)
+                || update_faults;
+
+            if is_fault_injector && let Some(fault_name) = fault_name {
+                let max_duration_ticks = entry["fault"]["max_duration"]
+                    .as_f64()
+                    .filter(|d| *d >= 0.0)
+                    .map(|d| (d * TICKS_PER_SECOND) as u64);
+                let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
+                let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
+
+                if let Some(target) = entry["fault"]["affected_nodes"]
+                    .as_array()
+                    .and_then(|arr| arr.first())
+                    .and_then(|first| first.as_str())
+                {
+                    if fault_name.eq("partition") || fault_name.eq("clog") {
+                        update_faults = self.active_fault_windows.add_network_fault(
+                            fault_name.to_string(),
+                            FaultWindowBounds {
+                                start_vtime: event_vtime_ticks,
+                                end_vtime,
+                            },
+                        ) || update_faults;
+                    }
+
+                    if fault_type.eq("node")
+                        && (fault_name.eq("pause") || fault_name.eq("throttle"))
+                    {
+                        update_faults = self.active_fault_windows.add_node_fault(
+                            fault_name.to_string(),
+                            target.to_string(),
+                            FaultWindowBounds {
+                                start_vtime: event_vtime_ticks,
+                                end_vtime,
+                            },
+                        ) || update_faults;
+                    }
+                }
+
+                if fault_name.eq("skip")
+                    && fault_type.eq("clock")
+                    && let Some(offset) = entry["fault"]["details"]["offset"].as_f64()
+                {
+                    update_faults = self.active_fault_windows.add_clock_fault(
+                        offset,
+                        FaultWindowBounds {
+                            start_vtime: event_vtime_ticks,
+                            end_vtime,
+                        },
+                    ) || update_faults;
+                }
             }
 
             if update_faults {
-                self.active_faults = active_fault_dictionary(&self.active_fault_windows);
+                self.active_faults = self.active_fault_windows.to_json();
             }
 
             if let Some(output_text) = entry["output_text"].as_str() {
@@ -504,138 +543,12 @@ impl LineTransformer for FaultAnnotator {
     }
 }
 
-fn try_get_fault_window_definition(
-    entry: &Value,
-    event_vtime_ticks: u64,
-    maybe_fault_name: Option<&str>,
-) -> Option<FaultWindow> {
-    if let Some(fault_name) = maybe_fault_name {
-        let max_duration_ticks = entry["fault"]["max_duration"]
-            .as_f64()
-            .filter(|d| *d >= 0.0)
-            .map(|d| (d * TICKS_PER_SECOND) as u64);
-        let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
-        let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
-
-        if let Some(target) = entry["fault"]["affected_nodes"]
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|first| first.as_str())
-        {
-            if fault_name.eq("partition") || fault_name.eq("clog") {
-                return Some(FaultWindow::Network {
-                    name: fault_name.to_string(),
-                    start_vtime: event_vtime_ticks,
-                    end_vtime,
-                });
-            }
-
-            if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
-                return Some(FaultWindow::Node {
-                    name: fault_name.to_string(),
-                    start_vtime: event_vtime_ticks,
-                    end_vtime,
-                    container: target.to_string(),
-                });
-            }
-        }
-
-        if fault_name.eq("skip")
-            && fault_type.eq("clock")
-            && let Some(offset) = entry["fault"]["details"]["offset"].as_f64()
-        {
-            return Some(FaultWindow::Clock {
-                name: fault_name.to_string(),
-                start_vtime: event_vtime_ticks,
-                offset,
-                end_vtime,
-            });
-        }
-    }
-
-    None
-}
-
 #[derive(Debug, PartialEq, Eq)]
 struct RenderedEventEntry {
     input_hash: String,
     vtime: String,
     source: String,
     output: String,
-}
-
-#[derive(Debug, PartialEq)]
-enum FaultWindow {
-    Network {
-        name: String,
-        start_vtime: u64,
-        end_vtime: Option<u64>,
-    },
-    Node {
-        name: String,
-        start_vtime: u64,
-        end_vtime: Option<u64>,
-        container: String,
-    },
-    Clock {
-        name: String,
-        start_vtime: u64,
-        offset: f64,
-        end_vtime: Option<u64>,
-    },
-}
-
-impl FaultWindow {
-    fn get_end_vtime(&self) -> &Option<u64> {
-        match self {
-            Self::Network {
-                name: _,
-                start_vtime: _,
-                end_vtime,
-            } => end_vtime,
-            Self::Node {
-                name: _,
-                start_vtime: _,
-                end_vtime,
-                container: _,
-            } => end_vtime,
-            Self::Clock {
-                name: _,
-                start_vtime: _,
-                offset: _,
-                end_vtime,
-            } => end_vtime,
-        }
-    }
-
-    fn is_expired(&self, latest_vtime: u64) -> bool {
-        self.get_end_vtime()
-            .map(|t| t < latest_vtime)
-            .unwrap_or(false)
-    }
-
-    fn is_network_fault(&self) -> bool {
-        matches!(
-            self,
-            Self::Network {
-                name: _,
-                start_vtime: _,
-                end_vtime: _,
-            }
-        )
-    }
-
-    fn is_node_fault(&self) -> bool {
-        matches!(
-            self,
-            Self::Node {
-                name: _,
-                start_vtime: _,
-                end_vtime: _,
-                container: _,
-            }
-        )
-    }
 }
 
 fn ansi_re() -> &'static Regex {
@@ -654,74 +567,205 @@ fn strip_ansi(text: &str) -> String {
     ansi_re().replace_all(text, "").to_string()
 }
 
-fn active_fault_dictionary(open_windows: &Vec<FaultWindow>) -> Value {
-    let mut result = Map::new();
-    let mut offset_sum = 0f64;
-    let mut max_clock_fault_start: Option<u64> = None;
-    let mut network_fault_starts = IndexMap::<String, u64>::new();
-    let mut node_faults = IndexMap::<String, Map<String, Value>>::new();
+struct FaultWindowBounds {
+    start_vtime: u64,
+    end_vtime: Option<u64>,
+}
 
-    for fault_window in open_windows {
-        if let FaultWindow::Clock {
-            name: _,
-            start_vtime,
-            offset,
-            end_vtime: _,
-        } = fault_window
-        {
-            max_clock_fault_start = max_clock_fault_start
-                .map(|prev| prev.max(*start_vtime))
-                .or(Some(*start_vtime));
-            offset_sum += offset;
-        } else if let FaultWindow::Network {
-            name,
-            start_vtime,
-            end_vtime: _,
-        } = fault_window
-        {
-            match network_fault_starts.entry(format!("network_{}", name)) {
-                Entry::Vacant(entry) => {
-                    entry.insert(*start_vtime);
-                }
-                Entry::Occupied(mut entry) => {
-                    if entry.get().ge(start_vtime) {
-                        entry.insert(*start_vtime);
-                    }
-                }
-            }
-        } else if let FaultWindow::Node {
-            name,
-            start_vtime,
-            end_vtime: _,
-            container,
-        } = fault_window
-        {
-            node_faults
-                .entry(format!("node_{}", name))
-                .or_default()
-                .insert(
-                    container.clone(),
-                    json!((*start_vtime as f64) / TICKS_PER_SECOND),
-                );
+impl FaultWindowBounds {
+    fn is_expired(&self, latest_vtime_ticks: &u64) -> bool {
+        self.end_vtime
+            .map(|expiry| expiry.lt(latest_vtime_ticks))
+            .unwrap_or(false)
+    }
+}
+
+struct ActiveFaultWindows {
+    network: IndexMap<String, FaultWindowBounds>,
+    node: IndexMap<String, IndexMap<String, FaultWindowBounds>>,
+    clock: Vec<(f64, FaultWindowBounds)>,
+}
+
+impl ActiveFaultWindows {
+    fn new() -> ActiveFaultWindows {
+        ActiveFaultWindows {
+            network: IndexMap::new(),
+            node: IndexMap::new(),
+            clock: Vec::new(),
         }
     }
 
-    for entry in network_fault_starts {
-        result.insert(
-            entry.0,
-            json!({"vtime": (entry.1 as f64) / TICKS_PER_SECOND}),
-        );
+    fn clear_network_faults(&mut self) -> bool {
+        let did_something = !self.network.is_empty();
+        self.network.clear();
+        did_something
     }
 
-    for entry in node_faults {
-        result.insert(entry.0, Value::Object(entry.1));
+    fn clear_node_faults(&mut self) -> bool {
+        let did_something = !self.node.is_empty();
+        self.node.clear();
+        did_something
     }
 
-    if let Some(latest_vtime) = max_clock_fault_start {
-        result.insert("clock_skip".to_string(), json!({"cumulative_offset": offset_sum, "vtime": (latest_vtime as f64) / TICKS_PER_SECOND}));
+    fn clear_expired_faults(&mut self, latest_vtime_ticks: u64) -> bool {
+        let mut did_something;
+
+        let clock_faults_length = self.clock.len();
+        self.clock
+            .retain(|fault| !fault.1.is_expired(&latest_vtime_ticks));
+        did_something = self.clock.len() != clock_faults_length;
+
+        for _ in self
+            .network
+            .extract_if(.., |_k, window| window.is_expired(&latest_vtime_ticks))
+        {
+            did_something = true;
+        }
+
+        let mut dropped_categories_of_node_faults = false;
+        for _ in self.node.extract_if(.., |_k, windows_by_container| {
+            for _ in windows_by_container
+                .extract_if(.., |_c, window| window.is_expired(&latest_vtime_ticks))
+            {
+                did_something = true;
+            }
+
+            windows_by_container.is_empty()
+        }) {
+            dropped_categories_of_node_faults = true;
+        }
+        did_something = did_something || dropped_categories_of_node_faults;
+
+        did_something
     }
 
-    Value::Object(result)
+    fn add_network_fault(&mut self, name: String, window: FaultWindowBounds) -> bool {
+        match self.network.entry(name) {
+            Entry::Vacant(entry) => {
+                entry.insert(window);
+                true
+            }
+            Entry::Occupied(mut entry) => {
+                if let Some(updated) = merge_fault_windows(entry.get(), window) {
+                    entry.insert(updated);
+                    return true;
+                }
+
+                false
+            }
+        }
+    }
+
+    fn add_node_fault(
+        &mut self,
+        name: String,
+        container_name: String,
+        window: FaultWindowBounds,
+    ) -> bool {
+        match self.node.entry(name) {
+            Entry::Vacant(entry) => {
+                let mut by_container_name_map = IndexMap::new();
+                by_container_name_map.insert(container_name, window);
+                entry.insert(by_container_name_map);
+                true
+            }
+            Entry::Occupied(mut container_name_to_window_map) => {
+                match container_name_to_window_map.get_mut().entry(container_name) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(window);
+                        true
+                    }
+                    Entry::Occupied(mut entry) => {
+                        if let Some(updated) = merge_fault_windows(entry.get(), window) {
+                            entry.insert(updated);
+                            return true;
+                        }
+
+                        false
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_clock_fault(&mut self, offset: f64, window: FaultWindowBounds) -> bool {
+        self.clock.push((offset, window));
+        true
+    }
+
+    fn to_json(&self) -> Value {
+        let mut result = Map::new();
+
+        for entry in &self.network {
+            result.insert(
+                format!("network_{}", entry.0),
+                json!({"vtime": (entry.1.start_vtime as f64) / TICKS_PER_SECOND}),
+            );
+        }
+
+        for entry in &self.node {
+            let mut node_fault_starts_by_container = Map::new();
+            for entry in entry.1 {
+                node_fault_starts_by_container.insert(
+                    entry.0.to_string(),
+                    json!((entry.1.start_vtime as f64) / TICKS_PER_SECOND),
+                );
+            }
+
+            result.insert(
+                format!("node_{}", entry.0),
+                Value::Object(node_fault_starts_by_container),
+            );
+        }
+
+        if !&self.clock.is_empty() {
+            let mut offset_sum = 0f64;
+            let mut max_clock_fault_start = 0u64;
+
+            for entry in &self.clock {
+                offset_sum += entry.0;
+                max_clock_fault_start = max_clock_fault_start.max(entry.1.start_vtime);
+            }
+
+            result.insert("clock_skip".to_string(), json!({"cumulative_offset": offset_sum, "vtime": (max_clock_fault_start as f64) / TICKS_PER_SECOND}));
+        }
+
+        Value::Object(result)
+    }
+}
+
+fn merge_fault_windows(
+    incumbent: &FaultWindowBounds,
+    new: FaultWindowBounds,
+) -> Option<FaultWindowBounds> {
+    if new.start_vtime.lt(&incumbent.start_vtime) {
+        return Some(FaultWindowBounds {
+            start_vtime: new.start_vtime,
+            end_vtime: incumbent.end_vtime.and_then(|prev_expiry| {
+                new.end_vtime.map(|new_expiry| new_expiry.max(prev_expiry))
+            }),
+        });
+    }
+
+    match incumbent.end_vtime {
+        None => None,
+        Some(prev_expiry) => match new.end_vtime {
+            None => Some(FaultWindowBounds {
+                start_vtime: incumbent.start_vtime,
+                end_vtime: None,
+            }),
+            Some(new_expiry) => {
+                if new_expiry.gt(&prev_expiry) {
+                    return Some(FaultWindowBounds {
+                        start_vtime: incumbent.start_vtime,
+                        end_vtime: Some(new_expiry),
+                    });
+                }
+
+                None
+            }
+        },
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1724,7 +1768,7 @@ mod tests {
     #[test]
     fn tracks_which_faults_are_active_based_on_vtime_and_max_duration() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -1813,7 +1857,7 @@ mod tests {
     #[test]
     fn restore_closes_network_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -1895,7 +1939,7 @@ mod tests {
     #[test]
     fn fault_injector_pause_clears_network_and_node_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -1999,7 +2043,7 @@ mod tests {
     #[test]
     fn clock_offsets_are_combined() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2067,7 +2111,7 @@ mod tests {
     #[test]
     fn empty_affected_nodes_does_not_open_network_window() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2115,7 +2159,7 @@ mod tests {
     #[test]
     fn missing_affected_nodes_does_not_open_network_window() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2165,7 +2209,7 @@ mod tests {
     #[test]
     fn untracked_fault_names_produce_empty_active_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2211,7 +2255,7 @@ mod tests {
     #[test]
     fn restore_after_only_untracked_faults_is_noop() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2255,7 +2299,7 @@ mod tests {
     #[test]
     fn fault_fields_from_non_fault_injector_source_are_ignored() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2285,7 +2329,7 @@ mod tests {
     #[test]
     fn event_without_vtime_ticks_still_gets_active_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2327,7 +2371,7 @@ mod tests {
     #[test]
     fn fault_window_active_at_exact_end_vtime_expires_one_tick_later() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2390,7 +2434,7 @@ mod tests {
     #[test]
     fn partition_without_max_duration_never_expires() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2433,7 +2477,7 @@ mod tests {
     #[test]
     fn restore_before_natural_expiration_clears_network_faults() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2482,7 +2526,7 @@ mod tests {
     #[test]
     fn partition_and_clog_expire_independently() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2544,7 +2588,7 @@ mod tests {
     #[test]
     fn non_overlapping_windows_start_fresh_after_expiry() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2597,7 +2641,7 @@ mod tests {
     #[test]
     fn overlapping_windows_report_earliest_start_vtime() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2637,7 +2681,6 @@ mod tests {
         );
 
         // At vtime 16: first window expired (15<<32 < 16<<32), second still alive (19<<32 not < 16<<32)
-        // Now only the second window remains; start_vtime becomes 14
         assert_eq!(
             transformer.try_transform(&format!("{}", json!({
                 "moment": { "_vtime_ticks": 16u64 << 32 },
@@ -2645,7 +2688,7 @@ mod tests {
             }))),
             Some(concat!(
                 r#"{"moment":{"_vtime_ticks":68719476736},"output_text":"after first window expired","#,
-                r#""vtime_seconds":16.0,"active_faults":{"network_partition":{"vtime":14.0}}}"#
+                r#""vtime_seconds":16.0,"active_faults":{"network_partition":{"vtime":10.0}}}"#
             ).to_string())
         );
 
@@ -2675,7 +2718,7 @@ mod tests {
     #[test]
     fn fault_injector_pause_preserves_clock_windows() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2736,7 +2779,7 @@ mod tests {
     #[test]
     fn multiple_containers_paused_simultaneously() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 
@@ -2780,7 +2823,7 @@ mod tests {
     #[test]
     fn node_fault_expires_via_max_duration() {
         let mut transformer = FaultAnnotator {
-            active_fault_windows: Vec::new(),
+            active_fault_windows: ActiveFaultWindows::new(),
             active_faults: json!({}),
         };
 

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -64,8 +64,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
         Some(RunsCommands::Events {
             run_id,
             query,
-            annotate_faults,
-        }) => cmd_runs_events(&run_id, &query, json, verbose, annotate_faults).await,
+        }) => cmd_runs_events(&run_id, &query, json, verbose).await,
     }
 }
 
@@ -285,7 +284,6 @@ async fn cmd_runs_events(
     query: &[String],
     json: bool,
     verbose: bool,
-    annotate_faults: bool,
 ) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
@@ -297,26 +295,11 @@ async fn cmd_runs_events(
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        if annotate_faults {
-            stream_ndjson_lines(
-                stream,
-                FaultAnnotator {
-                    active_fault_windows: LinkedList::new(),
-                    active_faults: json!({}),
-                },
-                |line| {
-                    writeln!(stdout, "{line}")?;
-                    Ok(())
-                },
-            )
-            .await
-        } else {
-            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-                writeln!(stdout, "{line}")?;
-                Ok(())
-            })
-            .await
-        }
+        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+            writeln!(stdout, "{line}")?;
+            Ok(())
+        })
+        .await
     } else {
         writeln!(
             stdout,

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,11 +1,14 @@
-use std::io::Write;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, LinkedList};
+use std::{io::Write, sync::OnceLock};
 use std::path::Path;
 
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
 use log::debug;
+use regex::Regex;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value, json};
 
 use crate::api::{
     AntithesisApi, Property, PropertyStatus, RunDetail, RunStatus, RunSummary, RunsFilterOptions,
@@ -33,8 +36,8 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             };
             cmd_runs_properties(&run_id, status, json, verbose).await
         }
-        Some(RunsCommands::BuildLogs { run_id }) => {
-            cmd_runs_build_logs(&run_id, json, verbose).await
+        Some(RunsCommands::BuildLogs { run_id, annotate_faults }) => {
+            cmd_runs_build_logs(&run_id, json, verbose, annotate_faults).await
         }
         Some(RunsCommands::Logs {
             run_id,
@@ -42,6 +45,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             vtime,
             begin_vtime,
             begin_input_hash,
+            annotate_faults,
         }) => {
             cmd_runs_logs(
                 &run_id,
@@ -51,11 +55,12 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
                 begin_vtime.as_deref(),
                 json,
                 verbose,
+                annotate_faults,
             )
             .await
         }
-        Some(RunsCommands::Events { run_id, query }) => {
-            cmd_runs_events(&run_id, &query, json, verbose).await
+        Some(RunsCommands::Events { run_id, query, annotate_faults }) => {
+            cmd_runs_events(&run_id, &query, json, verbose, annotate_faults).await
         }
     }
 }
@@ -222,7 +227,7 @@ fn print_run_detail(run: &RunDetail) {
     }
 }
 
-async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<()> {
+async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool, annotate_faults: bool) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;
@@ -230,13 +235,13 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
     let mut stdout = std::io::stdout().lock();
 
     if json {
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
     } else {
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
                 let ts = entry["timestamp"].as_str().unwrap_or("");
                 let stream = entry["stream"].as_str().unwrap_or("out");
@@ -251,7 +256,7 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
     }
 }
 
-async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool) -> Result<()> {
+async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool, annotate_faults: bool) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
     let api = AntithesisApi::from_env(verbose)?;
@@ -262,7 +267,7 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             writeln!(stdout, "{line}")?;
             Ok(())
         })
@@ -273,7 +278,7 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
             "{:<22}  {:<22}  {:<20}  OUTPUT",
             "HASH", "VTIME", "SOURCE"
         )?;
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let input_hash = rendered.input_hash;
@@ -301,6 +306,7 @@ async fn cmd_runs_logs(
     begin_vtime: Option<&str>,
     json: bool,
     verbose: bool,
+    annotate_faults: bool
 ) -> Result<()> {
     debug!("streaming logs for run: {}", run_id);
 
@@ -312,14 +318,14 @@ async fn cmd_runs_logs(
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
     } else {
         writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
-        stream_ndjson_lines(stream, |line| {
+        stream_ndjson_lines(stream, annotate_faults, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let vtime = rendered.vtime;
@@ -335,8 +341,11 @@ async fn cmd_runs_logs(
     }
 }
 
+const TICKS_PER_SECOND: f64 = (1u64 << 32) as f64;
+
 async fn stream_ndjson_lines<S, C>(
     mut stream: S,
+    annotate_faults: bool,
     mut process_line: impl FnMut(&str) -> Result<()>,
 ) -> Result<()>
 where
@@ -346,6 +355,9 @@ where
     use futures_util::StreamExt;
 
     let mut buf: Vec<u8> = Vec::new();
+    let mut faults_need_updating;
+    let mut active_fault_windows = LinkedList::<FaultWindow>::new();
+    let mut active_faults: Option<Value> = None;
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
@@ -356,7 +368,69 @@ where
             if !line_bytes.is_empty() {
                 let line = std::str::from_utf8(line_bytes)
                     .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-                process_line(line)?;
+                if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
+                    let mut rewrite_line = false;
+
+                    if annotate_faults {
+                        let event_vtime_ticks = entry["moment"]["_vtime_ticks"].as_u64().unwrap_or(0);
+                        let fault_name =  entry["fault"]["name"].as_str();
+                        let is_fault_injector = entry["source"]["name"].as_str().map(|source| source.eq("fault_injector")).unwrap_or(false);
+                        let faults_were_paused = is_fault_injector && 
+                            entry["info"]["message"].as_str().map(|message| message.eq("status")).unwrap_or(false) &&
+                            entry["info"]["details"]["paused"].as_bool().unwrap_or(false);
+                        let is_restore_event = fault_name.map(|n| n.eq("restore")).unwrap_or(false);
+
+                        let windows_before_scrubbing = active_fault_windows.len();
+                        // clear any fault windows that are expired or mooted by fault injector pauses
+                        active_fault_windows
+                            .extract_if(|w| w.is_expired(event_vtime_ticks) ||
+                                (faults_were_paused && (w.is_network_fault() || w.is_node_fault())) ||
+                                (is_restore_event && w.is_network_fault()))
+                            .for_each(drop);
+                        faults_need_updating = windows_before_scrubbing == active_fault_windows.len();
+
+                        if is_fault_injector && let Some(fault_name) = fault_name {
+                            let max_duration_ticks = entry["fault"]["max_duration"].as_f64().filter(|d| *d >= 0.0).map(|d| (d * TICKS_PER_SECOND) as u64);
+                            let end_vtime = max_duration_ticks.map(|duration| duration + event_vtime_ticks);
+                            let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
+
+                            if let Some(target) = entry["fault"]["affected_nodes"].as_array().and_then(|arr| arr.first()).and_then(|first| first.as_str()) {
+                                if fault_name.eq("partition") || fault_name.eq("clog") {
+                                    active_fault_windows.push_back(FaultWindow::Network { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime });
+                                    faults_need_updating = true;
+                                } else if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
+                                    active_fault_windows.push_back(FaultWindow::Node { name: fault_name.to_string(), start_vtime: event_vtime_ticks, end_vtime, container: target.to_string() });
+                                    faults_need_updating = true;
+                                }
+                            }
+
+                            if fault_name.eq("skip") && fault_type.eq("clock") && let Some(offset) = entry["fault"]["details"]["offset"].as_f64() {
+                                active_fault_windows.push_back(FaultWindow::Clock { name: fault_name.to_string(), start_vtime: event_vtime_ticks, offset, end_vtime });
+                                faults_need_updating = true;
+                            }
+                        }
+
+                        if faults_need_updating {
+                            active_faults = if active_fault_windows.is_empty() { None } else { Some(active_fault_dictionary(&active_fault_windows)) };
+                        }
+
+                        if let Some(output_text) = entry["output_text"].as_str() {
+                            entry["output_text"] = Value::String(strip_ansi(output_text));
+                            rewrite_line = true;
+                        }
+
+                        if let Some(ref faults_snapshot) = active_faults {
+                            entry["active_faults"] = faults_snapshot.clone();
+                            rewrite_line = true;
+                        }
+                    }
+
+                    let line_to_process = if rewrite_line { &format!("{}", entry) } else { line };
+
+                    process_line(line_to_process)?;
+                } else {
+                    process_line(line)?;
+                }
             }
             buf.drain(..=pos);
         }
@@ -377,6 +451,98 @@ struct RenderedEventEntry {
     vtime: String,
     source: String,
     output: String,
+}
+
+#[derive(Debug, PartialEq)]
+enum FaultWindow {
+    Network { name: String, start_vtime: u64, end_vtime: Option<u64> },
+    Node { name: String, start_vtime: u64, end_vtime: Option<u64>, container: String },
+    Clock { name: String, start_vtime: u64, offset: f64, end_vtime: Option<u64> }
+}
+
+impl FaultWindow {
+    fn get_end_vtime(&self) -> &Option<u64> {
+        match self {
+            Self::Network { name: _, start_vtime: _, end_vtime } => end_vtime,
+            Self::Node { name: _, start_vtime: _, end_vtime, container: _ } => end_vtime,
+            Self::Clock { name: _, start_vtime: _, offset: _, end_vtime } => end_vtime,
+        }
+    }
+
+    fn is_expired(&self, latest_vtime: u64) -> bool {
+        self.get_end_vtime().map(|t| t < latest_vtime).unwrap_or(false)
+    }
+
+    fn is_network_fault(&self) -> bool {
+        match self {
+            Self::Network { name: _, start_vtime: _, end_vtime: _ } => true,
+            _ => false,
+        }
+    }
+
+    fn is_node_fault(&self) -> bool {
+        match self {
+            Self::Node { name: _, start_vtime: _, end_vtime: _, container: _ } => true,
+            _ => false,
+        }
+    }
+}
+
+fn ansi_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"\x1b\[[\x20-\x3f]*[\x40-\x7e]",      // CSI: ESC [ ... final
+            r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)", // OSC: ESC ] ... (BEL | ESC \)
+            r"|\x1b[\x20-\x7e]",                   // two-byte: ESC + single printable
+        ))
+        .unwrap()
+    })
+}
+
+fn strip_ansi(text: &str) -> String {
+    ansi_re().replace_all(text, "").to_string()
+}
+
+fn active_fault_dictionary(open_windows: &LinkedList<FaultWindow>) -> Value {
+    let mut result = Map::new();
+    let mut offset_sum = 0f64;
+    let mut max_clock_fault_start: Option<u64> = None;
+    let mut network_fault_starts = HashMap::<String, u64>::new();
+    let mut node_faults = HashMap::<String, Map<String, Value>>::new();
+
+    for fault_window in open_windows {
+        if let FaultWindow::Clock { name: _, start_vtime, offset, end_vtime: _ } = fault_window {
+            max_clock_fault_start = max_clock_fault_start.map(|prev| prev.max(*start_vtime)).or(Some(*start_vtime));
+            offset_sum += offset;
+        } else if let FaultWindow::Network { name, start_vtime, end_vtime: _ } = fault_window {
+            match network_fault_starts.entry(format!("network_{}", name)) {
+                Entry::Vacant(entry) => { entry.insert(*start_vtime); },
+                Entry::Occupied(mut entry) => {
+                    if entry.get().ge(start_vtime) {
+                        entry.insert(*start_vtime);
+                    }
+                }
+            }
+        } else if let FaultWindow::Node { name, start_vtime, end_vtime: _, container } = fault_window {
+            node_faults.entry(format!("node_{}", name)).or_insert_with(|| Map::new())
+                .insert(container.clone(), json!((*start_vtime as f64) / TICKS_PER_SECOND));
+        }
+    }
+
+    for entry in network_fault_starts {
+        result[&entry.0] = json!(entry.1);
+    }
+
+    for entry in node_faults {
+        result[&entry.0] = Value::Object(entry.1);
+    }
+
+    if let Some(latest_vtime) = max_clock_fault_start {
+        result["clock_skip"] = json!({"cumulative_offset": offset_sum, "vtime": (latest_vtime as f64) / TICKS_PER_SECOND});
+    }
+
+    return Value::Object(result);
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -461,7 +461,8 @@ impl LineTransformer for FaultAnnotator {
                 && entry["info"]["details"]["paused"]
                     .as_bool()
                     .unwrap_or(false);
-            let is_restore_event = is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false);
+            let is_restore_event =
+                is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false);
 
             // clear any fault windows that are expired or mooted by fault injector pauses
             let length_before_cleanup = self.active_fault_windows.len();

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -547,6 +547,8 @@ fn mock_route_get_run_logs(_run_id: &str) -> (u16, String) {
         // bracketed label and curated fields render as <path>=<value> pairs.
         r#"{"started_task":"abc_parallel_driver_fetch","task_status":"started","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"400.5"}}"#,
         r#"{"fault":{"name":"clog","type":"network","details":{"disruption_type":"Stopped"},"affected_nodes":["client2","setup"],"max_duration":0.267},"source":{"name":"fault_injector","pid":1086},"moment":{"input_hash":"5181922178177328213","vtime":"401.5"}}"#,
+        r#"{"started_task":"abc_parallel_driver_fetch","task_status":"progressing","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"401.75"}}"#,
+        r#"{"started_task":"abc_parallel_driver_fetch","task_status":"completed","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"402"}}"#,
     ];
     (200, lines.join("\n") + "\n")
 }


### PR DESCRIPTION
Resolves #96 

This PR is meant to replicate the effect of running [process-logs.py](https://github.com/antithesishq/antithesis-skills/blob/main/antithesis-triage/assets/process-logs.py) over a log file. Annotations are applied over the log stream as new entries come in.

I'm pretty new to rust, so let me know if anything should be updated to match the expected style or be more idiomatic.