### PR TITLE
feat: detect test commands stranded in stopped containers

### DIFF
--- a/specs/help.txt
+++ b/specs/help.txt
@@ -28,7 +28,7 @@ snouty validate --help
 stdout '.*Compose configs:.*'
 stdout '.*docker-compose locally.*'
 stdout '.*setup-complete.*'
-stdout '.*Scripts are not executed.*'
+stdout '.*Test commands are not executed.*'
 stdout '.*Kubernetes configs:.*'
 stdout '.*k8s-validator.*'
 stdout '.*manifests\/.*'

--- a/specs_engine/validate_failures.txt
+++ b/specs_engine/validate_failures.txt
@@ -3,10 +3,10 @@
 # Unknown prefix file — validate errors.
 build-image unknown-prefix-failures:latest unknown_prefix
 ! snouty validate config_unknown --timeout 15
-stderr 'unrecognized command names.*'
+stderr 'Unrecognized command names.*'
 stderr 'suite/readme.txt.*'
 
-# Non-executable script — validate detects missing executable bit.
+# Non-executable test command — validate detects missing executable bit.
 build-image noexec-failures:latest noexec
 ! snouty validate config_noexec --timeout 15
 stderr 'not executable.*'

--- a/specs_engine/validate_setup.txt
+++ b/specs_engine/validate_setup.txt
@@ -1,19 +1,19 @@
 # snouty validate — positive setup cases with container runtime
 
-# Setup-complete only (no test scripts) — validate succeeds.
+# Setup-complete only (no test commands) — validate succeeds.
 build-image setup-emitter-setup:latest setup_emitter
 snouty validate config_no_scripts --timeout 15
 stderr 'Isolating networks: default.*'
 stderr 'Setup-complete event detected.*'
-stderr 'No test scripts in service.*'
+stderr 'No test commands in service.*'
 stderr 'Setup validation successful.*'
 
-# All script types discovered and validated, helper_ ignored.
-#    Includes a sidecar without scripts to verify it doesn't block validation.
+# All test command types discovered and validated, helper_ ignored.
+#    Includes a sidecar without test commands to verify it doesn't block validation.
 build-image all-types-setup:latest all_types
 snouty validate config_all_types --timeout 15
 stderr 'Setup-complete event detected.*'
-stderr 'Found 2 first, 1 driver, 1 anytime, 1 eventually, 1 finally scripts.*'
+stderr 'Found 2 first, 1 driver, 1 anytime, 1 eventually, 1 finally test commands.*'
 stderr 'Setup validation successful.*'
 
 # Setup-complete via ANTITHESIS_SDK_LOCAL_OUTPUT (legacy env var).
@@ -34,7 +34,7 @@ services:
 -- all_types/suite/first_setup --
 #!/bin/sh
 # Emit an SDK event to sdk.jsonl to verify that non-setup_complete events
-# in first scripts don't trigger the chicken-and-egg diagnostic.
+# in first_ test commands don't trigger the chicken-and-egg diagnostic.
 echo '{"antithesis_assert":{"hit":true,"must_hit":true,"assert_type":"sometimes","display_type":"Sometimes","message":"first_setup ran","condition":true,"id":"first_setup","location":{},"details":null}}' >> "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl"
 echo "first_setup ran"
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use color_eyre::Section;
 use color_eyre::eyre::{Context, Report, Result, eyre};
 use futures_util::stream;
 use log::debug;
@@ -254,7 +255,7 @@ impl AntithesisApi {
             .await
         {
             Ok(response) => Ok(response.into_inner()),
-            Err(err) => Err(format_api_client_error(err).await),
+            Err(err) => Err(format_launch_client_error(err).await),
         }
     }
 
@@ -262,7 +263,7 @@ impl AntithesisApi {
         let body = launch_mvd_request(params)?;
         match self.client.launch_mvd().body(body).send().await {
             Ok(response) => Ok(response.into_inner()),
-            Err(err) => Err(format_api_client_error(err).await),
+            Err(err) => Err(format_launch_client_error(err).await),
         }
     }
 
