### PR TITLE
fix: runs list robustness and clearer auth errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ SNOUTY_STAGING=1 cargo nextest run spec_tests
 
 Required env in staging mode: `ANTITHESIS_TENANT` plus either
 `ANTITHESIS_API_KEY` or `ANTITHESIS_USERNAME`+`ANTITHESIS_PASSWORD`.
+The `runs` specs require `ANTITHESIS_API_KEY` (every endpoint other than
+launch only accepts API key authentication).
 `ANTITHESIS_BASE_URL` is optional (defaults to `https://<tenant>.antithesis.com`).
 
 When `SNOUTY_STAGING` is set, the `mock-runs-server` directive becomes a

--- a/README.md
+++ b/README.md
@@ -56,18 +56,20 @@ export ANTITHESIS_TENANT="your-tenant"
 export ANTITHESIS_REPOSITORY="us-central1-docker.pkg.dev/your-project/your-repo"
 ```
 
-Antithesis supports two forms of authentication. Some tenants have API keys, which you can specify like so:
+Antithesis supports two forms of authentication. An API key works with every command and is the recommended option:
 
 ```sh
 export ANTITHESIS_API_KEY="your-api-key"
 ```
 
-Other tenants use username/password authentication, which you can specify like so:
+Username/password authentication is only supported when launching runs (`snouty launch`, `snouty debug`, and `snouty api webhook`). All other commands that talk to the API — such as `snouty runs` — require an API key.
 
 ```sh
 export ANTITHESIS_USERNAME="your-username"
 export ANTITHESIS_PASSWORD="your-password"
 ```
+
+If you don't have an API key, ask your Antithesis contact for one.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export ANTITHESIS_USERNAME="your-username"
 export ANTITHESIS_PASSWORD="your-password"
 ```
 
-If you don't have an API key, ask your Antithesis contact for one.
+If you don't have an API key, ask Antithesis support for one.
 
 ## Usage
 

--- a/build.rs
+++ b/build.rs
@@ -39,8 +39,40 @@ fn generate_api_client(out_dir: &Path) {
     let tokens = generator.generate_tokens(&spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();
     let content = prettyplease::unparse(&ast);
+    let content = patch_lenient_booleans(content);
 
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
+}
+
+// The API represents booleans as the strings "true"/"false", but some
+// historical run data stored "on"/"off" instead. Accept those as aliases when
+// deserializing API responses so commands like `snouty runs list` don't hard
+// error on old runs (#122). Panics if the expected generated code is missing,
+// so a progenitor upgrade that changes the output shape fails the build
+// instead of silently dropping the aliases.
+fn patch_lenient_booleans(content: String) -> String {
+    let replacements = [
+        (
+            r##"#[serde(rename = "true")]"##,
+            r##"#[serde(rename = "true", alias = "on")]"##,
+        ),
+        (
+            r##"#[serde(rename = "false")]"##,
+            r##"#[serde(rename = "false", alias = "off")]"##,
+        ),
+    ];
+
+    let mut content = content;
+    for (from, to) in replacements {
+        assert_eq!(
+            content.matches(from).count(),
+            1,
+            "expected generated API client to contain `{from}` exactly once; \
+             progenitor output may have changed"
+        );
+        content = content.replace(from, to);
+    }
+    content
 }
 
 fn rustc_version() -> Result<String, Box<dyn std::error::Error>> {

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -12,9 +12,20 @@
 # command output or required arguments.
 
 # The command authenticates with the Antithesis API using
-#    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT env vars.
+#    ANTITHESIS_API_KEY and ANTITHESIS_TENANT env vars. Every endpoint other
+#    than launch requires an API key, so unlike the launch commands,
+#    username/password authentication is not supported.
 ! snouty runs
-stderr 'missing environment variable.*'
+stderr 'missing environment variable: ANTITHESIS_API_KEY.*'
+
+# With only username/password configured, the command fails fast with a clear
+# message instead of sending a request the API would reject with a 403.
+env ANTITHESIS_USERNAME=testuser
+env ANTITHESIS_PASSWORD=testpass
+env ANTITHESIS_TENANT=testtenant
+! snouty runs
+stderr 'missing environment variable: ANTITHESIS_API_KEY.*'
+stderr 'only accepts API key authentication.*'
 
 # On success, the command fetches all pages via next_cursor and prints a table.
 mock-runs-server

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -157,8 +157,12 @@ mock-runs-server empty
 snouty runs
 stdout 'No runs found\.'
 
-# API errors are reported with status code and body.
+# API errors are reported with status code and body. The generic mock-server
+# directive only sets username/password, which `snouty runs` rejects before
+# making a request, so set an API key explicitly rather than relying on one
+# leaking from an earlier mock-runs-server block.
 mock-server 400 '{"message":"bad request"}'
+env ANTITHESIS_API_KEY=test-api-key
 ! snouty runs
 stderr 'API error: 400.*'
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -175,7 +175,7 @@ impl Auth {
             );
         }
         Err(err.suggestion(
-            "set ANTITHESIS_API_KEY; ask your Antithesis contact for an API key if you \
+            "set ANTITHESIS_API_KEY; ask Antithesis support for an API key if you \
              don't have one",
         ))
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -154,6 +154,31 @@ impl Auth {
             required_env("ANTITHESIS_PASSWORD")?,
         ))
     }
+
+    /// Like [`Auth::from_env`], but only accepts an API key. The API rejects
+    /// basic auth everywhere except the launch endpoints, so commands that hit
+    /// other endpoints should fail fast with a clear message instead of
+    /// sending a request destined for a 403.
+    fn api_key_from_env() -> Result<Self> {
+        if let Some(api_key) = optional_env("ANTITHESIS_API_KEY")? {
+            return Ok(Self::bearer(api_key));
+        }
+        let has_basic = optional_env("ANTITHESIS_USERNAME")?.is_some()
+            || optional_env("ANTITHESIS_PASSWORD")?.is_some();
+        let mut err = eyre!("missing environment variable: ANTITHESIS_API_KEY");
+        if has_basic {
+            err = err.note(
+                "ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD are set, but this command only \
+                 accepts API key authentication; username/password authentication is only \
+                 supported when launching runs (`snouty launch`, `snouty debug`, \
+                 `snouty api webhook`)",
+            );
+        }
+        Err(err.suggestion(
+            "set ANTITHESIS_API_KEY; ask your Antithesis contact for an API key if you \
+             don't have one",
+        ))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -180,6 +205,16 @@ impl Config {
             verbose: false,
         })
     }
