### PR TITLE
fix: always build config image for amd64

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -237,9 +237,12 @@ pub trait ContainerRuntime: Send + Sync {
     /// Callers are responsible for validating the directory beforehand
     /// (typically via [`crate::config::detect_config`]). Returns the pinned
     /// image reference.
+    ///
+    /// The image is always built for `linux/amd64` (x86-64) because Antithesis
+    /// does not support arm64, and the host may well be an arm machine.
     fn build_and_push_config_image(&self, config_dir: &Path, image_ref: &str) -> Result<String> {
         eprintln!("Building config image: {}", image_ref);
-        self.build_image(config_dir, image_ref, None, None)?;
+        self.build_image(config_dir, image_ref, None, Some("linux/amd64"))?;
 
         eprintln!("Pushing config image: {}", image_ref);
         let pinned = self.image_push(image_ref)?;
@@ -1270,6 +1273,13 @@ mod tests {
             let image_ref = format!("{addr}/test/snouty-config:test");
             rt.build_and_push_config_image(dir.path(), &image_ref)
                 .unwrap_or_else(|e| panic!("{}: {e:?}", rt.name()));
+
+            // The config image must always be amd64: Antithesis does not support
+            // arm64, and this build runs unchanged on arm hosts.
+            let arch = rt
+                .image_architecture(&image_ref)
+                .unwrap_or_else(|e| panic!("{}: {e:?}", rt.name()));
+            assert_eq!(arch, "amd64", "{}: config image must be amd64", rt.name());
 
             // Clean up the local image.
             let _ = Command::new(rt.name()).args(["rmi", &image_ref]).output();


### PR DESCRIPTION
Antithesis only supports x86-64 (amd64) container images, but `build_and_push_config_image` was building with no explicit platform. On an arm64 host that meant the auto-generated config image got stamped `arm64` and rejected by the platform.

This passes `--platform linux/amd64` for the config-image build. Because the config image is `FROM scratch` + `COPY . /` with no `RUN` steps, there's no QEMU emulation involved, so it builds on any standard Docker/Podman install without needing multi-platform support enabled — and it adds no new build requirement, since this is the trivial no-emulation cross-arch case.