### PR TITLE
Skip engine spec image cleanup on CI to fix podman 'layer not known' flake

### DIFF
--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -338,6 +338,22 @@ fn find_runtime(runtime_name: &str) -> Option<Box<dyn snouty::container::Contain
 }
 
 fn cleanup_engine_images(runtime_name: &str, built_images: &[String], registry_addr: Option<&str>) {
+    // The engine spec cases run as separate `#[test]` processes in parallel and
+    // share one local `containers/storage`. A forced image removal here mutates
+    // that store's layer database while a sibling test's `podman build` is
+    // enumerating images for its build-cache check ("getting top layer info"),
+    // intermittently yielding `layer not known` (issue #136). On CI the runner
+    // is ephemeral and thrown away after the job, so there is nothing to clean
+    // up — skip the `rmi` entirely there to remove the writer that races those
+    // concurrent builds. Locally we still clean up so a dev's image store does
+    // not accumulate junk across runs.
+    if std::env::var_os("CI").is_some() {
+        eprintln!(
+            "CI is set: skipping {} image cleanup (ephemeral runner; avoids racing concurrent builds, issue #136)",
+            runtime_name
+        );
+        return;
+    }
     for image in built_images {
         let _ = std::process::Command::new(runtime_name)
             .args(["rmi", "-f", image])


### PR DESCRIPTION
The `*_engine_*_specs` tests in `tests/spec.rs` run as separate `#[test]` processes in parallel under nextest, all sharing one local `containers/storage`. After each case, `cleanup_engine_images` force-removes (`rmi -f`) the images that case built. That removal mutates the shared layer database while a sibling test's `podman build` is enumerating images for its build-cache check (`checking if cached image exists from a previous build: getting top layer info`), so the build stats a top layer the concurrent removal just deleted, intermittently yielding `layer not known` (#136). Unique image names don't avoid it: the cache check walks every image in the store regardless of name, and removal is the only operation that makes an already-listed image's layer vanish mid-walk — concurrent builds only add. Docker doesn't hit this because its daemon serializes store access; podman is daemonless.

On CI the runner is ephemeral and discarded after the job, so there's nothing to clean up. This skips the `rmi` entirely when `CI` is set, removing the writer that races those concurrent builds while keeping the tests fully parallel (no CI slowdown). Locally cleanup still runs so a developer's image store doesn't accumulate junk across runs, and a message is printed when cleanup is skipped.

Verified on an Ubuntu + podman + Compose v2 sandbox matching the CI podman leg: with `CI` set, the engine specs accumulate images (cleanup skipped) and the previously-flaky `podman_engine_launch_config_push_specs` passed across repeated parallel runs with no `layer not known`, and no assertion regressions from the accumulated images.

fixes #136