+
+    /// Like [`Config::from_env`], but only accepts API key authentication.
+    pub fn from_env_requiring_api_key() -> Result<Self> {
+        debug!("loading config from environment (API key required)");
+        Ok(Self {
+            auth: Auth::api_key_from_env()?,
+            tenant: required_env("ANTITHESIS_TENANT")?,
+            verbose: false,
+        })
+    }
 }
 
 pub struct AntithesisApi {
@@ -195,7 +230,16 @@ impl AntithesisApi {
     }
 
     pub fn from_env(verbose: bool) -> Result<Self> {
-        let mut config = Config::from_env()?;
+        Self::from_config(Config::from_env()?, verbose)
+    }
+
+    /// Like [`AntithesisApi::from_env`], but fails fast unless an API key is
+    /// configured. Every endpoint other than launch requires one.
+    pub fn from_env_requiring_api_key(verbose: bool) -> Result<Self> {
+        Self::from_config(Config::from_env_requiring_api_key()?, verbose)
+    }
+
+    fn from_config(mut config: Config, verbose: bool) -> Result<Self> {
         config.verbose = verbose;
         if let Ok(base_url) = env::var("ANTITHESIS_BASE_URL") {
             debug!("using ANTITHESIS_BASE_URL override: {}", base_url);
@@ -1286,6 +1330,64 @@ mod tests {
 
         let run_ids = runs.into_iter().map(|run| run.run_id).collect::<Vec<_>>();
         assert_eq!(run_ids, vec!["run-1", "run-2"]);
+    }
+
+    // Some historical run data stored is_ephemeral as "on"/"off" instead of
+    // "true"/"false"; parsing must accept those as aliases (#122).
+    #[tokio::test]
+    async fn stream_runs_accepts_on_off_booleans_in_parameters() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "run_id": "run-on",
+                        "status": "completed",
+                        "created_at": "2025-03-20T02:00:00Z",
+                        "launcher": "nightly",
+                        "parameters": {"antithesis.is_ephemeral": "on"}
+                    },
+                    {
+                        "run_id": "run-off",
+                        "status": "completed",
+                        "created_at": "2025-03-19T02:00:00Z",
+                        "launcher": "nightly",
+                        "parameters": {"antithesis.is_ephemeral": "off"}
+                    }
+                ],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = AntithesisApi::with_base_url(test_config(), mock_server.uri()).unwrap();
+
+        let runs = api
+            .stream_runs_filtered(&RunsFilterOptions::default())
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let is_ephemeral = runs
+            .iter()
+            .map(|run| {
+                run.parameters
+                    .as_ref()
+                    .unwrap()
+                    .antithesis_is_ephemeral
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            is_ephemeral,
+            vec![
+                generated::types::ParamsAntithesisIsEphemeral::True,
+                generated::types::ParamsAntithesisIsEphemeral::False,
+            ]
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use snouty::container;
 use snouty::docs;
 use snouty::moment;
 use snouty::params::Params;
-use snouty::runs::StdoutWriteError;
 use snouty::validate;
 
 fn read_stdin() -> Result<String> {
@@ -112,16 +111,21 @@ async fn main() -> Result<()> {
         Commands::Docs { offline, command } => docs::cmd_docs(command, offline, json).await,
     };
 
-    // When our output is piped into something that exits early (e.g. `snouty
-    // runs list | head`), writes to stdout fail with BrokenPipe. That's a
-    // normal way for a pipeline to end, not an error — exit quietly. Only
-    // errors explicitly tagged as stdout writes qualify, so io errors from
-    // other layers (e.g. inside reqwest) can never take this path.
+    suppress_broken_pipe(result)
+}
+
+/// When our output is piped into something that exits early (e.g. `snouty
+/// runs list | head`), writes to stdout fail with BrokenPipe. That's a
+/// normal way for a pipeline to end, not an error — exit quietly. Network
+/// errors don't take this path: they surface as reqwest errors, whose
+/// underlying io::Error sits in reqwest's source chain and is not
+/// downcastable from the report (see the tests below).
+fn suppress_broken_pipe(result: Result<()>) -> Result<()> {
     match result {
         Err(err)
             if err
-                .downcast_ref::<StdoutWriteError>()
-                .is_some_and(StdoutWriteError::is_broken_pipe) =>
+                .downcast_ref::<io::Error>()
+                .is_some_and(|e| e.kind() == ErrorKind::BrokenPipe) =>
         {
             Ok(())
         }
@@ -372,4 +376,61 @@ fn cmd_update() -> Result<()> {
         env!("CARGO_PKG_VERSION")
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::{Report, eyre};
+
+    #[test]
+    fn suppress_broken_pipe_swallows_stdout_pipe_errors() {
+        let err = io::Error::new(ErrorKind::BrokenPipe, "stdout closed");
+        assert!(suppress_broken_pipe(Err(Report::new(err))).is_ok());
+    }
+
+    #[test]
+    fn suppress_broken_pipe_passes_through_other_errors() {
+        let io_err = io::Error::other("disk on fire");
+        assert!(suppress_broken_pipe(Err(Report::new(io_err))).is_err());
+        assert!(suppress_broken_pipe(Err(eyre!("plain error"))).is_err());
+    }
+
+    /// A broken connection during an API call must not be mistaken for a
+    /// closed stdout pipe. reqwest wraps the socket-level io::Error in its
+    /// own error type, whose source chain eyre's downcast does not traverse —
+    /// so no io::Error (broken pipe or otherwise) is downcastable from an
+    /// API error report, and it can never be suppressed.
+    #[tokio::test]
+    async fn suppress_broken_pipe_ignores_network_socket_errors() {
+        // Grab a port that refuses connections by binding then dropping.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let reqwest_err = reqwest::get(format!("http://{addr}/api/v0/runs"))
+            .await
+            .unwrap_err();
+
+        // Sanity check: the socket failure really is an io::Error, buried in
+        // reqwest's source chain.
+        let mut source = std::error::Error::source(&reqwest_err);
+        let mut found_io = false;
+        while let Some(err) = source {
+            found_io |= err.downcast_ref::<io::Error>().is_some();
+            source = err.source();
+        }
+        assert!(
+            found_io,
+            "expected an io::Error in the reqwest source chain"
+        );
+
+        // Wrap it the way api.rs wraps communication errors.
+        let report = eyre!(reqwest_err).wrap_err("failed to contact API");
+
+        // The io::Error is not downcastable through reqwest's error...
+        assert!(report.downcast_ref::<io::Error>().is_none());
+        // ...so the report can never be suppressed.
+        assert!(suppress_broken_pipe(Err(report)).is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     if json && let Some(name) = json_unaware_command_name(&cli.command) {
         eprintln!("warning: --json has no effect for `snouty {name}`");
     }
-    match cli.command {
+    let result = match cli.command {
         Commands::Launch(args) => {
             info!("launching test with webhook: {}", args.webhook);
             cmd_launch(args, json, verbose).await
@@ -109,6 +109,22 @@ async fn main() -> Result<()> {
         }
         Commands::Update => cmd_update(),
         Commands::Docs { offline, command } => docs::cmd_docs(command, offline, json).await,
+    };
+
+    // When our output is piped into something that exits early (e.g. `snouty
+    // runs list | head`), writes to stdout fail with BrokenPipe. That's a
+    // normal way for a pipeline to end, not an error — exit quietly. Network
+    // errors don't take this path: they surface as reqwest errors, whose
+    // underlying io::Error is not downcastable from the report.
+    match result {
+        Err(err)
+            if err
+                .downcast_ref::<io::Error>()
+                .is_some_and(|e| e.kind() == ErrorKind::BrokenPipe) =>
+        {
+            Ok(())
+        }
+        other => other,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use snouty::container;
 use snouty::docs;
 use snouty::moment;
 use snouty::params::Params;
+use snouty::runs::StdoutWriteError;
 use snouty::validate;
 
 fn read_stdin() -> Result<String> {
@@ -113,14 +114,14 @@ async fn main() -> Result<()> {
 
     // When our output is piped into something that exits early (e.g. `snouty
     // runs list | head`), writes to stdout fail with BrokenPipe. That's a
-    // normal way for a pipeline to end, not an error — exit quietly. Network
-    // errors don't take this path: they surface as reqwest errors, whose
-    // underlying io::Error is not downcastable from the report.
+    // normal way for a pipeline to end, not an error — exit quietly. Only
+    // errors explicitly tagged as stdout writes qualify, so io errors from
+    // other layers (e.g. inside reqwest) can never take this path.
     match result {
         Err(err)
             if err
-                .downcast_ref::<io::Error>()
-                .is_some_and(|e| e.kind() == ErrorKind::BrokenPipe) =>
+                .downcast_ref::<StdoutWriteError>()
+                .is_some_and(StdoutWriteError::is_broken_pipe) =>
         {
             Ok(())
         }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::OnceLock;
+use std::{io::Write, sync::OnceLock};
 
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
@@ -16,43 +16,6 @@ use crate::api::{
 #[cfg(test)]
 use crate::api::{Event, EventProperty, Moment, NonEventProperty};
 use crate::cli::{RunsCommands, RunsListArgs};
-
-/// A failed write to snouty's own stdout. Tagging these at the write site
-/// lets main distinguish "our stdout pipe closed" (a normal way for
-/// `snouty ... | head` to end) from io errors bubbling out of other layers,
-/// without relying on downcast semantics of a bare [`std::io::Error`].
-#[derive(Debug)]
-pub struct StdoutWriteError(pub std::io::Error);
-
-impl std::fmt::Display for StdoutWriteError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "failed to write to stdout: {}", self.0)
-    }
-}
-
-impl std::error::Error for StdoutWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.0)
-    }
-}
-
-impl StdoutWriteError {
-    pub fn is_broken_pipe(&self) -> bool {
-        self.0.kind() == std::io::ErrorKind::BrokenPipe
-    }
-}
-
-/// `println!`, except write failures come back as a tagged
-/// [`StdoutWriteError`] instead of a panic. Evaluates to `Result<()>`, so
-/// call sites just append `?`. Locking per call is fine: `Stdout`'s lock is
-/// reentrant and this is exactly what `println!` does internally.
-macro_rules! outln {
-    ($($arg:tt)*) => {{
-        use std::io::Write as _;
-        writeln!(std::io::stdout().lock(), $($arg)*)
-            .map_err(|e| color_eyre::Report::new(StdoutWriteError(e)))
-    }};
-}
 
 pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) -> Result<()> {
     match command {
@@ -152,19 +115,20 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<
             .then(a.status.cmp(&b.status))
     });
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         for run in &runs {
-            outln!("{}", serde_json::to_string(run)?)?;
+            writeln!(stdout, "{}", serde_json::to_string(run)?)?;
         }
         return Ok(());
     }
 
     if runs.is_empty() {
-        outln!("No runs found.")?;
+        writeln!(stdout, "No runs found.")?;
         return Ok(());
     }
 
-    outln!("{}", render_runs_table(&runs))?;
+    writeln!(stdout, "{}", render_runs_table(&runs))?;
     Ok(())
 }
 
@@ -174,10 +138,11 @@ async fn cmd_runs_show(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let run = api.get_run(run_id).await?;
 
+    let mut stdout = std::io::stdout().lock();
     if json {
-        outln!("{}", serde_json::to_string_pretty(&run)?)?;
+        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?)?;
     } else {
-        print_run_detail(&run)?;
+        print_run_detail(&mut stdout, &run)?;
     }
 
     Ok(())
@@ -203,12 +168,13 @@ async fn cmd_runs_properties(
             .then(a.name().cmp(b.name()))
     });
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         for property in &properties {
-            outln!("{}", serde_json::to_string(property)?)?;
+            writeln!(stdout, "{}", serde_json::to_string(property)?)?;
         }
     } else if properties.is_empty() {
-        outln!("No properties found.")?;
+        writeln!(stdout, "No properties found.")?;
     } else {
         let event_rows = flatten_property_events(&properties);
         let non_event_rows = flatten_non_event_property_values(&properties);
@@ -220,13 +186,13 @@ async fn cmd_runs_properties(
         if !non_event_rows.is_empty() {
             sections.push(render_property_values_table(&non_event_rows));
         }
-        outln!("{}", sections.join("\n\n"))?;
+        writeln!(stdout, "{}", sections.join("\n\n"))?;
     }
 
     Ok(())
 }
 
-fn print_run_detail(run: &RunDetail) -> Result<()> {
+fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
     let mut rows: Vec<(&str, String)> = vec![
         ("Run ID", run.run_id.clone()),
         ("Status", run.status.to_string()),
@@ -262,7 +228,7 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
 
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
     for (label, value) in &rows {
-        outln!("{label:label_width$}  {}", sanitize(value))?;
+        writeln!(out, "{label:label_width$}  {}", sanitize(value))?;
     }
     Ok(())
 }
@@ -278,10 +244,11 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let stream = api.get_run_build_logs(run_id).await?.into_inner();
+    let mut stdout = std::io::stdout().lock();
 
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            outln!("{line}")?;
+            writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
@@ -291,9 +258,9 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
                 let ts = entry["timestamp"].as_str().unwrap_or("");
                 let stream = entry["stream"].as_str().unwrap_or("out");
                 let text = sanitize(entry["text"].as_str().unwrap_or(""));
-                outln!("{ts} [{stream}] {text}")?;
+                writeln!(stdout, "{ts} [{stream}] {text}")?;
             } else {
-                outln!("{line}")?;
+                writeln!(stdout, "{line}")?;
             }
             Ok(())
         })
@@ -310,14 +277,19 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
         .await?
         .into_inner();
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            outln!("{line}")?;
+            writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
     } else {
-        outln!("{:<22}  {:<22}  {:<20}  OUTPUT", "HASH", "VTIME", "SOURCE")?;
+        writeln!(
+            stdout,
+            "{:<22}  {:<22}  {:<20}  OUTPUT",
+            "HASH", "VTIME", "SOURCE"
+        )?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
@@ -325,9 +297,12 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
                 let vtime = rendered.vtime;
                 let source = rendered.source;
                 let output = rendered.output;
-                outln!("{input_hash:<22}  {vtime:<22}  {source:<20}  {output}")?;
+                writeln!(
+                    stdout,
+                    "{input_hash:<22}  {vtime:<22}  {source:<20}  {output}"
+                )?;
             } else {
-                outln!("{:<22}  {:<22}  {:<20}  {line}", "", "", "")?;
+                writeln!(stdout, "{:<22}  {:<22}  {:<20}  {line}", "", "", "")?;
             }
             Ok(())
         })