@@ -810,13 +811,33 @@ async fn format_api_client_error(err: ClientError<generated::types::ErrorRespons
         ClientError::InvalidResponsePayload(body, err) => {
             let body = String::from_utf8_lossy(&body);
             if body.trim().is_empty() {
-                eyre!("invalid API response payload: response body was empty")
+                eyre!("API returned an empty response body where a JSON payload was expected")
             } else {
                 let snippet = format_payload_snippet(&body, err.line(), err.column());
                 eyre!("invalid API response payload: {err}\n{snippet}")
             }
         }
         ClientError::Custom(message) => eyre!(message),
+    }
+}
+
+/// Same as [`format_api_client_error`] but adds a launch-specific suggestion
+/// when the server returned an empty body where a launch response (with
+/// `run_id`) was expected. Call from launch_test / launch_debugging only —
+/// other endpoints have their own meaningful responses for empty bodies.
+async fn format_launch_client_error(err: ClientError<generated::types::ErrorResponse>) -> Report {
+    let body_is_empty = matches!(
+        &err,
+        ClientError::InvalidResponsePayload(body, _)
+            if body.iter().all(u8::is_ascii_whitespace)
+    );
+    let report = format_api_client_error(err).await;
+    if body_is_empty {
+        report.with_suggestion(|| {
+            "this can happen when the Antithesis server is on an older version that omits expected fields (for example, run_id from a launch response). Contact Antithesis support to confirm whether your tenant needs to be upgraded."
+        })
+    } else {
+        report
     }
 }
 
@@ -949,13 +970,57 @@ mod tests {
 
         let report = format_api_client_error(err).await;
         let message = format!("{report}");
+        let debug = format!("{report:?}");
 
         assert_eq!(
             message,
-            "invalid API response payload: response body was empty"
+            "API returned an empty response body where a JSON payload was expected"
         );
         assert!(!message.contains("EOF while parsing"));
         assert!(!message.contains('^'));
+        assert!(
+            !debug.contains("Antithesis support"),
+            "generic formatter must not attach the launch-specific suggestion, got: {debug}"
+        );
+    }
+
+    #[tokio::test]
+    async fn format_launch_client_error_attaches_suggestion_for_empty_body() {
+        let parse_err = serde_json::from_slice::<serde_json::Value>(b"").unwrap_err();
+        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+            Default::default(),
+            parse_err,
+        );
+
+        let report = format_launch_client_error(err).await;
+        let debug = format!("{report:?}");
+
+        assert!(
+            debug.contains("Antithesis support"),
+            "expected launch-specific suggestion, got: {debug}"
+        );
+        assert!(
+            debug.contains("run_id from a launch response"),
+            "expected run_id wording in suggestion, got: {debug}"
+        );
+    }
+
+    #[tokio::test]
+    async fn format_launch_client_error_skips_suggestion_for_non_empty_body() {
+        let body: &[u8] = b"not json";
+        let parse_err = serde_json::from_slice::<serde_json::Value>(body).unwrap_err();
+        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+            body.to_vec().into(),
+            parse_err,
+        );
+
+        let report = format_launch_client_error(err).await;
+        let debug = format!("{report:?}");
+
+        assert!(
+            !debug.contains("Antithesis support"),
+            "non-empty body must not attach the launch suggestion, got: {debug}"
+        );
     }
 
     #[tokio::test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,14 +114,14 @@ Using Moment.from (copy from triage report):
 Compose configs:
   Runs docker-compose locally and watches for the setup-complete event to
   confirm instrumentation is working. After setup-complete is detected,
-  discovers Test Composer scripts from /opt/antithesis/test/v1 inside the
+  discovers test commands from /opt/antithesis/test/v1 inside the
   running containers and validates their structure.
 
 
-  Scripts are discovered by scanning /opt/antithesis/test/v1 from each running
-  container for {test_name}/{command} entries. Scripts are
+  Test commands are discovered by scanning /opt/antithesis/test/v1 from each
+  running container for {test_name}/{command} entries. Test commands are
   validated to have recognized prefixes and at least one driver or anytime
-  script when test scripts are present. Scripts are not executed.
+  test command when any are present. Test commands are not executed.
 
 Kubernetes configs:
   Runs docker.io/antithesishq/k8s-validator against the manifests/

--- a/src/container.rs
+++ b/src/container.rs
@@ -287,12 +287,37 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(pinned)
     }
 
-    /// Copy files from a container to the local filesystem.
+    /// Copy the Antithesis test-template tree (`/opt/antithesis/test/v1`)
+    /// out of a container into `dst`. Returns [`TestTemplates::Absent`]
+    /// when the directory does not exist inside the container — a normal
+    /// outcome for services that don't define any test commands. Real cp
+    /// failures (permission denied, runtime errors, etc.) are returned as
+    /// `Err` with stderr attached.
     ///
