### PR TITLE
feat: load env variables from .env file if exists

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .claude/settings.local.json
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtor"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2498,7 @@ dependencies = [
  "console",
  "ctor",
  "dirs",
+ "dotenvy",
  "env_logger",
  "form_urlencoded",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ default-run = "snouty"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+dotenvy = "0.15"
 getrandom = "0.3"
 env_logger = "0.11"
 form_urlencoded = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn get_params(args: Vec<String>, use_stdin: bool, support_moment: bool) -> Resul
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    // Load a local .env file if present. Real environment variables take
+    // precedence over values in the file (dotenvy does not override).
+    let dotenv_path = dotenvy::dotenv().ok();
     color_eyre::install().unwrap();
     env_logger::Builder::from_default_env()
         .format(|buf, record| {
@@ -70,6 +73,9 @@ async fn main() -> Result<()> {
             writeln!(buf, "{}", record.args())
         })
         .init();
+    if let Some(path) = &dotenv_path {
+        debug!("loaded environment from {}", path.display());
+    }
     let cli = Cli::parse();
 
     let json = cli.json;


### PR DESCRIPTION
- snouty looks for a .env file in the current directory, walking up to parent
  directories if none is found
- reads all config from it: API key, username, password, tenant, repo
- real shell env vars take precedence over .env — no override, the shell wins
- if there's no .env, snouty works exactly as before — nothing breaks
- adds the dotenvy crate, loaded before anything reads the environment
- .env is added to .gitignore so secrets don't leak into git
- a Claude settings rule denies reading .env files, so the agent can't see secrets