@@ -355,6 +330,7 @@ async fn cmd_runs_logs(
         .await?
         .into_inner();
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         if annotate_faults {
             stream_ndjson_lines(
@@ -364,29 +340,29 @@ async fn cmd_runs_logs(
                     active_faults: json!({}),
                 },
                 |line| {
-                    outln!("{line}")?;
+                    writeln!(stdout, "{line}")?;
                     Ok(())
                 },
             )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-                outln!("{line}")?;
+                writeln!(stdout, "{line}")?;
                 Ok(())
             })
             .await
         }
     } else {
-        outln!("{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
+        writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let vtime = rendered.vtime;
                 let source = rendered.source;
                 let output = rendered.output;
-                outln!("{vtime:<22}  {source:<20}  {output}")?;
+                writeln!(stdout, "{vtime:<22}  {source:<20}  {output}")?;
             } else {
-                outln!("{line}")?;
+                writeln!(stdout, "{line}")?;
             }
             Ok(())
         })

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -22,6 +22,18 @@ use crate::api::{EventProperty, Moment, NonEventProperty};
 use crate::cli::{RunsCommands, RunsListArgs};
 use crate::error::{api_error_status, user_error};
 
+/// `print!`/`println!`, but routed through `write!`/`writeln!` to stdout so a
+/// closed pipe (e.g. `snouty runs list | head`) surfaces as an `io::Error` the
+/// caller propagates with `?` — `println!` would panic instead. Each call
+/// evaluates to an `io::Result<()>`, so every use must be `?`-ed.
+macro_rules! out {
+    ($($arg:tt)*) => {{ write!(std::io::stdout(), $($arg)*) }};
+}
+macro_rules! outln {
+    () => {{ writeln!(std::io::stdout()) }};
+    ($($arg:tt)*) => {{ writeln!(std::io::stdout(), $($arg)*) }};
+}
+
 /// Event stream classification. Variants match the canonical values that
 /// appear in an event's `source.stream` field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -155,24 +167,23 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<
             .then(a.status.cmp(&b.status))
     });
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         for run in &runs {
-            writeln!(stdout, "{}", serde_json::to_string(run)?)?;
+            outln!("{}", serde_json::to_string(run)?)?;
         }
         return Ok(());
     }
 
     if runs.is_empty() {
-        writeln!(stdout, "No runs found.")?;
+        outln!("No runs found.")?;
         return Ok(());
     }
 
     if args.detail {
-        write!(stdout, "{}", render_runs_detail(&runs))?;
+        out!("{}", render_runs_detail(&runs))?;
     } else {
         let width = terminal_width();
-        writeln!(stdout, "{}", render_runs_table(&runs, width))?;
+        outln!("{}", render_runs_table(&runs, width))?;
     }
     Ok(())
 }