-    /// Runs `{runtime} cp {container_id}:{src} {dst}`.
-    fn container_cp(&self, container_id: &str, src: &str, dst: &Path) -> Result<()> {
+    /// When `running` is true, performs an unambiguous pre-flight existence
+    /// check via `runtime exec <id> test -d <path>`. When false (stopped
+    /// containers — exec is unavailable), falls back to attempting the cp
+    /// and inspecting stderr to distinguish absence from real errors.
+    fn extract_test_templates(
+        &self,
+        container_id: &str,
+        dst: &Path,
+        running: bool,
+    ) -> Result<TestTemplates> {
+        if running {
+            match self.container_path_kind(container_id, TEST_TEMPLATES_PATH)? {
+                PathKind::Directory => {}
+                PathKind::Missing => return Ok(TestTemplates::Absent),
+                PathKind::OtherOrUnknown => {
+                    // exec succeeded but path isn't a directory, or the
+                    // pre-flight is inconclusive. Fall through to cp and let
+                    // it produce the diagnostic.
+                }
+            }
+        }
+
         let runtime = self.name();
-        let src_arg = format!("{container_id}:{src}");
+        let src_arg = format!("{container_id}:{TEST_TEMPLATES_PATH}");
         let output = Command::new(runtime)
             .args(["cp", &src_arg, &dst.display().to_string()])
             .output()
@@ -300,12 +325,69 @@ pub trait ContainerRuntime: Send + Sync {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr_indicates_missing_source(&stderr) {
+                return Ok(TestTemplates::Absent);
+            }
             return Err(eyre!("'{runtime} cp' failed"))
                 .with_section(move || stderr.trim().to_string().header("Stderr:"));
         }
 
-        Ok(())
+        Ok(TestTemplates::Present)
     }
+
+    /// Probe whether `path` exists inside `container_id` (must be running).
+    /// Runs `runtime exec <id> test -d <path>`; exit 0 → Directory, exit 1 →
+    /// Missing, any other failure (no shell, container died, etc.) →
+    /// OtherOrUnknown so callers fall back to cp.
+    fn container_path_kind(&self, container_id: &str, path: &str) -> Result<PathKind> {
+        let runtime = self.name();
+        let output = Command::new(runtime)
+            .args(["exec", container_id, "test", "-d", path])
+            .output()
+            .wrap_err_with(|| format!("failed to run '{runtime} exec'"))?;
+        match output.status.code() {
+            Some(0) => Ok(PathKind::Directory),
+            Some(1) => Ok(PathKind::Missing),
+            _ => Ok(PathKind::OtherOrUnknown),
+        }
+    }
+}
+
+/// Result of [`ContainerRuntime::container_path_kind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathKind {
+    /// Path exists and is a directory.
+    Directory,
+    /// Path does not exist inside the container.
+    Missing,
+    /// Pre-flight inconclusive (no `test` binary, exec failed, etc.).
+    OtherOrUnknown,
+}
+
+/// Standard path inside a container where Antithesis test templates live.
+const TEST_TEMPLATES_PATH: &str = "/opt/antithesis/test/v1";
+
+/// Result of [`ContainerRuntime::extract_test_templates`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestTemplates {
+    /// Templates were present and copied into the destination directory.
+    Present,
+    /// The container does not have an Antithesis test-templates directory.
+    Absent,
+}
+
+/// Match patterns `docker cp` and `podman cp` emit when the source path
+/// doesn't exist inside the container. Used only as a fallback for stopped
+/// containers where the `test -d` pre-flight can't run.
+///
+/// The loose substring `"no such file"` (without "or directory") is
+/// deliberately excluded — it matches destination-side messages too.
+fn stderr_indicates_missing_source(stderr: &str) -> bool {
+    let s = stderr.to_ascii_lowercase();
+    s.contains("could not find the file")
+        || s.contains("no such file or directory")
+        || s.contains("does not exist in container")
+        || s.contains("could not be found on container")
 }
 
 /// Compose backend abstraction.
@@ -340,6 +422,18 @@ pub trait Compose: Send + Sync {
         (&[], &["--format", "json"])
     }
 
