### PR TITLE
fix: give setup-complete watch its own timeout budget in validate

### DIFF
--- a/specs_engine/validate_setup.txt
+++ b/specs_engine/validate_setup.txt
@@ -10,8 +10,9 @@ stderr 'Setup validation successful.*'
 
 # All test command types discovered and validated, helper_ ignored.
 #    Includes a sidecar without test commands to verify it doesn't block validation.
+#    Two services start here, so allow extra headroom on slow runtimes.
 build-image all-types-setup:latest all_types
-snouty validate config_all_types --timeout 15
+snouty validate config_all_types --timeout 30
 stderr 'Setup-complete event detected.*'
 stderr 'Found 2 first, 1 driver, 1 anytime, 1 eventually, 1 finally test commands.*'
 stderr 'Setup validation successful.*'

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -212,7 +212,7 @@ async fn validate_compose(
         );
     }
 
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
+    let up_deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
 
     eprintln!("Starting compose services...");
     let mut up_child = compose.up_detached(&config, overlay)?;
@@ -234,7 +234,7 @@ async fn validate_compose(
                 bail!("compose up --detach failed (exit status: {status})");
             }
         }
-        _ = tokio::time::sleep_until(deadline) => {
+        _ = tokio::time::sleep_until(up_deadline) => {
             up_child.kill_group().await.ok();
             bail!("timed out during 'compose up --detach'");
         }
@@ -247,6 +247,11 @@ async fn validate_compose(
     // Discover scripts early so we can use them for both the success path
     // and the timeout diagnostic.
     let scripts = discover_scripts(&*compose, &config, overlay, temp_dir)?;
+
+    // Reset the budget now that containers are up. `--timeout` bounds how long
+    // we wait for the setup-complete event; slow container startup (e.g. several
+    // services, or a slow runtime like podman-on-macOS) shouldn't eat into it.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
 
     let mut logs_child = compose.logs_follow(&config, overlay)?;
 


### PR DESCRIPTION
The `validate --timeout` deadline was set before `compose up` and shared between container startup and the wait for the setup-complete event. On slow runtimes (e.g. podman-on-macOS) starting multiple services could consume most of the budget, leaving little time for the event to arrive — producing spurious `timed out waiting for setup-complete event` failures even though startup and script discovery had succeeded. This is what flaked the `config_all_types` case (two services) of `podman_engine_validate_setup_specs` on the macOS-intel runner.

Reset the deadline once containers are up so `--timeout` bounds only the event wait, as intended. Container startup still has its own `--timeout` budget via a separate `up_deadline`.

Also bump the two-service `config_all_types` spec case from `--timeout 15` to `--timeout 30` for extra headroom on slow runtimes.