@@ -247,11 +258,10 @@ async fn cmd_runs_show(run_id: &str, web: bool, json: bool, verbose: bool) -> Re
         return open_run_report(&run, json);
     }
 
-    let mut stdout = std::io::stdout().lock();
     if json {
-        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?)?;
+        outln!("{}", serde_json::to_string_pretty(&run)?)?;
     } else {
-        print_run_detail(&mut stdout, &run)?;
+        print_run_detail(&run)?;
     }
 
     Ok(())
@@ -271,20 +281,19 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
             ))
         })?;
 
-    let mut stdout = std::io::stdout().lock();
     if json {
-        writeln!(stdout, "{}", serde_json::json!({ "url": url }))?;
+        outln!("{}", serde_json::json!({ "url": url }))?;
         return Ok(());
     }
 
     let launched = launch_browser(url);
     if launched {
-        writeln!(stdout, "Opening report for run {}…", run.run_id)?;
-        writeln!(stdout, "If your browser didn't open, manually visit:")?;
-        writeln!(stdout, "  {url}")?;
+        outln!("Opening report for run {}…", run.run_id)?;
+        outln!("If your browser didn't open, manually visit:")?;
+        outln!("  {url}")?;
     } else {
-        writeln!(stdout, "Open this URL to view the report:")?;
-        writeln!(stdout, "  {url}")?;
+        outln!("Open this URL to view the report:")?;
+        outln!("  {url}")?;
     }
     Ok(())
 }