+    /// Whether `compose ps -a` is safe to use on this backend. When false,
+    /// `ps()` omits `-a` and the returned listing reports
+    /// `includes_stopped = false` so callers can suppress diagnostics that
+    /// depend on seeing stopped containers.
+    ///
+    /// Older `podman-compose` rejects `-a`, and even where it's accepted it
+    /// has been observed to dispatch to `podman ps -a` and leak containers
+    /// from unrelated projects.
+    fn supports_ps_all(&self) -> bool {
+        true
+    }
+
     // --- default implementations ---
 
     /// Run `compose config` to resolve the compose file with env substitutions,
@@ -372,15 +466,26 @@ pub trait Compose: Send + Sync {
         parse_compose_config(&yaml)
     }
 
-    /// Parse `compose ps --format json` to get `(service_name, container_id)` pairs.
-    fn ps(&self, config: &ComposeConfig, overlay: Option<&Path>) -> Result<Vec<(String, String)>> {
+    /// Parse `compose ps [-a] --format json` into a [`PsListing`].
+    ///
+    /// Passes `-a` only when [`supports_ps_all`](Self::supports_ps_all) is
+    /// true, so stopped/exited containers are included alongside running
+    /// ones. Callers can then check [`ComposeContainer::stopped`] to decide
+    /// what to do with them. The returned listing's `includes_stopped`
+    /// indicates whether the backend was queried with `-a`.
+    fn ps(&self, config: &ComposeConfig, overlay: Option<&Path>) -> Result<PsListing> {
         let runtime = self.runtime().name();
+        let includes_stopped = self.supports_ps_all();
         let mut cmd = self.runtime().command(&["compose"]);
         cmd.current_dir(config.dir());
         let (pre, post) = self.ps_extra_args();
         cmd.args(compose_file_args(overlay));
         cmd.args(pre);
-        cmd.args(["ps"]);
+        if includes_stopped {
+            cmd.args(["ps", "-a"]);
+        } else {
+            cmd.arg("ps");
+        }
         cmd.args(post);
 
         let output = cmd
@@ -394,7 +499,11 @@ pub trait Compose: Send + Sync {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        parse_compose_ps(&stdout)
+        let containers = parse_compose_ps(&stdout)?;
+        Ok(PsListing {
+            containers,
+            includes_stopped,
+        })
     }
 
     /// Run a command inside a running compose service container.
@@ -534,6 +643,15 @@ impl Compose for PodmanCompose<'_> {
 
     fn ps_extra_args(&self) -> (&[&str], &[&str]) {
         (&["--podman-args=--format=json"], &[])
+    }
+
+    fn supports_ps_all(&self) -> bool {
+        // podman-compose's `ps` rejects `-a` in older releases, and where it
+        // is accepted the call has been observed to dispatch to `podman ps -a`
+        // (returning containers from all projects). Skip `-a` here, which also
+        // means the stranded-test-commands diagnostic doesn't fire on native
+        // podman-compose.
+        false
     }
 }
 
@@ -990,14 +1108,52 @@ fn is_local_image(image: &str) -> bool {
     }
 }
 
+/// A container reported by `compose ps`, with just the fields snouty needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeContainer {
+    /// Compose service name (e.g. `"app"`).
+    pub service: String,
+    /// Container ID (whatever the runtime emitted — short or full).
+    pub id: String,
+    /// Whether the container's entrypoint has exited. Antithesis can't run
+    /// test commands in stopped containers, so validate flags any service
+    /// that has test commands defined but ended up in this state. Only
+    /// `exited` and `dead` count as stopped — transient states like
+    /// `created`, `restarting`, `paused`, and missing State are treated as
+    /// not-stopped to avoid false positives on healthy setups still settling.
+    pub stopped: bool,
+}
+
+/// Result of [`Compose::ps`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PsListing {
+    /// Containers reported by `compose ps`.
+    pub containers: Vec<ComposeContainer>,
+    /// Whether the listing included stopped containers (i.e. whether `-a`
+    /// was supported and passed). When false, callers must not rely on the
+    /// absence of a service in the listing to mean it isn't stopped.
+    pub includes_stopped: bool,
+}
+
+/// Determine whether a `State` field value reports a stopped container.
+/// Only `exited` and `dead` qualify — every other value (including missing
+/// `State`, transient `created`/`restarting`/`paused`, and human-readable
+/// forms like "Up 5 seconds") is treated as not-stopped.
+fn state_is_stopped(state: Option<&str>) -> bool {
+    match state {
+        Some(s) => s.eq_ignore_ascii_case("exited") || s.eq_ignore_ascii_case("dead"),
+        None => false,
+    }
+}
+
 /// Parse the JSON output of `compose ps --format json`.
 ///
 /// Handles both NDJSON (one object per line) and JSON array formats.
 ///
 /// Two schemas are supported:
