### PR TITLE
Add a cargo fmt + check hook for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cargo fmt; out=$(cargo check --all-targets --quiet --color never 2>&1) || { echo \"$out\"; exit 2; }",
+            "asyncRewake": true,
+            "timeout": 600,
+            "statusMessage": "cargo fmt + check",
+            "rewakeSummary": "cargo check found errors",
+            "rewakeMessage": "cargo check reported errors. Fix them before finishing:"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/docs/snippet.rs
+++ b/src/docs/snippet.rs
@@ -121,10 +121,8 @@ fn flatten_markdown(content: &str) -> String {
             Event::Text(ref text) | Event::Code(ref text) if depth > 0 => {
                 result.push_str(text);
             }
-            Event::SoftBreak | Event::HardBreak if depth > 0 => {
-                if !result.ends_with(' ') {
-                    result.push(' ');
-                }
+            Event::SoftBreak | Event::HardBreak if depth > 0 && !result.ends_with(' ') => {
+                result.push(' ');
             }
             _ => {}
         }


### PR DESCRIPTION
Adds a committed `.claude/settings.json` with a Stop hook that runs `cargo fmt` followed by `cargo check --all-targets` once per turn after Claude finishes responding. Formatting is applied automatically, and if the crate fails to compile the hook surfaces the errors and wakes Claude to fix them before the turn ends. Running on stop rather than per-edit keeps it lightweight while still guaranteeing the working tree stays formatted and compiling.

Also cleans up a pre-existing `collapsible_match` clippy lint in `src/docs/snippet.rs` that newer stable toolchains flag.