### PR TITLE
Short-circuit run properties/build logs for runs that predate them

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -275,6 +275,7 @@ impl AntithesisApi {
     }
 
     pub async fn get_run_build_logs(&self, run_id: &str) -> Result<ByteStream> {
+        ensure_resource_supported(run_id, MIN_BUILD_LOGS_VERSION, "build logs")?;
         match self.client.get_run_build_logs().run_id(run_id).send().await {
             Ok(response) => Ok(response.into_inner()),
             Err(err) => Err(format_api_client_error(err).await),
@@ -317,6 +318,7 @@ impl AntithesisApi {
         paginate(move |after| {
             let run_id = run_id.clone();
             async move {
+                ensure_resource_supported(&run_id, MIN_PROPERTIES_VERSION, "run properties")?;
                 let page = self
                     .fetch_run_properties_page(&run_id, after.as_deref(), status)
                     .await?;
@@ -716,6 +718,54 @@ fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequ
         generated::types::builder::LaunchMvdRequest::default().params(typed_params),
     )
     .wrap_err("failed to build debugging request")
+}
+
+/// The tenant version that first served the run properties resource. Runs
+/// created on older tenants 404 on `/runs/{run_id}/properties`.
+const MIN_PROPERTIES_VERSION: u32 = 52;
+
+/// The tenant version that first served the run build logs resource. Runs
+/// created on older tenants 404 on `/runs/{run_id}/build_logs`.
+///
+/// Note the other nested run resources have different (or no) cutoffs: run
+/// properties arrived in v52, while logs and events are served for every
+/// version we can produce, so neither needs a guard.
+const MIN_BUILD_LOGS_VERSION: u32 = 54;
+
+/// Run IDs encode the tenant version that produced them as their second
+/// dash-delimited field — e.g. the `40` in
+/// `e88ec3ec6cdb7b31ea08718616e04849-40-11`, which is structured as
+/// `{hash}-{version}-{tenant_version}`. Returns an error when that version
+/// predates `min_version`, since `resource` does not exist for those runs and
+/// the server would otherwise answer with an opaque 404.
+///
+/// When the run ID doesn't match the expected structure the run is allowed
+/// through, letting the server respond authoritatively rather than guessing
+/// from the format.
+fn ensure_resource_supported(run_id: &str, min_version: u32, resource: &str) -> Result<()> {
+    if let Some(version) = run_version(run_id)
+        && version < min_version
+    {
+        return Err(eyre!(
+            "run {run_id} was generated on a tenant before v{min_version}, which introduced the {resource} API being used. Re-run {run_id} on a more recent version to access {resource}."
+        ));
+    }
+    Ok(())
+}
+
+/// Extracts the tenant version encoded in a run ID structured as
+/// `{hash}-{version}-{tenant_version}`, where the hash is a 32-character hex
+/// string. Returns `None` when the ID doesn't match that structure (e.g. test
+/// fixtures or future formats), so callers don't act on a misread version.
+fn run_version(run_id: &str) -> Option<u32> {
+    let parts: Vec<&str> = run_id.split('-').collect();
+    let [hash, version, _tenant_version] = parts.as_slice() else {
+        return None;
+    };
+    if hash.len() != 32 || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    version.parse::<u32>().ok()
 }
 
 fn format_api_error(status: u16, body: &str) -> Report {
@@ -1450,5 +1500,55 @@ mod tests {
         let debug = format!("{:?}", auth);
         assert!(!debug.contains("secret-key"));
         assert!(debug.contains("[REDACTED]"));
+    }
+
+    fn rid(version: u32) -> String {
+        format!("e88ec3ec6cdb7b31ea08718616e04849-{version}-11")
+    }
+
+    #[test]
+    fn properties_rejected_before_v52() {
+        let err = ensure_resource_supported(&rid(40), MIN_PROPERTIES_VERSION, "run properties")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("before v52"));
+        assert!(err.contains("run properties"));
+        assert!(err.contains("Re-run") && err.contains("more recent version"));
+        // v51 is the last version without properties.
+        assert!(
+            ensure_resource_supported(&rid(51), MIN_PROPERTIES_VERSION, "run properties").is_err()
+        );
+    }
+
+    #[test]
+    fn properties_allowed_at_and_after_v52() {
+        ensure_resource_supported(&rid(52), MIN_PROPERTIES_VERSION, "run properties").unwrap();
+        ensure_resource_supported(&rid(60), MIN_PROPERTIES_VERSION, "run properties").unwrap();
+    }
+
+    #[test]
+    fn build_logs_rejected_before_v54() {
+        // build logs arrive two versions after properties, so v52/v53 are still rejected.
+        assert!(ensure_resource_supported(&rid(52), MIN_BUILD_LOGS_VERSION, "build logs").is_err());
+        let err = ensure_resource_supported(&rid(53), MIN_BUILD_LOGS_VERSION, "build logs")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("before v54"));
+        assert!(err.contains("build logs"));
+    }
+
+    #[test]
+    fn build_logs_allowed_at_and_after_v54() {
+        ensure_resource_supported(&rid(54), MIN_BUILD_LOGS_VERSION, "build logs").unwrap();
+        ensure_resource_supported(&rid(60), MIN_BUILD_LOGS_VERSION, "build logs").unwrap();
+    }
+
+    #[test]
+    fn resource_allowed_when_version_unparsable() {
+        // Unexpected formats are allowed through so the server can respond.
+        for id in ["run-1", "no-dashes", "plainrunid"] {
+            ensure_resource_supported(id, MIN_PROPERTIES_VERSION, "run properties").unwrap();
+            ensure_resource_supported(id, MIN_BUILD_LOGS_VERSION, "build logs").unwrap();
+        }
     }
 }


### PR DESCRIPTION
Run IDs encode the tenant version that produced them as their second dash-delimited field — the `40` in `e88ec3ec6cdb7b31ea08718616e04849-40-11`, structured as `{hash}-{version}-{tenant_version}`. Some nested run resources were only added in later versions, so requesting them for an older run returns an opaque `404 Not Found — Resource not found`. This parses that version before hitting the API and returns a clear, actionable error instead, telling the user to re-run on a more recent version to access the resource.

I verified the actual per-resource cutoffs empirically against real runs on the `orbitinghail` tenant (guard disabled, sampling multiple runs per version):

| endpoint | available from | pre-cutoff behavior |
|---|---|---|
| run properties | **v52** | 404 |
| build logs | **v54** | 404 |
| logs | all versions (v40+) | served |
| events | all versions (v40+) | served |

So the guard is applied per-resource at its own cutoff — `properties` at v52, `build_logs` at v54 — and `logs`/`events` are intentionally left unguarded since the server serves them for every run we can produce.

Run IDs that don't match the `{hash}-{version}-{tenant_version}` structure (32-char hex hash) pass through untouched — including test fixtures and any future formats — so the server stays authoritative.

Closes #118