-/// - **docker compose**: `{"Service": "...", "ID": "..."}`
-/// - **podman-compose** (native podman ps): `{"Id": "...", "Labels": {"com.docker.compose.service": "..."}}`
-fn parse_compose_ps(stdout: &str) -> Result<Vec<(String, String)>> {
+/// - **docker compose**: `{"Service": "...", "ID": "...", "State": "running"}`
+/// - **podman-compose** (native podman ps): `{"Id": "...", "State": "running", "Labels": {"com.docker.compose.service": "..."}}`
+fn parse_compose_ps(stdout: &str) -> Result<Vec<ComposeContainer>> {
     let stdout = stdout.trim();
     if stdout.is_empty() {
         return Ok(Vec::new());
@@ -1034,7 +1190,16 @@ fn parse_compose_ps(stdout: &str) -> Result<Vec<(String, String)>> {
                 })
                 .ok_or_else(|| eyre!("missing service name in compose ps output"))?;
 
-            Ok((service.to_string(), id.to_string()))
+            let state = v
+                .get("State")
+                .or_else(|| v.get("state"))
+                .and_then(|v| v.as_str());
+
+            Ok(ComposeContainer {
+                service: service.to_string(),
+                id: id.to_string(),
+                stopped: state_is_stopped(state),
+            })
         })
         .collect()
 }
@@ -1111,30 +1276,35 @@ mod tests {
         }
     }
 
+    fn cc(service: &str, id: &str, stopped: bool) -> ComposeContainer {
+        ComposeContainer {
+            service: service.to_string(),
+            id: id.to_string(),
+            stopped,
+        }
+    }
+
     #[test]
     fn parse_compose_ps_ndjson() {
         let stdout = "{\"ID\":\"abc123\",\"Service\":\"app\",\"State\":\"running\"}\n\
-                      {\"ID\":\"def456\",\"Service\":\"sidecar\",\"State\":\"running\"}\n";
+                      {\"ID\":\"def456\",\"Service\":\"sidecar\",\"State\":\"exited\"}\n";
         let result = parse_compose_ps(stdout).unwrap();
         assert_eq!(
             result,
-            vec![
-                ("app".to_string(), "abc123".to_string()),
-                ("sidecar".to_string(), "def456".to_string()),
-            ]
+            vec![cc("app", "abc123", false), cc("sidecar", "def456", true)]
         );
     }
 
     #[test]
     fn parse_compose_ps_json_array() {
-        let stdout = r#"[{"ID":"abc123","Service":"app"},{"ID":"def456","Service":"sidecar"}]"#;
+        let stdout = r#"[
+            {"ID":"abc123","Service":"app","State":"running"},
+            {"ID":"def456","Service":"sidecar","State":"running"}
+        ]"#;
         let result = parse_compose_ps(stdout).unwrap();
         assert_eq!(
             result,
-            vec![
-                ("app".to_string(), "abc123".to_string()),
-                ("sidecar".to_string(), "def456".to_string()),
-            ]
+            vec![cc("app", "abc123", false), cc("sidecar", "def456", false)]
         );
     }
 