@@ -355,10 +364,9 @@ async fn cmd_runs_properties(
             .then(a.name().cmp(b.name()))
     });
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         for property in &properties {
-            writeln!(stdout, "{}", serde_json::to_string(property)?)?;
+            outln!("{}", serde_json::to_string(property)?)?;
         }
     } else if properties.is_empty() {
         let message = match status {
@@ -366,9 +374,9 @@ async fn cmd_runs_properties(
             Some(PropertyStatus::Failing) => "No failing properties found.",
             None => "No properties found.",
         };
-        writeln!(stdout, "{message}")?;
+        outln!("{message}")?;
     } else {
-        writeln!(stdout, "{}", render_properties_table(&properties))?;
+        outln!("{}", render_properties_table(&properties))?;
     }
 
     Ok(())
@@ -528,14 +536,13 @@ async fn cmd_runs_property(run_id: &str, name: &str, json: bool, verbose: bool) 
         }
     };
 
-    let mut stdout = std::io::stdout().lock();
     if json {
-        writeln!(stdout, "{}", serde_json::to_string_pretty(property)?)?;
+        outln!("{}", serde_json::to_string_pretty(property)?)?;
         return Ok(());
     }
 
-    print_property_header(&mut stdout, property)?;
-    writeln!(stdout, "{}", render_property_examples(property))?;
+    print_property_header(property)?;
+    outln!("{}", render_property_examples(property))?;
     Ok(())
 }
 
@@ -639,15 +646,11 @@ fn render_prose_block(label: &str, text: &str, layout: ProseLayout) -> String {
     out
 }
 
-fn print_property_header(out: &mut impl Write, property: &Property) -> Result<()> {
-    writeln!(out, "Name      {}", sanitize(property.name()))?;
-    writeln!(
-        out,
-        "Status    {}",
-        property_status_label(property.status())
-    )?;
+fn print_property_header(property: &Property) -> Result<()> {
+    outln!("Name      {}", sanitize(property.name()))?;
+    outln!("Status    {}", property_status_label(property.status()))?;
     if let Some(group) = property_group(property) {
-        writeln!(out, "Group     {}", sanitize(group))?;
+        outln!("Group     {}", sanitize(group))?;
     }
     let description = match property {
         Property::EventProperty(p) => p.description.as_deref(),
@@ -656,8 +659,7 @@ fn print_property_header(out: &mut impl Write, property: &Property) -> Result<()
     if let Some(desc) = description {
         // Details is free-form prose, wrapped under a 10-char label column so
         // continuation lines hang-indent to match the value column above.
-        write!(
-            out,
+        out!(
             "{}",
             render_prose_block(
                 "Details",
@@ -669,7 +671,7 @@ fn print_property_header(out: &mut impl Write, property: &Property) -> Result<()
             )
         )?;
     }
-    writeln!(out)?;
+    outln!()?;
     Ok(())
 }
 
@@ -849,7 +851,7 @@ fn render_properties_table(properties: &[Property]) -> String {
     render_table_wrap_last(&headers, &rows, terminal_width())
 }
 
-fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
+fn print_run_detail(run: &RunDetail) -> Result<()> {
     let mut rows: Vec<(&str, String)> = Vec::new();
 
     // Lead with the identifier; the human labels follow.
@@ -881,7 +883,7 @@ fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
         rows.push(("Creator", name.clone()));
     }
 
-    write!(out, "{}", render_kv(&rows, 0))?;
+    out!("{}", render_kv(&rows, 0))?;
 
     // The description can be an enormous multi-paragraph blob, so it goes as its
     // own block — wrapped to the terminal, with the label on its own line —
@@ -890,7 +892,7 @@ fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
     if let Some(desc) = run.test_description() {
         let block = render_prose_block("Description", desc, ProseLayout::OwnLine);
         if !block.is_empty() {
-            write!(out, "\n{block}")?;
+            out!("\n{block}")?;
         }
     }
 
@@ -903,8 +905,7 @@ fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
         .and_then(|l| l.triage_report.as_deref())
         .is_some();
     if has_report {
-        writeln!(
-            out,
+        outln!(
             "\nview the report in your browser:\n  snouty runs show {} --web",
             run.run_id
         )?;

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::{io::Write, sync::OnceLock};
+use std::sync::OnceLock;
 
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
@@ -42,16 +42,16 @@ impl StdoutWriteError {
     }
 }
 
-trait WriteResultExt<T> {
-    /// Tag the io::Result of a stdout write so [`StdoutWriteError`] is
-    /// downcastable from the resulting report.
-    fn stdout_err(self) -> Result<T>;
-}
-
-impl<T> WriteResultExt<T> for std::io::Result<T> {
-    fn stdout_err(self) -> Result<T> {
-        self.map_err(|e| color_eyre::Report::new(StdoutWriteError(e)))
-    }
+/// `println!`, except write failures come back as a tagged
+/// [`StdoutWriteError`] instead of a panic. Evaluates to `Result<()>`, so
+/// call sites just append `?`. Locking per call is fine: `Stdout`'s lock is
+/// reentrant and this is exactly what `println!` does internally.
+macro_rules! outln {
+    ($($arg:tt)*) => {{
+        use std::io::Write as _;
+        writeln!(std::io::stdout().lock(), $($arg)*)
+            .map_err(|e| color_eyre::Report::new(StdoutWriteError(e)))
+    }};
 }
 
 pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) -> Result<()> {
@@ -152,20 +152,19 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<
             .then(a.status.cmp(&b.status))
     });
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         for run in &runs {
-            writeln!(stdout, "{}", serde_json::to_string(run)?).stdout_err()?;
+            outln!("{}", serde_json::to_string(run)?)?;
         }
         return Ok(());
     }
 
     if runs.is_empty() {
-        writeln!(stdout, "No runs found.").stdout_err()?;
+        outln!("No runs found.")?;
         return Ok(());
     }
 
-    writeln!(stdout, "{}", render_runs_table(&runs)).stdout_err()?;
+    outln!("{}", render_runs_table(&runs))?;
     Ok(())
 }
 
@@ -175,11 +174,10 @@ async fn cmd_runs_show(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let run = api.get_run(run_id).await?;
 
-    let mut stdout = std::io::stdout().lock();
     if json {
-        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?).stdout_err()?;
+        outln!("{}", serde_json::to_string_pretty(&run)?)?;
     } else {
-        print_run_detail(&mut stdout, &run)?;
+        print_run_detail(&run)?;
     }
 
     Ok(())
@@ -205,13 +203,12 @@ async fn cmd_runs_properties(
             .then(a.name().cmp(b.name()))
     });
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         for property in &properties {
-            writeln!(stdout, "{}", serde_json::to_string(property)?).stdout_err()?;
+            outln!("{}", serde_json::to_string(property)?)?;
         }
     } else if properties.is_empty() {
-        writeln!(stdout, "No properties found.").stdout_err()?;
+        outln!("No properties found.")?;
     } else {
         let event_rows = flatten_property_events(&properties);
         let non_event_rows = flatten_non_event_property_values(&properties);
@@ -223,13 +220,13 @@ async fn cmd_runs_properties(
         if !non_event_rows.is_empty() {
             sections.push(render_property_values_table(&non_event_rows));
         }
-        writeln!(stdout, "{}", sections.join("\n\n")).stdout_err()?;
+        outln!("{}", sections.join("\n\n"))?;
     }
 
     Ok(())
 }
 
-fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
+fn print_run_detail(run: &RunDetail) -> Result<()> {
     let mut rows: Vec<(&str, String)> = vec![
         ("Run ID", run.run_id.clone()),
         ("Status", run.status.to_string()),
@@ -265,7 +262,7 @@ fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
 
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
     for (label, value) in &rows {
-        writeln!(out, "{label:label_width$}  {}", sanitize(value)).stdout_err()?;
+        outln!("{label:label_width$}  {}", sanitize(value))?;
     }
     Ok(())
 }
@@ -281,11 +278,10 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let stream = api.get_run_build_logs(run_id).await?.into_inner();
-    let mut stdout = std::io::stdout().lock();
 
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            writeln!(stdout, "{line}").stdout_err()?;
+            outln!("{line}")?;
             Ok(())
         })
         .await
@@ -295,9 +291,9 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
                 let ts = entry["timestamp"].as_str().unwrap_or("");
                 let stream = entry["stream"].as_str().unwrap_or("out");
                 let text = sanitize(entry["text"].as_str().unwrap_or(""));
-                writeln!(stdout, "{ts} [{stream}] {text}").stdout_err()?;
+                outln!("{ts} [{stream}] {text}")?;
             } else {
-                writeln!(stdout, "{line}").stdout_err()?;
+                outln!("{line}")?;
             }
             Ok(())
         })
@@ -314,20 +310,14 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
         .await?
         .into_inner();
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            writeln!(stdout, "{line}").stdout_err()?;
+            outln!("{line}")?;
             Ok(())
         })
         .await
     } else {
-        writeln!(
-            stdout,
-            "{:<22}  {:<22}  {:<20}  OUTPUT",
-            "HASH", "VTIME", "SOURCE"
-        )
-        .stdout_err()?;
+        outln!("{:<22}  {:<22}  {:<20}  OUTPUT", "HASH", "VTIME", "SOURCE")?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
@@ -335,13 +325,9 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
                 let vtime = rendered.vtime;
                 let source = rendered.source;
                 let output = rendered.output;
-                writeln!(
-                    stdout,
-                    "{input_hash:<22}  {vtime:<22}  {source:<20}  {output}"
-                )
-                .stdout_err()?;
+                outln!("{input_hash:<22}  {vtime:<22}  {source:<20}  {output}")?;
             } else {
-                writeln!(stdout, "{:<22}  {:<22}  {:<20}  {line}", "", "", "").stdout_err()?;
+                outln!("{:<22}  {:<22}  {:<20}  {line}", "", "", "")?;
             }
             Ok(())
         })
@@ -369,7 +355,6 @@ async fn cmd_runs_logs(
         .await?
         .into_inner();
 
-    let mut stdout = std::io::stdout().lock();
     if json {
         if annotate_faults {
             stream_ndjson_lines(
@@ -379,29 +364,29 @@ async fn cmd_runs_logs(
                     active_faults: json!({}),
                 },
                 |line| {
-                    writeln!(stdout, "{line}").stdout_err()?;
+                    outln!("{line}")?;
                     Ok(())
                 },
             )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-                writeln!(stdout, "{line}").stdout_err()?;
+                outln!("{line}")?;
                 Ok(())
             })
             .await
         }
     } else {
-        writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE").stdout_err()?;
+        outln!("{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let vtime = rendered.vtime;
                 let source = rendered.source;
                 let output = rendered.output;
-                writeln!(stdout, "{vtime:<22}  {source:<20}  {output}").stdout_err()?;
+                outln!("{vtime:<22}  {source:<20}  {output}")?;
             } else {
-                writeln!(stdout, "{line}").stdout_err()?;
+                outln!("{line}")?;
             }
             Ok(())
         })

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -70,7 +70,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
 async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<()> {
     debug!("listing runs");
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
 
     let status = args
         .status
@@ -115,32 +115,34 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<
             .then(a.status.cmp(&b.status))
     });
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         for run in &runs {
-            println!("{}", serde_json::to_string(run)?);
+            writeln!(stdout, "{}", serde_json::to_string(run)?)?;
         }
         return Ok(());
     }
 
     if runs.is_empty() {
-        println!("No runs found.");
+        writeln!(stdout, "No runs found.")?;
         return Ok(());
     }
 
-    println!("{}", render_runs_table(&runs));
+    writeln!(stdout, "{}", render_runs_table(&runs))?;
     Ok(())
 }
 
 async fn cmd_runs_show(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     debug!("showing run: {}", run_id);
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let run = api.get_run(run_id).await?;
 
+    let mut stdout = std::io::stdout().lock();
     if json {
-        println!("{}", serde_json::to_string_pretty(&run)?);
+        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?)?;
     } else {
-        print_run_detail(&run);
+        print_run_detail(&mut stdout, &run)?;
     }
 
     Ok(())
@@ -154,7 +156,7 @@ async fn cmd_runs_properties(
 ) -> Result<()> {
     debug!("listing properties for run: {}", run_id);
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let mut properties = api
         .stream_run_properties(run_id, status)
         .try_collect::<Vec<_>>()
@@ -166,12 +168,13 @@ async fn cmd_runs_properties(
             .then(a.name().cmp(b.name()))
     });
 
+    let mut stdout = std::io::stdout().lock();
     if json {
         for property in &properties {
-            println!("{}", serde_json::to_string(property)?);
+            writeln!(stdout, "{}", serde_json::to_string(property)?)?;
         }
     } else if properties.is_empty() {
-        println!("No properties found.");
+        writeln!(stdout, "No properties found.")?;
     } else {
         let event_rows = flatten_property_events(&properties);
         let non_event_rows = flatten_non_event_property_values(&properties);
@@ -183,13 +186,13 @@ async fn cmd_runs_properties(
         if !non_event_rows.is_empty() {
             sections.push(render_property_values_table(&non_event_rows));
         }
-        println!("{}", sections.join("\n\n"));
+        writeln!(stdout, "{}", sections.join("\n\n"))?;
     }
 
     Ok(())
 }
 
