### PR TITLE
docs: unhide and document the  subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,19 @@ export ANTITHESIS_PASSWORD="your-password"
 Snouty provides the following subcommands. Invoke `snouty <command> --help` to find out more.
 
 - `snouty launch`: push images and kick off an Antithesis run.
-- `snouty validate`: locally run and validate your docker-compose.yaml setup.
-- `snouty docs`: fast, local search of the Antithesis documentation.
+- `snouty runs`: list and inspect Antithesis test runs and their results.
+  - `snouty runs list`: list runs, with status/launcher/date filters.
+  - `snouty runs show <run_id>`: show details for a single run.
+  - `snouty runs properties <run_id>`: list property (assertion) results.
+  - `snouty runs build-logs <run_id>`: stream a run's build logs.
+  - `snouty runs logs <run_id> <hash> <vtime>`: stream logs for a moment.
+  - `snouty runs events <run_id> <query>`: search events in a run.
 - `snouty debug`: start a debug session.
+- `snouty validate`: locally run and validate your docker-compose.yaml setup.
+- `snouty api webhook`: send a raw request to an Antithesis webhook endpoint.
+- `snouty doctor`: check your environment is configured correctly.
+- `snouty docs`: fast, local search of the Antithesis documentation.
+- `snouty completions <shell>`: generate shell completion scripts.
 - `snouty update`: install the latest version.
 
 ## Shell Completions

--- a/specs/help.txt
+++ b/specs/help.txt
@@ -12,6 +12,7 @@ stdout 'snouty \d+\.\d+\.\d+'
 snouty --help
 stdout '.*debug.*'
 stdout '.*version.*'
+stdout '.*runs.*'
 stdout '.*api.*'
 stdout '.*docs.*'
 stdout '.*completions.*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,7 +58,6 @@ Environment variables:
 
     /// Interact with test runs
     #[command(
-        hide = true,
         long_about = r#"Interact with test runs
 
 List, inspect, and view logs for Antithesis test runs.


### PR DESCRIPTION
The `runs` subcommand (list/show/properties/build-logs/logs/events) was already implemented but marked hidden, so it never appeared in `snouty --help` or the README — making it look like only raw API requests were supported.

- cli: unhide the `runs` command so it shows in `--help`
- readme: complete the Usage list (add runs + subcommands, api webhook, doctor, completions)
- specs: assert `runs` appears in `--help` output