@@ -1150,22 +1320,105 @@ mod tests {
             {
                 "Id": "abc123",
                 "Names": ["project-app-1"],
+                "State": "running",
                 "Labels": {"com.docker.compose.service": "app"}
             },
             {
                 "Id": "def456",
                 "Names": ["project-sidecar-1"],
+                "State": "exited",
                 "Labels": {"com.docker.compose.service": "sidecar"}
             }
         ]"#;
         let result = parse_compose_ps(stdout).unwrap();
         assert_eq!(
             result,
+            vec![cc("app", "abc123", false), cc("sidecar", "def456", true)]
+        );
+    }
+
+    #[test]
+    fn parse_compose_ps_missing_state_is_not_stopped() {
+        // A container with no State field — typical during early startup —
+        // must NOT be classified as stopped, or the stranded-test-commands
+        // diagnostic fires on healthy containers.
+        let stdout = r#"[{"ID":"abc","Service":"app"}]"#;
+        let result = parse_compose_ps(stdout).unwrap();
+        assert_eq!(result, vec![cc("app", "abc", false)]);
+    }
+
+    #[test]
+    fn parse_compose_ps_transient_states_are_not_stopped() {
+        // created / restarting / paused are not "stopped" — Antithesis may
+        // still see them recover. Only `exited` and `dead` count as stopped.
+        let stdout = r#"[
+            {"ID":"a","Service":"svc","State":"created"},
+            {"ID":"b","Service":"svc","State":"restarting"},
+            {"ID":"c","Service":"svc","State":"paused"},
+            {"ID":"d","Service":"svc","State":"Up 5 seconds"},
+            {"ID":"e","Service":"svc","State":"dead"},
+            {"ID":"f","Service":"svc","State":"EXITED"}
+        ]"#;
+        let result = parse_compose_ps(stdout).unwrap();
+        let stopped: Vec<(&str, bool)> =
+            result.iter().map(|c| (c.id.as_str(), c.stopped)).collect();
+        assert_eq!(
+            stopped,
             vec![
-                ("app".to_string(), "abc123".to_string()),
-                ("sidecar".to_string(), "def456".to_string()),
+                ("a", false),
+                ("b", false),
+                ("c", false),
+                ("d", false),
+                ("e", true),
+                ("f", true),
             ]
         );
+    }
+
+    #[test]
+    fn parse_compose_ps_returns_one_entry_per_replica() {
+        // Scaled services (`replicas: N`) emit one entry per container, all
+        // sharing the same Service value but with distinct IDs. Validate
+        // keys per-container work by container.id rather than service.
+        let stdout = r#"[
+            {"ID":"a1","Service":"worker","State":"running"},
+            {"ID":"a2","Service":"worker","State":"running"},
+            {"ID":"a3","Service":"worker","State":"exited"}
+        ]"#;
+        let result = parse_compose_ps(stdout).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                cc("worker", "a1", false),
+                cc("worker", "a2", false),
+                cc("worker", "a3", true),
+            ]
+        );
+    }
+
+    #[test]
+    fn stderr_indicates_missing_source_matches_docker_and_podman() {
+        assert!(stderr_indicates_missing_source(
+            "Error response from daemon: Could not find the file /opt/x in container abc"
+        ));
+        assert!(stderr_indicates_missing_source(
+            "Error: \"/opt/antithesis/test/v1\": no such file or directory"
+        ));
+        // Podman 4.x phrasings.
+        assert!(stderr_indicates_missing_source(
+            "Error: \"/opt/antithesis/test/v1\" does not exist in container"
+        ));
+        assert!(stderr_indicates_missing_source(
+            "Error: /opt/antithesis/test/v1 could not be found on container abc"
+        ));
+        // Real cp errors must not be misclassified.
+        assert!(!stderr_indicates_missing_source("Error: permission denied"));
+        // The loose "no such file" (without "or directory") is deliberately
+        // excluded — it matches destination-side errors and shadows real
+        // failures.
+        assert!(!stderr_indicates_missing_source(
+            "Error: writing to destination: no such file"
+        ));
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Seek;
 use std::path::{Path, PathBuf};
 
 use color_eyre::Section;
+use color_eyre::SectionExt;
 use color_eyre::eyre::{Context, Result, bail, eyre};
-use log::{debug, info};
+use log::{debug, info, warn};
 use serde::Deserialize;
 use tokio::time::{Duration, sleep};
 
@@ -376,63 +377,184 @@ fn contains_setup_complete(reader: &mut (impl std::io::Read + std::io::Seek)) ->
     Ok(false)
 }
 