-fn print_run_detail(run: &RunDetail) {
+fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
     let mut rows: Vec<(&str, String)> = vec![
         ("Run ID", run.run_id.clone()),
         ("Status", run.status.to_string()),
@@ -225,8 +228,9 @@ fn print_run_detail(run: &RunDetail) {
 
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
     for (label, value) in &rows {
-        println!("{label:label_width$}  {}", sanitize(value));
+        writeln!(out, "{label:label_width$}  {}", sanitize(value))?;
     }
+    Ok(())
 }
 
 struct LogOutputOptions {
@@ -238,7 +242,7 @@ struct LogOutputOptions {
 async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<()> {
     debug!("streaming build logs for run: {}", run_id);
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let stream = api.get_run_build_logs(run_id).await?.into_inner();
     let mut stdout = std::io::stdout().lock();
 
@@ -267,7 +271,7 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
 async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bool) -> Result<()> {
     debug!("searching events for run: {}", run_id);
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let stream = api
         .search_run_events(run_id, &query.join(" "))
         .await?
@@ -320,7 +324,7 @@ async fn cmd_runs_logs(
 ) -> Result<()> {
     debug!("streaming logs for run: {}", run_id);
 
-    let api = AntithesisApi::from_env(verbose)?;
+    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let stream = api
         .get_run_logs(run_id, input_hash, vtime, begin_input_hash, begin_vtime)
         .await?

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -17,6 +17,43 @@ use crate::api::{
 use crate::api::{Event, EventProperty, Moment, NonEventProperty};
 use crate::cli::{RunsCommands, RunsListArgs};
 
+/// A failed write to snouty's own stdout. Tagging these at the write site
+/// lets main distinguish "our stdout pipe closed" (a normal way for
+/// `snouty ... | head` to end) from io errors bubbling out of other layers,
+/// without relying on downcast semantics of a bare [`std::io::Error`].
+#[derive(Debug)]
+pub struct StdoutWriteError(pub std::io::Error);
+
+impl std::fmt::Display for StdoutWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "failed to write to stdout: {}", self.0)
+    }
+}
+
+impl std::error::Error for StdoutWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl StdoutWriteError {
+    pub fn is_broken_pipe(&self) -> bool {
+        self.0.kind() == std::io::ErrorKind::BrokenPipe
+    }
+}
+
+trait WriteResultExt<T> {
+    /// Tag the io::Result of a stdout write so [`StdoutWriteError`] is
+    /// downcastable from the resulting report.
+    fn stdout_err(self) -> Result<T>;
+}
+
+impl<T> WriteResultExt<T> for std::io::Result<T> {
+    fn stdout_err(self) -> Result<T> {
+        self.map_err(|e| color_eyre::Report::new(StdoutWriteError(e)))
+    }
+}
+
 pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) -> Result<()> {
     match command {
         None => cmd_runs_list(RunsListArgs::default(), json, verbose).await,
@@ -118,17 +155,17 @@ async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<
     let mut stdout = std::io::stdout().lock();
     if json {
         for run in &runs {
-            writeln!(stdout, "{}", serde_json::to_string(run)?)?;
+            writeln!(stdout, "{}", serde_json::to_string(run)?).stdout_err()?;
         }
         return Ok(());
     }
 
     if runs.is_empty() {
-        writeln!(stdout, "No runs found.")?;
+        writeln!(stdout, "No runs found.").stdout_err()?;
         return Ok(());
     }
 
-    writeln!(stdout, "{}", render_runs_table(&runs))?;
+    writeln!(stdout, "{}", render_runs_table(&runs)).stdout_err()?;
     Ok(())
 }
 
@@ -140,7 +177,7 @@ async fn cmd_runs_show(run_id: &str, json: bool, verbose: bool) -> Result<()> {
 
     let mut stdout = std::io::stdout().lock();
     if json {
-        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?)?;
+        writeln!(stdout, "{}", serde_json::to_string_pretty(&run)?).stdout_err()?;
     } else {
         print_run_detail(&mut stdout, &run)?;
     }
@@ -171,10 +208,10 @@ async fn cmd_runs_properties(
     let mut stdout = std::io::stdout().lock();
     if json {
         for property in &properties {
-            writeln!(stdout, "{}", serde_json::to_string(property)?)?;
+            writeln!(stdout, "{}", serde_json::to_string(property)?).stdout_err()?;
         }
     } else if properties.is_empty() {
-        writeln!(stdout, "No properties found.")?;
+        writeln!(stdout, "No properties found.").stdout_err()?;
     } else {
         let event_rows = flatten_property_events(&properties);
         let non_event_rows = flatten_non_event_property_values(&properties);
@@ -186,7 +223,7 @@ async fn cmd_runs_properties(
         if !non_event_rows.is_empty() {
             sections.push(render_property_values_table(&non_event_rows));
         }
-        writeln!(stdout, "{}", sections.join("\n\n"))?;
+        writeln!(stdout, "{}", sections.join("\n\n")).stdout_err()?;
     }
 
     Ok(())
@@ -228,7 +265,7 @@ fn print_run_detail(out: &mut impl Write, run: &RunDetail) -> Result<()> {
 
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
     for (label, value) in &rows {
-        writeln!(out, "{label:label_width$}  {}", sanitize(value))?;
+        writeln!(out, "{label:label_width$}  {}", sanitize(value)).stdout_err()?;
     }
     Ok(())
 }
@@ -248,7 +285,7 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
 
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            writeln!(stdout, "{line}")?;
+            writeln!(stdout, "{line}").stdout_err()?;
             Ok(())
         })
         .await
@@ -258,9 +295,9 @@ async fn cmd_runs_build_logs(run_id: &str, json: bool, verbose: bool) -> Result<
                 let ts = entry["timestamp"].as_str().unwrap_or("");
                 let stream = entry["stream"].as_str().unwrap_or("out");
                 let text = sanitize(entry["text"].as_str().unwrap_or(""));
-                writeln!(stdout, "{ts} [{stream}] {text}")?;
+                writeln!(stdout, "{ts} [{stream}] {text}").stdout_err()?;
             } else {
-                writeln!(stdout, "{line}")?;
+                writeln!(stdout, "{line}").stdout_err()?;
             }
             Ok(())
         })
@@ -280,7 +317,7 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
     let mut stdout = std::io::stdout().lock();
     if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            writeln!(stdout, "{line}")?;
+            writeln!(stdout, "{line}").stdout_err()?;
             Ok(())
         })
         .await