-/// Discover test scripts from running containers.
+/// Discover test commands across all compose containers, including stopped
+/// ones when the backend supports `compose ps -a`.
+///
+/// Each container is inspected regardless of state — Antithesis only runs
+/// test commands in *running* containers, but we still inspect stopped ones
+/// (when visible) so we can fail validation with a clear error when test
+/// commands are stranded in a container whose entrypoint exited prematurely.
+/// Supports scaled services (`replicas > 1`): per-container scratch dirs are
+/// keyed on container ID so replicas don't trample each other's extracts.
+///
+/// Tolerates per-container `cp` failures — the loop logs a warning and
+/// moves on. Only if every container failed (and no scripts were collected)
+/// does the function surface a combined error.
 fn discover_scripts(
     compose: &dyn container::Compose,
     config: &ComposeConfig,
     overlay: Option<&Path>,
     temp_dir: &Path,
 ) -> Result<Vec<TestScript>> {
-    let services = compose.ps(config, overlay)?;
+    let listing = compose.ps(config, overlay)?;
 
     let scripts_dir = temp_dir.join("scripts");
     std::fs::create_dir_all(&scripts_dir).wrap_err("failed to create scripts directory")?;
 
     let mut all_scripts: Vec<TestScript> = Vec::new();
-    for (service_name, container_id) in &services {
-        let service_dir = scripts_dir.join(service_name);
-        match compose
-            .runtime()
-            .container_cp(container_id, "/opt/antithesis/test/v1", &service_dir)
-        {
-            Ok(()) => {
-                let result = scan_scripts(&service_dir, service_name)?;
-                if !result.unrecognized.is_empty() {
-                    let mut err = eyre!(
-                        "unrecognized command names in service {service_name} (not a known prefix or helper_)"
-                    );
-                    for command in result.unrecognized {
-                        err = err.with_note(|| command);
-                    }
-                    return Err(err);
-                }
-                if !result.not_executable.is_empty() {
-                    let mut err = eyre!("scripts in service {service_name} are not executable");
-                    for command in result.not_executable {
-                        err = err.with_note(|| command);
-                    }
-                    return Err(err);
-                }
-                if result.scripts.is_empty() {
-                    eprintln!("No scripts found in {service_name}");
-                }
-                info!(
-                    "Found {} scripts in service '{service_name}'",
-                    result.scripts.len()
+    // Replicas share an image, so each one rediscovers the same scripts. Track
+    // (service, test_name, command_name) to count each command once instead of
+    // once per replica.
+    let mut seen_scripts: BTreeSet<(String, String, String)> = BTreeSet::new();
+    let mut stopped_with_scripts: BTreeSet<String> = BTreeSet::new();
+    let mut unrecognized: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut not_executable: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut cp_failures: BTreeMap<String, color_eyre::Report> = BTreeMap::new();
+
+    for container in &listing.containers {
+        let service_name = container.service.as_str();
+        // Key per-container so scaled-replica containers don't collide on
+        // disk. Short the id for readable warnings.
+        let short_id: String = container.id.chars().take(12).collect();
+        let service_dir = scripts_dir.join(format!("{service_name}-{short_id}"));
+        let templates = match compose.runtime().extract_test_templates(
+            &container.id,
+            &service_dir,
+            !container.stopped,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(
+                    "extracting test commands from service '{service_name}' \
+                     (container {short_id}) failed; continuing without it: {e}"
                 );
-                all_scripts.extend(result.scripts);
-            }
-            Err(_) => {
-                info!("No test scripts in service '{service_name}'");
+                cp_failures.insert(format!("{service_name} ({short_id})"), e);
                 continue;
             }
+        };
+
+        if matches!(templates, container::TestTemplates::Absent) {
+            info!("No test commands in service '{service_name}' (container {short_id})");
+            continue;
         }
+
+        let result = scan_scripts(&service_dir, service_name)?;
+        for command in result.unrecognized {
+            unrecognized
+                .entry(service_name.to_string())
+                .or_default()
+                .insert(command);
+        }
+        for command in result.not_executable {
+            not_executable
+                .entry(service_name.to_string())
+                .or_default()
+                .insert(command);
+        }
+        if result.scripts.is_empty() {
+            info!("No test commands found in service '{service_name}' (container {short_id})");
+        } else {
+            info!(
+                "Found {} test commands in service '{service_name}' (container {short_id})",
+                result.scripts.len()
+            );
+            if container.stopped && listing.includes_stopped {
+                stopped_with_scripts.insert(service_name.to_string());
+            }
+            all_scripts.extend(result.scripts.into_iter().filter(|s| {
+                seen_scripts.insert((
+                    s.service.clone(),
+                    s.test_name.clone(),
+                    s.command_name.clone(),
+                ))
+            }));
+        }
+    }
+
+    // If every container failed to surrender its templates and nothing
+    // useful was discovered, surface the underlying errors instead of
+    // silently succeeding with an empty script list.
+    if !cp_failures.is_empty()
+        && all_scripts.is_empty()
+        && unrecognized.is_empty()
+        && not_executable.is_empty()
+        && cp_failures.len() == listing.containers.len()
+    {
+        let mut err = eyre!("failed to extract test commands from every container");
+        for (label, cause) in &cp_failures {
+            err = err.with_section(|| format!("{label}: {cause:?}").header("Container:"));
+        }
+        return Err(err);
+    }
+
+    if !unrecognized.is_empty() || !not_executable.is_empty() || !stopped_with_scripts.is_empty() {
+        return Err(combined_discovery_error(
+            unrecognized,
+            not_executable,
+            stopped_with_scripts,
+        ));
     }
 
     Ok(all_scripts)
 }
 
-/// Validate the structure of discovered test scripts without executing them.
+/// Build a single error report covering every category of discovery problem
+/// found across all containers. Sections are sorted by service name for
+/// deterministic output.
+fn combined_discovery_error(
+    unrecognized: BTreeMap<String, BTreeSet<String>>,
+    not_executable: BTreeMap<String, BTreeSet<String>>,
+    stopped_with_scripts: BTreeSet<String>,
+) -> color_eyre::Report {
+    let mut err = eyre!("test command discovery failed");
+
+    for (service, commands) in &unrecognized {
+        let listing = commands
+            .iter()
+            .map(|c| format!("  {c}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        err = err.with_section(|| {
+            listing.header(format!(
+                "Unrecognized command names in service '{service}' (not a known prefix or helper_):"
+            ))
+        });
+    }
+
+    for (service, commands) in &not_executable {
+        let listing = commands
+            .iter()
+            .map(|c| format!("  {c}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        err = err.with_section(|| {
+            listing.header(format!(
+                "Test commands in service '{service}' are not executable:"
+            ))
+        });
+    }
+
+    if !stopped_with_scripts.is_empty() {
+        let listing = stopped_with_scripts
+            .iter()
+            .map(|s| format!("  {s}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        err = err.with_section(|| {
+            listing.header(
+                "Services contain Antithesis test commands but their containers exited. \
+                 Antithesis cannot run test commands in stopped containers:",
+            )
+        });
+        err = err.with_suggestion(|| {
+            "set the service's command/entrypoint to a long-running process (for example `sleep infinity`, or `tail -f /dev/null`) so the container stays alive for the duration of the test"
+        });
+    }
+
+    err
+}
+
+/// Validate the structure of discovered test commands without executing them.
 fn validate_test_scripts(scripts: &[TestScript]) -> Result<()> {
     let first = scripts
         .iter()
@@ -453,12 +575,12 @@ fn validate_test_scripts(scripts: &[TestScript]) -> Result<()> {
         .count();
 
     eprintln!(
-        "Found {} first, {} driver, {} anytime, {} eventually, {} finally scripts",
+        "Found {} first, {} driver, {} anytime, {} eventually, {} finally test commands",
         first, drivers, anytime, eventually, finally,
     );
 
     if scripts.is_empty() {
-        debug!("no services contained test scripts");
+        debug!("no services contained test commands");
         return Ok(());
     }
 

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -59,7 +59,7 @@ fn validate_help_documents_compose_and_kubernetes() {
         .stdout(predicate::str::contains("Compose configs:"))
         .stdout(predicate::str::contains("docker-compose locally"))
         .stdout(predicate::str::contains("setup-complete"))
-        .stdout(predicate::str::contains("Scripts are not executed"))
+        .stdout(predicate::str::contains("Test commands are not executed"))
         .stdout(predicate::str::contains("Kubernetes configs:"))
         .stdout(predicate::str::contains("k8s-validator"))
         .stdout(predicate::str::contains("manifests/"));


### PR DESCRIPTION
validate now inspects every compose container, not just running ones. compose ps returns a PsListing carrying per-container stopped state (via compose ps -a where the backend supports it), and discover_scripts fails with a clear diagnostic when a service defines test commands but its container has exited, since Antithesis can't run commands in stopped containers. Native podman-compose opts out of -a (it rejects the flag or leaks containers from other projects), so the diagnostic is suppressed there.

extract_test_templates replaces container_cp: for running containers it does an unambiguous 'test -d' pre-flight, and for stopped ones it falls back to matching cp stderr to distinguish a missing templates directory from a real copy failure. Per-container scratch dirs keyed on container id support scaled replicas.

Also rename user-facing 'scripts' / 'Test Composer scripts' to 'test commands' throughout, and attach an Antithesis-support suggestion when a launch request gets an empty response body (older server omitting run_id).