@@ -289,7 +326,8 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
             stdout,
             "{:<22}  {:<22}  {:<20}  OUTPUT",
             "HASH", "VTIME", "SOURCE"
-        )?;
+        )
+        .stdout_err()?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
@@ -300,9 +338,10 @@ async fn cmd_runs_events(run_id: &str, query: &[String], json: bool, verbose: bo
                 writeln!(
                     stdout,
                     "{input_hash:<22}  {vtime:<22}  {source:<20}  {output}"
-                )?;
+                )
+                .stdout_err()?;
             } else {
-                writeln!(stdout, "{:<22}  {:<22}  {:<20}  {line}", "", "", "")?;
+                writeln!(stdout, "{:<22}  {:<22}  {:<20}  {line}", "", "", "").stdout_err()?;
             }
             Ok(())
         })
@@ -340,29 +379,29 @@ async fn cmd_runs_logs(
                     active_faults: json!({}),
                 },
                 |line| {
-                    writeln!(stdout, "{line}")?;
+                    writeln!(stdout, "{line}").stdout_err()?;
                     Ok(())
                 },
             )
             .await
         } else {
             stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-                writeln!(stdout, "{line}")?;
+                writeln!(stdout, "{line}").stdout_err()?;
                 Ok(())
             })
             .await
         }
     } else {
-        writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE")?;
+        writeln!(stdout, "{:<22}  {:<20}  OUTPUT", "VTIME", "SOURCE").stdout_err()?;
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             if let Ok(entry) = serde_json::from_str::<Value>(line) {
                 let rendered = render_event_entry(&entry);
                 let vtime = rendered.vtime;
                 let source = rendered.source;
                 let output = rendered.output;
-                writeln!(stdout, "{vtime:<22}  {source:<20}  {output}")?;
+                writeln!(stdout, "{vtime:<22}  {source:<20}  {output}").stdout_err()?;
             } else {
-                writeln!(stdout, "{line}")?;
+                writeln!(stdout, "{line}").stdout_err()?;
             }
             Ok(())
         })

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -884,18 +884,20 @@ fn runs_list_exits_cleanly_when_stdout_closes_early() {
     ] {
         cmd.env_remove(env_var);
     }
-    let mut child = cmd
+    // Hand snouty a pipe whose read end is already closed before it spawns,
+    // so its very first stdout write deterministically hits a broken pipe.
+    let (reader, writer) = std::io::pipe().unwrap();
+    drop(reader);
+
+    let child = cmd
         .env("ANTITHESIS_API_KEY", &mock.token)
         .env("ANTITHESIS_TENANT", "testtenant")
         .env("ANTITHESIS_BASE_URL", &mock.url)
         .args(["runs", "list"])
-        .stdout(std::process::Stdio::piped())
+        .stdout(writer)
         .stderr(std::process::Stdio::piped())
         .spawn()
         .unwrap();
-
-    // Close the read end of stdout so snouty's writes hit a broken pipe.
-    drop(child.stdout.take());
 
     let output = child.wait_with_output().unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -866,3 +866,43 @@ fn validate_help_shows_keep_running() {
         .success()
         .stdout(predicate::str::contains("--keep-running"));
 }
+
+// `snouty runs list | head` closes stdout before snouty finishes writing;
+// snouty must exit cleanly instead of panicking on the broken pipe (#121).
+#[test]
+fn runs_list_exits_cleanly_when_stdout_closes_early() {
+    let mock = start_runs_server(false);
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_snouty"));
+    for env_var in [
+        "ANTITHESIS_API_KEY",
+        "ANTITHESIS_USERNAME",
+        "ANTITHESIS_PASSWORD",
+        "ANTITHESIS_TENANT",
+        "ANTITHESIS_BASE_URL",
+        "ANTITHESIS_REPOSITORY",
+    ] {
+        cmd.env_remove(env_var);
+    }
+    let mut child = cmd
+        .env("ANTITHESIS_API_KEY", &mock.token)
+        .env("ANTITHESIS_TENANT", "testtenant")
+        .env("ANTITHESIS_BASE_URL", &mock.url)
+        .args(["runs", "list"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Close the read end of stdout so snouty's writes hit a broken pipe.
+    drop(child.stdout.take());
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected clean exit on broken pipe, got {:?}; stderr:\n{stderr}",
+        output.status
+    );
+    assert!(!stderr.contains("panicked"), "stderr:\n{stderr}");
+}


### PR DESCRIPTION
Fixes #122
Fixes #121
Fixes #129

`snouty runs list` hard-errored on runs whose `antithesis.is_ephemeral` was stored as `"on"` rather than `"true"` (#122). The enum is generated from openapi.json by progenitor at build time, so build.rs now patches the generated client to add `serde(alias = "on")`/`alias = "off"` to the true/false variants, normalizing the values on the way in. The patch asserts the expected generated code is present exactly once, so a progenitor upgrade that changes the output shape fails the build instead of silently dropping the aliases.

Piping runs output into something that exits early (`snouty runs list | head -n1`) panicked on the broken pipe (#121). The runs list/show/properties paths now print through a small `outln!`/`out!` macro pair that writes to stdout with fallible `writeln!`/`write!` rather than `println!`, so a closed pipe surfaces as an io::Error instead of a panic, and main treats a BrokenPipe write error as a normal quiet exit. Network errors don't take that path: they surface as reqwest errors whose inner io::Error is not downcastable from the report.

Every API endpoint other than launch rejects basic auth, but snouty would happily send username/password and surface a bare 403 (#129). The runs commands now require ANTITHESIS_API_KEY up front and fail with a message explaining that username/password authentication only works for the launch commands (`snouty launch`, `snouty debug`, `snouty api webhook`), with a suggestion to ask your Antithesis contact for a key. The README auth section, the runs spec, and the AGENTS.md staging notes are updated to match.

Each fix has a regression test: a wiremock test covering on/off parsing, a CLI test that closes snouty's stdout and asserts a clean exit, and new runs spec assertions for the fail-fast auth error.

Co-Authored-By: Claude <noreply@anthropic.com>
