### PR TITLE
Improve `snouty runs` output and `--help` quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 .claude/settings.local.json
+
+# Python bytecode cache (e.g. from running scripts/gen-gallery.py)
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ CLI tool for the Antithesis API. Written in Rust.
 - `specs/` — feature specs
 - `src/` — all source code
 - `tests/` — integration tests
+- `scripts/` — maintenance/dev scripts (Python, run via `uv`)
 - `.github/workflows/` — CI/CD
 
 ## Specs
@@ -56,6 +57,16 @@ lines prefixed with `[!staging]` are skipped (those assert on hardcoded
 mock data); unprefixed lines still run and hit staging. Only read-oriented
 checks run against staging — any spec that would mutate state is gated
 `[!staging]`.
+
+## Scripts
+
+The `scripts/` directory holds Python helpers run via `uv` (each has an inline
+`# /// script` dependency header). After changing `gen-gallery.py`, type-check it
+with pyright and confirm it reports 0 errors before considering the change done:
+
+```
+uvx pyright scripts/gen-gallery.py
+```
 
 ## AI Coding Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for project instructions.

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -315,9 +315,10 @@ def _pick_property_with_moments(sn: Snouty, run: str, props: list[dict], status:
 
 
 # A non-event ("system") property renders its value under a `Result` label
-# (see render_result in src/runs.rs) — `Result   <scalar>` inline or `Result:`
-# above indented JSON — never as a moment HASH/VTIME row.
-_NONEVENT_RESULT = re.compile(r"^\s*Result[: ]", re.MULTILINE)
+# (see render_result in src/runs.rs) — `Result   <scalar>` inline, or a bare
+# `Result` label line above indented JSON (no colon) for an object/array —
+# never as a moment HASH/VTIME row.
+_NONEVENT_RESULT = re.compile(r"^\s*Result\b", re.MULTILINE)
 
 
 def _has_real_value(value) -> bool:
@@ -346,13 +347,14 @@ def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
         if any(_has_real_value(v) for v in values):
             candidates.append(p)
     candidates.sort(key=lambda p: p.get("example_count") or 0, reverse=True)
-    for p in candidates:
+    # Render-probe candidates (most examples first) until one renders the
+    # non-event shape: a `Result` label block and no moment rows (which would mean
+    # we misclassified an event property). Try several rather than bailing on the
+    # first miss, so one oddly-rendering top candidate can't sink the whole story.
+    for p in candidates[:8]:
         rendered = _render_property(sn, run, p["name"])
-        # Confirm it renders the non-event shape: a labelled example block and no
-        # moment rows (which would mean we misclassified an event property).
         if _NONEVENT_RESULT.search(rendered) and not _has_moment_rows(rendered):
             return p["name"]
-        break  # chosen candidate didn't render a usable value — bail
     raise GalleryError(f"no non-event property on {run} renders a usable value")
 
 

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -313,24 +313,21 @@ def _pick_property_with_moments(sn: Snouty, run: str, props: list[dict], status:
     )
 
 
-_VALUE_ROW = re.compile(r"^(?:passing|failing|unreachable)\s+(.*)$", re.MULTILINE)
-
-# Rendered VALUE cells that aren't a usable single value: the synthetic
-# `unreachable  -` row and the `(no example value)` rendering of an empty collection (see
-# render_property_value in src/runs.rs). "[0 items]" can no longer be emitted.
-_DEGENERATE_VALUES = ("-", "(no example value)")
+# A non-event example renders as a `passing:`/`failing:` labelled block (see
+# render_value_example in src/runs.rs), never as a moment HASH/VTIME row.
+_NONEVENT_EXAMPLE = re.compile(r"^(?:passing|failing):", re.MULTILINE)
 
 
 def _has_real_value(value) -> bool:
-    """Whether a non-event example value renders as a usable single VALUE cell —
-    i.e. a scalar, not an empty collection (which renders as `(no example value)`)."""
+    """Whether a non-event example renders as a usable value — i.e. a scalar or a
+    non-empty collection (an empty one renders as the `(no value)` placeholder)."""
     if isinstance(value, (list, dict)):
         return len(value) > 0
-    return True  # scalars (incl. False/0) all render to a visible cell
+    return True  # scalars (incl. False/0) all render to a visible block
 
 
 def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
-    """Pick a non-event property that shows a real single value. We read the
+    """Pick a non-event property that renders a real example value. We read the
     example arrays straight from the JSON and only render-probe the chosen one."""
     candidates = []
     for p in props:
@@ -342,11 +339,10 @@ def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
     candidates.sort(key=lambda p: p.get("example_count") or 0, reverse=True)
     for p in candidates:
         rendered = _render_property(sn, run, p["name"])
-        m = _VALUE_ROW.search(rendered)
-        if m:
-            value = m.group(1).strip()
-            if value and value not in _DEGENERATE_VALUES:
-                return p["name"]
+        # Confirm it renders the non-event shape: a labelled example block and no
+        # moment rows (which would mean we misclassified an event property).
+        if _NONEVENT_EXAMPLE.search(rendered) and not _has_moment_rows(rendered):
+            return p["name"]
         break  # chosen candidate didn't render a usable value — bail
     raise GalleryError(f"no non-event property on {run} renders a usable value")
 
@@ -598,12 +594,15 @@ def property_has_examples(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     return (ok, "shows example moments" if ok else "no example moments (degenerate)")
 
 
-def property_single_value(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+def property_non_event_examples(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+    """A non-event property renders each example as a labelled `passing:`/
+    `failing:` block under an `Examples:` header, with no per-moment rows."""
     text = sr.result.combined
-    m = _VALUE_ROW.search(text)
-    value = m.group(1).strip() if m else ""
-    ok = bool(value) and value not in _DEGENERATE_VALUES and not _has_moment_rows(text)
-    return (ok, f"value={value!r}, no moments")
+    has_header = "Examples:" in text
+    has_value = _NONEVENT_EXAMPLE.search(text) is not None
+    no_moments = not _has_moment_rows(text)
+    ok = has_header and has_value and no_moments
+    return (ok, f"header={has_header}, labelled value={has_value}, no moments={no_moments}")
 
 
 def resolves_single_property(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
@@ -872,11 +871,11 @@ def build_stories(d: Discovery) -> list[Story]:
         ),
         Story(
             "runs-property-non-event",
-            "View a non-event property — a single value",
-            "I want to inspect a non-event property, which is a single value rather than moments.",
-            "Shows the property's value and has no per-moment rows.",
+            "View a non-event property — example values",
+            "I want to inspect a non-event property, whose examples are values (objects) rather than moments.",
+            "Renders each example value under an 'Examples:' header (labelled passing/failing), with no per-moment hash/vtime rows.",
             ["runs", "property", d.success, d.nonevent_prop],
-            property_single_value,
+            property_non_event_examples,
             json_capable=False,
         ),
         Story(
@@ -1116,11 +1115,11 @@ def build_help_stories(d: Discovery) -> list[Story]:
         _help_story(
             "help-runs-property",
             "Learn to read a single property's moments",
-            "I want the help to explain the moment table (and the VALUE form for "
-            "non-event properties) and how to feed a moment into `runs logs`.",
+            "I want the help to explain the moment table (and the value-example form "
+            "for non-event properties) and how to feed a moment into `runs logs`.",
             ["runs", "property"],
             ["runs", "property", s, d.pass_event_prop],
-            samples=[("a non-event property (VALUE form)", ["runs", "property", s, d.nonevent_prop])],
+            samples=[("a non-event property (value examples)", ["runs", "property", s, d.nonevent_prop])],
             align=("HASH", "VTIME"),
         ),
         _help_story(

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -174,8 +174,7 @@ class Discovery:
     fail_prop: str = ""  # failing event property whose detail shows counter-examples
     pass_event_prop: str = ""  # passing event property whose detail shows examples
     nonevent_prop: str = ""  # non-event property whose detail shows a real value
-    fuzzy: str = ""  # substring that resolves to exactly one property
-    ambiguous: str = ""  # substring shared by >= 2 property names
+    name_filter: str = ""  # substring matching exactly one property name
     fail_hash: str = ""
     fail_vtime: str = ""
 
@@ -270,7 +269,9 @@ def _pick_second_needle(event: dict, keyword: str) -> str | None:
 
 
 def _render_property(sn: Snouty, run: str, name: str) -> str:
-    return sn.run(["runs", "property", run, name]).combined
+    # `--name` is a substring filter; passing the exact name selects it (plus any
+    # other name it's a substring of, which is fine for these render probes).
+    return sn.run(["runs", "properties", run, "--name", name, "--detail"]).combined
 
 
 _MOMENT_ROW = re.compile(r"-?\d{6,}\s+\d+\.\d+")  # long hash + float vtime
@@ -347,28 +348,16 @@ def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
     raise GalleryError(f"no non-event property on {run} renders a usable value")
 
 
-def _pick_fuzzy(prop_names: list[str]) -> str:
-    """A case-insensitive substring contained in exactly one property name — so
-    snouty resolves it to a single property instead of erroring."""
+def _pick_name_filter(prop_names: list[str]) -> str:
+    """A case-insensitive word contained in exactly one property name — so the
+    `--name` filter story narrows the list to a single, predictable property."""
     lower = [n.lower() for n in prop_names]
-    # Try whole words first (read naturally), then fall back to any substring.
     for name in prop_names:
         for word in re.findall(r"[A-Za-z]{4,}", name):
             w = word.lower()
             if sum(w in n for n in lower) == 1:
                 return word
-    raise GalleryError("no substring resolves to exactly one property")
-
-
-def _pick_ambiguous(prop_names: list[str]) -> str:
-    counts: dict[str, int] = {}
-    for name in prop_names:
-        for word in {w.lower() for w in re.findall(r"[A-Za-z]{5,}", name)}:
-            counts[word] = counts.get(word, 0) + 1
-    shared = sorted((w for w, c in counts.items() if c > 1), key=len, reverse=True)
-    if shared:
-        return shared[0]
-    raise GalleryError("no substring is shared by >= 2 properties")
+    raise GalleryError("no substring matches exactly one property")
 
 
 def discover(sn: Snouty, scan: int) -> Discovery:
@@ -423,8 +412,7 @@ def discover(sn: Snouty, scan: int) -> Discovery:
         fail_prop=_pick_property_with_moments(sn, success, props, "Failing"),
         pass_event_prop=_pick_property_with_moments(sn, success, props, "Passing"),
         nonevent_prop=_pick_nonevent_property(sn, success, props),
-        fuzzy=_pick_fuzzy(prop_names),
-        ambiguous=_pick_ambiguous(prop_names),
+        name_filter=_pick_name_filter(prop_names),
         fail_hash=fail_moment.get("input_hash", ""),
         fail_vtime=fail_moment.get("vtime", ""),
     )
@@ -603,17 +591,6 @@ def property_non_event_examples(sr: StoryRun, reg: Registry) -> tuple[bool, str]
     no_moments = not _has_moment_rows(text)
     ok = has_header and has_value and no_moments
     return (ok, f"header={has_header}, labelled value={has_value}, no moments={no_moments}")
-
-
-def resolves_single_property(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
-    text = sr.result.combined
-    ok = sr.result.ok and "multiple properties match" not in text.lower() and "Name" in text
-    return (ok, "resolved to one property" if ok else "did not resolve to a single property")
-
-
-def shows_ambiguity(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
-    ok = "multiple properties match" in sr.result.combined.lower()
-    return (ok, "listed candidates" if ok else "did not show the ambiguity prompt")
 
 
 def succeeds_with(*needles: str):
@@ -850,59 +827,49 @@ def build_stories(d: Discovery) -> list[Story]:
             expect_message("incomplete"),
             json_capable=False,
         ),
-        # -- property detail ------------------------------------------------
+        # -- property detail (`properties --name <x> --detail`) -------------
         Story(
-            "runs-property-failing",
+            "runs-properties-detail-failing",
             "Drill into a failing property's counter-examples",
             "A property failed; I want to see concrete counter-examples I can debug.",
             "Shows the property plus at least one counter-example with a moment (hash/vtime) — not an empty `unreachable`.",
-            ["runs", "property", d.success, d.fail_prop],
+            ["runs", "properties", d.success, "--name", d.fail_prop, "--detail"],
             property_has_examples,
             json_capable=False,
         ),
         Story(
-            "runs-property-passing",
+            "runs-properties-detail-passing",
             "Look at the examples behind a passing property",
             "A property passed; I want to see example moments that satisfied it.",
             "Shows at least one example with a moment (hash/vtime).",
-            ["runs", "property", d.success, d.pass_event_prop],
+            ["runs", "properties", d.success, "--name", d.pass_event_prop, "--detail"],
             property_has_examples,
             json_capable=False,
         ),
         Story(
-            "runs-property-non-event",
-            "View a non-event property — example values",
+            "runs-properties-detail-non-event",
+            "Detail a non-event property — example values",
             "I want to inspect a non-event property, whose examples are values (objects) rather than moments.",
             "Renders each example value under an 'Examples:' header (labelled passing/failing), with no per-moment hash/vtime rows.",
-            ["runs", "property", d.success, d.nonevent_prop],
+            ["runs", "properties", d.success, "--name", d.nonevent_prop, "--detail"],
             property_non_event_examples,
             json_capable=False,
         ),
         Story(
-            "runs-property-fuzzy",
-            "Substring match — let snouty figure out which property",
-            "I type part of a property name and expect snouty to find the one I meant.",
-            "Resolves to exactly one property and shows it; does NOT print 'multiple properties match'.",
-            ["runs", "property", d.success, d.fuzzy],
-            resolves_single_property,
-            json_capable=False,
+            "runs-properties--name",
+            "Filter the property list by name substring",
+            "I want to narrow the property list to ones whose name matches a substring.",
+            "Non-empty: every shown property's name contains the substring (case-insensitive).",
+            ["runs", "properties", d.success, "--name", d.name_filter],
+            non_empty_table,
         ),
         Story(
-            "runs-property-ambiguous",
-            "Substring matches multiple properties",
-            "I type an ambiguous substring; I want to understand how snouty responds.",
-            "Lists the candidate properties and asks me to disambiguate.",
-            ["runs", "property", d.success, d.ambiguous],
-            shows_ambiguity,
-            json_capable=False,
-        ),
-        Story(
-            "runs-property-not-found",
-            "Typo'd a property name — get a clean error",
-            "I mistyped a property name and want a helpful error.",
-            "A clear 'no property matches' message, not a stack trace.",
-            ["runs", "property", d.success, "this property does not exist"],
-            expect_message("no property matches"),
+            "runs-properties--name-no-match",
+            "A name filter that matches nothing",
+            "I filter on a substring no property has; I want a friendly empty result.",
+            "A clear 'No properties match' message — not an error or a crash.",
+            ["runs", "properties", d.success, "--name", "this property does not exist"],
+            expect_message("No properties match"),
             json_capable=False,
         ),
         # -- events ---------------------------------------------------------
@@ -1104,23 +1071,20 @@ def build_help_stories(d: Discovery) -> list[Story]:
         ),
         _help_story(
             "help-runs-properties",
-            "Learn to read the properties table",
+            "Learn the properties table, filters, and --detail",
             "I want the help to explain the STATUS/EXAMPLES/NAME columns and the "
-            "examples/counterexamples count, and to match the table.",
+            "examples/counterexamples count, and the --name/--group/--detail flags "
+            "(including how --detail feeds a moment into `runs logs`).",
             ["runs", "properties"],
             ["runs", "properties", s],
-            samples=[("--failing only", ["runs", "properties", s, "--failing"])],
+            samples=[
+                ("--failing only", ["runs", "properties", s, "--failing"]),
+                (
+                    "--name <x> --detail (one property's moments)",
+                    ["runs", "properties", s, "--name", d.pass_event_prop, "--detail"],
+                ),
+            ],
             align=("STATUS", "EXAMPLES", "NAME"),
-        ),
-        _help_story(
-            "help-runs-property",
-            "Learn to read a single property's moments",
-            "I want the help to explain the moment table (and the value-example form "
-            "for non-event properties) and how to feed a moment into `runs logs`.",
-            ["runs", "property"],
-            ["runs", "property", s, d.pass_event_prop],
-            samples=[("a non-event property (value examples)", ["runs", "property", s, d.nonevent_prop])],
-            align=("HASH", "VTIME"),
         ),
         _help_story(
             "help-runs-events",

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -13,6 +13,17 @@ story is also gated by a programmatic check; a degenerate example (an empty
 table, an unintended error, a filter that didn't narrow) fails the run rather
 than being silently emitted.
 
+There are two kinds of story:
+
+  * goal stories — capture one command's output and judge it against a user goal
+    (the bulk of the gallery; slugs like `runs-events-single`).
+  * help stories — capture `snouty <cmd> --help` next to that command's default
+    output (slugs like `help-runs-properties`) and judge whether the help is
+    informative, clear, concise, consistent, and *aligned* with what the command
+    prints. Commands that mutate state or need an interactive arg (launch,
+    debug, validate, update, completions) are help-only. An automated check
+    verifies any column/field the help names actually appears in the output.
+
 Credentials come from the usual ANTITHESIS_* environment variables (snouty reads
 them). Behaviour is controlled with flags, not env vars:
 
@@ -441,6 +452,21 @@ class Story:
     args: list[str]
     check: Callable[["StoryRun", "Registry"], tuple[bool, str]]
     json_capable: bool = True  # can we re-run with --json for structured rows?
+    # -- help stories ------------------------------------------------------
+    # When `help_cmd` is set the story is a "help story": it captures
+    # `snouty <help_cmd> --help` and renders it next to the command's default
+    # output (`args`, plus any `samples`), so a reviewer can judge whether the
+    # help is informative/clear/concise/consistent *and* matches what the
+    # command actually prints. `args` may be empty (help-only, for commands we
+    # must not run because they mutate state, e.g. launch/debug).
+    help_cmd: list[str] | None = None
+    # Extra labelled default-output captures shown after the primary one
+    # (e.g. `runs list --detail`): list of (label, args).
+    samples: list[tuple[str, list[str]]] | None = None
+    # Tokens that must appear in BOTH the help text and the default output —
+    # an automated "help aligns with output" gate (e.g. column headers the help
+    # promises). Only enforced when there is default output to compare against.
+    align_tokens: tuple[str, ...] = ()
 
 
 @dataclass
@@ -448,6 +474,8 @@ class StoryRun:
     story: Story
     result: Result
     rows: list[dict] | None  # structured rows from the --json variant, if any
+    help_result: Result | None = None  # `<help_cmd> --help` capture, for help stories
+    sample_results: list[tuple[str, Result]] | None = None  # extra labelled captures
 
 
 class Registry:
@@ -615,6 +643,37 @@ def logs_begin_at(begin: str):
     return chk
 
 
+def help_story_check(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+    """Gate a help story: the `--help` must be well-formed (exit 0, has a Usage
+    line), any documented `align_tokens` must appear in BOTH the help and the
+    default output (the "help matches output" guarantee), and a command that is
+    supposed to print default output must actually print something. The
+    subjective judgment — is the help clear/concise/consistent? — is left to the
+    reviewer; this only stops a degenerate help/output pair from passing."""
+    h = sr.help_result
+    if h is None or not h.ok or "Usage:" not in h.combined:
+        rc = "none" if h is None else h.returncode
+        return (False, f"help missing or malformed (exit {rc})")
+    help_text = h.combined
+    story = sr.story
+
+    # Help-only story (mutating command we don't run): just the help is enough.
+    if not story.args:
+        return (True, "help only")
+
+    out = sr.result.combined
+    if not out.strip():
+        return (False, "default output is empty")
+
+    if story.align_tokens:
+        miss_help = [t for t in story.align_tokens if t not in help_text]
+        miss_out = [t for t in story.align_tokens if t not in out]
+        if miss_help or miss_out:
+            return (False, f"misaligned — absent from help={miss_help} output={miss_out}")
+        return (True, f"help + output aligned on {list(story.align_tokens)}")
+    return (True, "help + default output present")
+
+
 # ---------------------------------------------------------------------------
 # Story definitions
 # ---------------------------------------------------------------------------
@@ -624,7 +683,7 @@ def build_stories(d: Discovery) -> list[Story]:
     kw, kw2 = d.event_keyword, d.event_kw2
     # `--begin-vtime` for the logs skip-ahead story: just before the sampled moment.
     vmin = f"{max(0.0, d.event_vtime - 0.5):.3f}"
-    return [
+    stories = [
         # -- listing --------------------------------------------------------
         Story(
             "runs",
@@ -944,6 +1003,227 @@ def build_stories(d: Discovery) -> list[Story]:
             json_capable=False,
         ),
     ]
+    return stories + build_help_stories(d)
+
+
+# ---------------------------------------------------------------------------
+# Help stories: render each command's `--help` next to its default output, with
+# rubrics that ask whether the help is informative, clear, concise, consistent,
+# and aligned with what the command actually prints. Commands that mutate state
+# (launch, debug, validate, update) or need an interactive arg (completions) are
+# help-only — `args=[]` so nothing is executed.
+# ---------------------------------------------------------------------------
+
+
+# How a reviewer should judge every help story (shared rubric, kept in one place
+# so the bar is consistent across commands).
+HELP_RUBRIC = (
+    "The `--help` should be **informative** (says what the command does and, for "
+    "read commands, how to read the output and the obvious next command), "
+    "**clear**, **concise** (no wall of text), and **consistent** with the other "
+    "commands' help in tone, layout, and flag ordering. Where default output is "
+    "shown, the help must **align** with it: any columns/fields the help names "
+    "must actually appear, and nothing in the output should be unexplained."
+)
+
+_OUTPUT_RUBRIC = (
+    " Compare the help against the default output shown below it."
+)
+_HELP_ONLY_RUBRIC = (
+    " This command mutates state or needs an interactive argument, so only its "
+    "help is shown — judge the help text on its own merits and for consistency "
+    "with its siblings."
+)
+
+
+def _help_story(
+    slug: str,
+    title: str,
+    goal: str,
+    help_cmd: list[str],
+    args: list[str] | None = None,
+    *,
+    samples: list[tuple[str, list[str]]] | None = None,
+    align: tuple[str, ...] = (),
+) -> Story:
+    args = args or []
+    judge = HELP_RUBRIC + (_OUTPUT_RUBRIC if args else _HELP_ONLY_RUBRIC)
+    return Story(
+        slug=slug,
+        title=title,
+        goal=goal,
+        judge=judge,
+        args=args,
+        check=help_story_check,
+        json_capable=False,
+        help_cmd=help_cmd,
+        samples=samples,
+        align_tokens=align,
+    )
+
+
+def build_help_stories(d: Discovery) -> list[Story]:
+    s = d.success
+    return [
+        # -- top level + read commands with default output ------------------
+        _help_story(
+            "help-root",
+            "Discover what snouty can do",
+            "I just installed snouty and run `snouty --help` to see what's available.",
+            [],
+        ),
+        _help_story(
+            # The parent help is an overview/index of subcommands, not a column
+            # legend (it points at `runs list` for the table), so no align tokens.
+            "help-runs",
+            "Understand the runs command group",
+            "I run `snouty runs --help` to learn how to work with test runs.",
+            ["runs"],
+            ["runs"],
+        ),
+        _help_story(
+            "help-runs-list",
+            "Learn to list runs, including the detailed view",
+            "I want to know what `runs list` shows and how the columns map to the output, "
+            "including the fuller `--detail` view.",
+            ["runs", "list"],
+            ["runs", "list", "-n", "6"],
+            samples=[("with --detail", ["runs", "list", "-n", "3", "--detail"])],
+            align=("RUN ID", "STATUS", "CREATED", "TEST NAME"),
+        ),
+        _help_story(
+            "help-runs-show",
+            "Learn what `runs show` reports",
+            "I want to confirm the help explains the metadata fields and the failure "
+            "moment shown for incomplete runs.",
+            ["runs", "show"],
+            ["runs", "show", s],
+            samples=[("an incomplete run (shows the failure moment)", ["runs", "show", d.fail])],
+            # show prints a key/value card (prose help vs Title-Case labels), not a
+            # columnar table — no strict token alignment; the reviewer compares the
+            # prose field list and the failure-moment claim against the two samples.
+        ),
+        _help_story(
+            "help-runs-properties",
+            "Learn to read the properties table",
+            "I want the help to explain the STATUS/EXAMPLES/NAME columns and the "
+            "examples/counterexamples count, and to match the table.",
+            ["runs", "properties"],
+            ["runs", "properties", s],
+            samples=[("--failing only", ["runs", "properties", s, "--failing"])],
+            align=("STATUS", "EXAMPLES", "NAME"),
+        ),
+        _help_story(
+            "help-runs-property",
+            "Learn to read a single property's moments",
+            "I want the help to explain the moment table (and the VALUE form for "
+            "non-event properties) and how to feed a moment into `runs logs`.",
+            ["runs", "property"],
+            ["runs", "property", s, d.pass_event_prop],
+            samples=[("a non-event property (VALUE form)", ["runs", "property", s, d.nonevent_prop])],
+            align=("HASH", "VTIME"),
+        ),
+        _help_story(
+            "help-runs-events",
+            "Learn to search events and chain into logs",
+            "I want the help to explain the HASH/VTIME/SOURCE/OUTPUT columns and that "
+            "a moment feeds `runs logs`.",
+            ["runs", "events"],
+            ["runs", "events", s, "--match", d.event_keyword],
+            align=("HASH", "VTIME", "SOURCE", "OUTPUT"),
+        ),
+        _help_story(
+            "help-runs-logs",
+            "Learn what the positional moment vs --begin-vtime do",
+            "I want the help to make clear that the positional moment streams logs up to "
+            "it and --begin-vtime sets the start, and to describe the line format.",
+            ["runs", "logs"],
+            ["runs", "logs", s, d.event_hash, f"{d.event_vtime}"],
+        ),
+        _help_story(
+            "help-runs-build-logs",
+            "Learn what build-logs streams",
+            "I want the help to tell me this is the build/setup log and the line format.",
+            ["runs", "build-logs"],
+            ["runs", "build-logs", s],
+        ),
+        _help_story(
+            "help-doctor",
+            "Learn what doctor checks",
+            "I run `snouty doctor --help` to see what it verifies, then run it.",
+            ["doctor"],
+            ["doctor"],
+        ),
+        _help_story(
+            "help-version",
+            "Check the version command's help",
+            "I want `version --help` to be a clear, minimal description.",
+            ["version"],
+            ["version"],
+        ),
+        # -- help-only (mutating / interactive) -----------------------------
+        _help_story(
+            "help-launch",
+            "Understand how to launch a run",
+            "I run `snouty launch --help` to learn how to start a test run.",
+            ["launch"],
+        ),
+        _help_story(
+            "help-debug",
+            "Understand how to open a debugging session",
+            "I run `snouty debug --help` to learn how to debug a moment.",
+            ["debug"],
+        ),
+        _help_story(
+            "help-validate",
+            "Understand local validation",
+            "I run `snouty validate --help` to learn how to validate my config.",
+            ["validate"],
+        ),
+        _help_story(
+            "help-completions",
+            "Generate shell completions",
+            "I run `snouty completions --help` to learn how to install completions.",
+            ["completions"],
+        ),
+        _help_story(
+            "help-update",
+            "Check for updates",
+            "I run `snouty update --help` to understand what updating does.",
+            ["update"],
+        ),
+        # -- docs (help-only: output depends on a downloaded docs DB) --------
+        _help_story(
+            "help-docs",
+            "Understand the docs command group",
+            "I run `snouty docs --help` to see how to search the documentation.",
+            ["docs"],
+        ),
+        _help_story(
+            "help-docs-search",
+            "Learn to search the docs",
+            "I run `snouty docs search --help` to learn the search syntax and output.",
+            ["docs", "search"],
+        ),
+        _help_story(
+            "help-docs-tree",
+            "Learn to browse the docs tree",
+            "I run `snouty docs tree --help` to learn how to browse documentation paths.",
+            ["docs", "tree"],
+        ),
+        _help_story(
+            "help-docs-show",
+            "Learn to show a docs page",
+            "I run `snouty docs show --help` to learn how to read a page.",
+            ["docs", "show"],
+        ),
+        _help_story(
+            "help-docs-sqlite",
+            "Locate the docs database",
+            "I run `snouty docs sqlite --help` to find the cached documentation DB.",
+            ["docs", "sqlite"],
+        ),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -951,8 +1231,47 @@ def build_stories(d: Discovery) -> list[Story]:
 # ---------------------------------------------------------------------------
 
 
+# Default-output samples in a help story are capped — the point there is to see
+# the *shape* of the output next to the help, not the full stream. The
+# goal-based stories (above) still capture full, untruncated output.
+HELP_SAMPLE_MAX_LINES = 18
+
+
+def _capped_block(args: list[str], text: str) -> str:
+    """A ```shell block showing `$ snouty <args>` and its output, truncated to
+    `HELP_SAMPLE_MAX_LINES` with a marker so help stories stay focused."""
+    lines = text.rstrip("\n").split("\n")
+    if len(lines) > HELP_SAMPLE_MAX_LINES:
+        hidden = len(lines) - HELP_SAMPLE_MAX_LINES
+        lines = lines[:HELP_SAMPLE_MAX_LINES] + [f"… ({hidden} more lines)"]
+    body = "\n".join(lines)
+    return f"```shell\n$ snouty {' '.join(args)}\n{body}\n```"
+
+
+def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
+    help_text = (sr.help_result.combined if sr.help_result else "").rstrip("\n")
+    parts = [
+        f"# {story.title}",
+        f"**User goal:** {story.goal}",
+        f"**Judge satisfaction by:** {story.judge}",
+        "## Help text",
+        f"```shell\n$ snouty {' '.join(story.help_cmd)} --help\n{help_text}\n```",
+    ]
+    if story.args:
+        parts.append("## Default output")
+        parts.append(_capped_block(story.args, sr.result.combined))
+        for label, res in sr.sample_results or []:
+            parts.append(f"### Variant: {label}")
+            parts.append(_capped_block(res.args, res.combined))
+    parts.append(f"_Automated check: {verdict} — {detail}_")
+    (out_dir / f"{story.slug}.md").write_text("\n\n".join(parts) + "\n")
+
+
 def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail: str) -> None:
     verdict = "PASS" if passed else "FAIL"
+    if story.help_cmd is not None:
+        _write_help_story(out_dir, story, sr, verdict, detail)
+        return
     body = sr.result.combined.rstrip("\n")
     md = (
         f"# {story.title}\n\n"
@@ -965,14 +1284,22 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
 
 
 def run_story(sn: Snouty, story: Story) -> StoryRun:
-    result = sn.run(story.args)
+    # Help-only stories pass no `args`; don't invoke a bare `snouty`.
+    result = sn.run(story.args) if story.args else Result([], "", "", 0)
     rows = None
-    if story.json_capable:
+    if story.json_capable and story.args:
         try:
             rows = sn.json_lines(story.args)
         except (GalleryError, json.JSONDecodeError):
             rows = None  # error stories are validated on rendered text instead
-    return StoryRun(story, result, rows)
+
+    help_result = None
+    sample_results = None
+    if story.help_cmd is not None:
+        help_result = sn.run([*story.help_cmd, "--help"])
+        if story.samples:
+            sample_results = [(label, sn.run(a)) for label, a in story.samples]
+    return StoryRun(story, result, rows, help_result, sample_results)
 
 
 def main() -> int:

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -331,9 +331,16 @@ def _has_real_value(value) -> bool:
 def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
     """Pick a non-event property that renders a real example value. We read the
     example arrays straight from the JSON and only render-probe the chosen one."""
+    # `--name` is a substring filter, so the chosen name must not be a substring
+    # of any *other* property's name — otherwise the --detail probe would also
+    # expand that other property, and an event sibling's moment rows would make us
+    # think we'd misclassified. Require the name to match only itself.
+    lower_names = [p["name"].lower() for p in props]
     candidates = []
     for p in props:
         if p.get("is_event") is not False:
+            continue
+        if sum(p["name"].lower() in n for n in lower_names) != 1:
             continue
         values = (p.get("examples") or []) + (p.get("counterexamples") or [])
         if any(_has_real_value(v) for v in values):
@@ -452,6 +459,10 @@ class Story:
     # an automated "help aligns with output" gate (e.g. column headers the help
     # promises). Only enforced when there is default output to compare against.
     align_tokens: tuple[str, ...] = ()
+    # Whether the default-output command is expected to exit 0. True for read
+    # commands; set False for a command that legitimately exits non-zero while
+    # still printing representative output (e.g. `doctor` when a check fails).
+    expect_ok: bool = True
 
 
 @dataclass
@@ -641,6 +652,13 @@ def help_story_check(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     if not out.strip():
         return (False, "default output is empty")
 
+    # A non-zero exit means `out` is probably an error (auth/API failure) captured
+    # as if it were the command's normal output — don't pass it off as a sample.
+    # `doctor` opts out (expect_ok=False): it exits non-zero on a failed check yet
+    # still prints representative output.
+    if story.expect_ok and not sr.result.ok:
+        return (False, f"default command failed (exit {sr.result.returncode})")
+
     if story.align_tokens:
         miss_help = [t for t in story.align_tokens if t not in help_text]
         miss_out = [t for t in story.align_tokens if t not in out]
@@ -692,8 +710,12 @@ def build_stories(d: Discovery) -> list[Story]:
             "Descriptions are shown in full (longer than the default view), one row per run.",
             ["runs", "list", "-n", "6", "--detail"],
             # --detail can't be combined with --json, so validate the rendered
-            # key-value blocks directly rather than re-running for JSON rows.
-            contains_all("Run ID", "Description"),
+            # key-value blocks directly rather than re-running for JSON rows. Check
+            # the always-present title-case labels (the default table uses
+            # UPPERCASE headers and no "Launcher"); "Description" is omitted when a
+            # run has none, so requiring it would falsely fail on description-less
+            # runs even though the detailed view rendered correctly.
+            contains_all("Run ID", "Created", "Launcher"),
             json_capable=False,
         ),
         Story(
@@ -1014,6 +1036,7 @@ def _help_story(
     *,
     samples: list[tuple[str, list[str]]] | None = None,
     align: tuple[str, ...] = (),
+    expect_ok: bool = True,
 ) -> Story:
     args = args or []
     judge = HELP_RUBRIC + (_OUTPUT_RUBRIC if args else _HELP_ONLY_RUBRIC)
@@ -1028,6 +1051,7 @@ def _help_story(
         help_cmd=help_cmd,
         samples=samples,
         align_tokens=align,
+        expect_ok=expect_ok,
     )
 
 
@@ -1119,6 +1143,9 @@ def build_help_stories(d: Discovery) -> list[Story]:
             "I run `snouty doctor --help` to see what it verifies, then run it.",
             ["doctor"],
             ["doctor"],
+            # `doctor` exits non-zero when a check fails but still prints its
+            # findings — that output is exactly what we want to show.
+            expect_ok=False,
         ),
         _help_story(
             "help-version",
@@ -1221,7 +1248,7 @@ def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, d
         f"**User goal:** {story.goal}",
         f"**Judge satisfaction by:** {story.judge}",
         "## Help text",
-        f"```shell\n$ snouty {' '.join(story.help_cmd)} --help\n{help_text}\n```",
+        f"```shell\n$ snouty {' '.join(story.help_cmd or [])} --help\n{help_text}\n```",
     ]
     if story.args:
         parts.append("## Default output")

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -314,9 +314,11 @@ def _pick_property_with_moments(sn: Snouty, run: str, props: list[dict], status:
     )
 
 
-# A non-event example renders as a `passing:`/`failing:` labelled block (see
-# render_value_example in src/runs.rs), never as a moment HASH/VTIME row.
-_NONEVENT_EXAMPLE = re.compile(r"^(?:passing|failing):", re.MULTILINE)
+# A non-event example renders either as an indented `passing:`/`failing:`
+# labelled block or, for a lone number, as an inline `Example   <n>` line (see
+# render_property_detail / render_value_example in src/runs.rs) — never as a
+# moment HASH/VTIME row. Leading whitespace allows for the --detail indent.
+_NONEVENT_EXAMPLE = re.compile(r"^\s*(?:(?:passing|failing):|Example\s)", re.MULTILINE)
 
 
 def _has_real_value(value) -> bool:

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -314,11 +314,10 @@ def _pick_property_with_moments(sn: Snouty, run: str, props: list[dict], status:
     )
 
 
-# A non-event example renders either as an indented `passing:`/`failing:`
-# labelled block or, for a lone number, as an inline `Example   <n>` line (see
-# render_property_detail / render_value_example in src/runs.rs) — never as a
-# moment HASH/VTIME row. Leading whitespace allows for the --detail indent.
-_NONEVENT_EXAMPLE = re.compile(r"^\s*(?:(?:passing|failing):|Example\s)", re.MULTILINE)
+# A non-event ("system") property renders its value under a `Result` label
+# (see render_result in src/runs.rs) — `Result   <scalar>` inline or `Result:`
+# above indented JSON — never as a moment HASH/VTIME row.
+_NONEVENT_RESULT = re.compile(r"^\s*Result[: ]", re.MULTILINE)
 
 
 def _has_real_value(value) -> bool:
@@ -344,7 +343,7 @@ def _pick_nonevent_property(sn: Snouty, run: str, props: list[dict]) -> str:
         rendered = _render_property(sn, run, p["name"])
         # Confirm it renders the non-event shape: a labelled example block and no
         # moment rows (which would mean we misclassified an event property).
-        if _NONEVENT_EXAMPLE.search(rendered) and not _has_moment_rows(rendered):
+        if _NONEVENT_RESULT.search(rendered) and not _has_moment_rows(rendered):
             return p["name"]
         break  # chosen candidate didn't render a usable value — bail
     raise GalleryError(f"no non-event property on {run} renders a usable value")
@@ -584,15 +583,14 @@ def property_has_examples(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     return (ok, "shows example moments" if ok else "no example moments (degenerate)")
 
 
-def property_non_event_examples(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
-    """A non-event property renders each example as a labelled `passing:`/
-    `failing:` block under an `Examples:` header, with no per-moment rows."""
+def property_non_event_result(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+    """A non-event property shows its value(s) under a `Result` label, with no
+    per-moment HASH/VTIME rows (those belong to event properties' Examples)."""
     text = sr.result.combined
-    has_header = "Examples:" in text
-    has_value = _NONEVENT_EXAMPLE.search(text) is not None
+    has_result = _NONEVENT_RESULT.search(text) is not None
     no_moments = not _has_moment_rows(text)
-    ok = has_header and has_value and no_moments
-    return (ok, f"header={has_header}, labelled value={has_value}, no moments={no_moments}")
+    ok = has_result and no_moments
+    return (ok, f"result={has_result}, no moments={no_moments}")
 
 
 def succeeds_with(*needles: str):
@@ -850,11 +848,11 @@ def build_stories(d: Discovery) -> list[Story]:
         ),
         Story(
             "runs-properties-detail-non-event",
-            "Detail a non-event property — example values",
-            "I want to inspect a non-event property, whose examples are values (objects) rather than moments.",
-            "Renders each example value under an 'Examples:' header (labelled passing/failing), with no per-moment hash/vtime rows.",
+            "Detail a non-event property — its result value",
+            "I want to inspect a non-event ('system') property, whose value is data rather than moments.",
+            "Shows the value under a 'Result' label (scalar inline, or JSON for an object/array), with no per-moment hash/vtime rows.",
             ["runs", "properties", d.success, "--name", d.nonevent_prop, "--detail"],
-            property_non_event_examples,
+            property_non_event_result,
             json_capable=False,
         ),
         Story(

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -691,7 +691,10 @@ def build_stories(d: Discovery) -> list[Story]:
             "Default titles are truncated; I want to read the full descriptions.",
             "Descriptions are shown in full (longer than the default view), one row per run.",
             ["runs", "list", "-n", "6", "--detail"],
-            non_empty_table,
+            # --detail can't be combined with --json, so validate the rendered
+            # key-value blocks directly rather than re-running for JSON rows.
+            contains_all("Run ID", "Description"),
+            json_capable=False,
         ),
         Story(
             "runs-list--status-completed",

--- a/specs/docs_shared.txt
+++ b/specs/docs_shared.txt
@@ -23,7 +23,8 @@
 #    set), the command tells the user to remove --offline.
 env HOME=$WORK/empty-home
 ! snouty docs --offline search docker
-stderr 'Documentation database not found. Remove --offline to download it.'
+stderr 'Documentation database not found.*'
+stderr 'remove --offline to download it.*'
 
 # The command is exposed as `snouty docs` with search, show, tree, and
 #    sqlite subcommands.

--- a/specs/docs_show.txt
+++ b/specs/docs_show.txt
@@ -33,5 +33,5 @@ stderr 'page not found.*nonexistent_page'
 
 # 3b. Partial match suggests similar pages.
 ! snouty docs --offline show sdk
-stderr 'Did you mean.*'
+stderr 'did you mean.*'
 stderr '/docs/sdk/python_sdk/.*'

--- a/specs/launch_config.txt
+++ b/specs/launch_config.txt
@@ -28,7 +28,7 @@ stderr '.*does not contain.*docker-compose.yaml.*manifests/.*'
 
 # Rejects docker-compose.yml (wrong extension).
 ! snouty launch -w basic_test -c yml_dir --duration 30
-stderr '.*requires docker-compose.yaml.*'
+stderr '.*rename it to docker-compose.yaml.*'
 
 # Rejects an ambiguous directory containing both compose and manifests/.
 ! snouty launch -w basic_test -c ambiguous --duration 30

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -149,7 +149,7 @@ snouty runs properties $R_run_id --name counter
 [!staging] stdout 'failing.*Counter value stays below limit'
 [!staging] stdout -count=0 'Setup completes'
 
-# --group is an exact, case-insensitive group filter ('safety' matches 'Safety').
+# --group is a case-insensitive substring group filter ('safety' matches 'Safety').
 mock-runs-server
 snouty runs properties $R_run_id --group safety
 [!staging] stdout 'failing.*Counter value stays below limit'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -100,10 +100,11 @@ snouty --json runs show $R_run_id
 stdout '"run_id".*"$R_run_id"'
 [!staging] stdout '"status".*"completed"'
 
-# `snouty runs properties` renders one row per property with a status word, the
-# example count (with counterexamples shown inline as `examples/counterexamples`
-# when a property has any), and name (the group is folded into the name as
-# `group ▸ name`). Counts are SI-shortened (e.g. `2.3k`) and right-aligned.
+# `snouty runs properties` renders one table per group (the group is the section
+# heading), each with STATUS, the example count (counterexamples shown inline as
+# `examples/counterexamples` when a property has any, SI-shortened and
+# right-aligned), and the property NAME. Ungrouped properties go in a trailing
+# "(ungrouped)" section.
 mock-runs-server
 snouty runs properties $R_run_id
 [!staging] stdout 'STATUS.*EXAMPLES.*NAME'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -155,11 +155,11 @@ snouty runs properties $R_run_id --group safety
 [!staging] stdout 'failing.*Counter value stays below limit'
 [!staging] stdout -count=0 'Setup completes'
 
-# A non-event property's --detail renders each example value as a labelled block
-# under an "Examples:" header (no per-moment HASH/VTIME table).
+# A non-event ("system") property's --detail shows its value under a `Result`
+# label — a single object renders as indented JSON, no moment table or Examples.
 mock-runs-server
 snouty runs properties $R_run_id --name 'Setup completes' --detail
-[!staging] stdout 'Examples:.*passing:'
+[!staging] stdout 'Result:.*final_counter'
 [!staging] stdout '"final_counter".*42'
 
 # A filter that matches nothing prints a friendly empty-state, not an error.

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -156,11 +156,19 @@ snouty runs properties $R_run_id --group safety
 [!staging] stdout -count=0 'Setup completes'
 
 # A non-event ("system") property's --detail shows its value under a `Result`
-# label — a single object renders as indented JSON, no moment table or Examples.
+# label (no `:`, like the other labels). A small object inlines as compact JSON
+# against the value column; there's no moment table or Examples.
 mock-runs-server
 snouty runs properties $R_run_id --name 'Setup completes' --detail
-[!staging] stdout 'Result:.*final_counter'
+[!staging] stdout 'Result.*final_counter'
 [!staging] stdout '"final_counter".*42'
+
+# A *failing* non-event property carries its violating value in counterexamples;
+# --detail labels those under `Counter-examples` (shown first), distinct from the
+# satisfying `Examples`, so the offending value isn't lost in an unlabelled list.
+mock-runs-server
+snouty runs properties $R_run_id --name 'Peak memory' --detail
+[!staging] stdout '(?s)Counter-examples.*1340.*Examples.*820'
 
 # A filter that matches nothing prints a friendly empty-state, not an error.
 mock-runs-server

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -100,13 +100,15 @@ snouty --json runs show $R_run_id
 stdout '"run_id".*"$R_run_id"'
 [!staging] stdout '"status".*"completed"'
 
-# `snouty runs properties` renders one row per property with a status word,
-# total example count, and name (the group is folded into the name as
-# `group ▸ name`).
+# `snouty runs properties` renders one row per property with a status word, the
+# example count (with counterexamples shown inline as `examples/counterexamples`
+# when a property has any), and name (the group is folded into the name as
+# `group ▸ name`). Counts are SI-shortened (e.g. `2.3k`) and right-aligned.
 mock-runs-server
 snouty runs properties $R_run_id
 [!staging] stdout 'STATUS.*EXAMPLES.*NAME'
-[!staging] stdout 'failing.*Counter value stays below limit'
+# Counter has 12 examples and 3 counterexamples -> `12/3`.
+[!staging] stdout 'failing.*12/3.*Counter value stays below limit'
 [!staging] stdout 'passing.*Setup completes'
 
 # `snouty runs properties --failing` shows only failing properties.
@@ -157,10 +159,12 @@ snouty runs property $R_run_id 'Setup completes'
 [!staging] stdout 'STATUS.*VALUE'
 [!staging] stdout 'passing.*'
 
-# An unknown property errors clearly.
+# An unknown property errors clearly, and points at the full list so the user
+# isn't left at a dead end.
 mock-runs-server
 ! snouty runs property $R_run_id no-such-property
 stderr 'no property matches.*no-such-property'
+[!staging] stderr 'runs properties.*to see the available'
 
 # `snouty runs build-logs` streams formatted build log lines. Timestamps are
 # reformatted into the local timezone without a tz suffix; TZ is pinned to UTC
@@ -299,9 +303,9 @@ stderr '.*'
 # moment/source/IPT_bytes_out envelope stripped.
 mock-runs-server
 snouty runs logs run-1 -123 1.0
-stdout '\[\s*1\] \[\s*app\] \[out\] \{"level":"info","msg":"starting"\}'
-stdout '\[\s*2\] \[\s*app\] \[err\] \{"level":"warn","msg":"slow request"\}'
-stdout '\[\s*311\.849\] \[\s*control\] \[\s*\] +- \{"antithesis_assert"'
+stdout '\[\s*1\.000\] \[\s*app\] \[out\] \{"level":"info","msg":"starting"\}'
+stdout '\[\s*2\.000\] \[\s*app\] \[err\] \{"level":"warn","msg":"slow request"\}'
+stdout '\[\s*311\.848\] \[\s*control\] \[\s*\] +- \{"antithesis_assert"'
 
 # `snouty --json runs logs` outputs NDJSON with faults annotated.
 mock-runs-server
@@ -327,7 +331,7 @@ stdout 'output_text.*starting'
 # or control-byte escaping); the line prefix is still formatted.
 mock-runs-server
 snouty runs logs --raw run-1 -123 1.0
-stdout '\[\s*1\] \[\s*app\] \[out\] \{"level":"info","msg":"starting"\}'
+stdout '\[\s*1\.000\] \[\s*app\] \[out\] \{"level":"info","msg":"starting"\}'
 
 # `snouty --json runs logs` emits a record whose output_text contains
 # a JSON-escaped newline on a single output line.

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -134,41 +134,45 @@ snouty --json runs properties $R_run_id
 [!staging] stdout '"name".*"Counter value stays below limit"'
 [!staging] stdout '"status".*"Failing"'
 
-# `snouty runs property` drills in on a single property and shows its examples
-# with a status column (passing/failing/unreachable).
+# `--name <substr> --detail` expands the matching property into its examples.
+# For the Counter event property that's a STATUS/HASH/VTIME table, sorted
+# numerically by vtime (5.0 before 10.0), failing before passing.
 mock-runs-server
-snouty runs property $R_run_id 'Counter value stays below limit'
+snouty runs properties $R_run_id --name 'Counter value' --detail
 [!staging] stdout 'STATUS.*HASH.*VTIME'
-# Rows within each group are sorted numerically by vtime (5.0 before 10.0,
-# even though the API returns them 10.0-then-5.0), failing before passing.
 [!staging] stdout '(?s)failing.*-100.*5\.0.*failing.*-200.*10\.0.*passing.*-300.*15\.0'
 
-# A fuzzy (substring) match discloses the substitution. In human mode the note
-# is printed first on stdout (so it reads above the resolved property); in --json
-# mode it goes to stderr so stdout stays clean JSON.
+# --name is a case-insensitive substring filter over property names; without
+# --detail it just narrows the (grouped) table.
 mock-runs-server
-snouty runs property $R_run_id counter
-[!staging] stdout 'no exact match for .counter., using closest property: .Counter value stays below limit.'
+snouty runs properties $R_run_id --name counter
+[!staging] stdout 'failing.*Counter value stays below limit'
+[!staging] stdout -count=0 'Setup completes'
 
+# --group is an exact, case-insensitive group filter ('safety' matches 'Safety').
 mock-runs-server
-snouty --json runs property $R_run_id counter
-[!staging] stderr 'no exact match for .counter., using closest property: .Counter value stays below limit.'
-[!staging] stdout '"name".*"Counter value stays below limit"'
+snouty runs properties $R_run_id --group safety
+[!staging] stdout 'failing.*Counter value stays below limit'
+[!staging] stdout -count=0 'Setup completes'
 
-# Non-event properties render each example value as its own labelled block under
-# an "Examples:" header (no per-moment HASH/VTIME table). Patterns include a
-# regex metacharacter so testscript matches them as a substring search.
+# A non-event property's --detail renders each example value as a labelled block
+# under an "Examples:" header (no per-moment HASH/VTIME table).
 mock-runs-server
-snouty runs property $R_run_id 'Setup completes'
+snouty runs properties $R_run_id --name 'Setup completes' --detail
 [!staging] stdout 'Examples:.*passing:'
 [!staging] stdout '"final_counter".*42'
 
-# An unknown property errors clearly, and points at the full list so the user
-# isn't left at a dead end.
+# A filter that matches nothing prints a friendly empty-state, not an error.
 mock-runs-server
-! snouty runs property $R_run_id no-such-property
-stderr 'no property matches.*no-such-property'
-[!staging] stderr 'runs properties.*to see the available'
+snouty runs properties $R_run_id --name no-such-property
+[!staging] stdout 'No properties match.*no-such-property'
+
+# --detail conflicts with --json (which already emits the full data), for both
+# `runs properties` and `runs list`.
+! snouty --json runs properties $R_run_id --detail
+stderr 'detail.*json'
+! snouty --json runs list --detail
+stderr 'detail.*json'
 
 # `snouty runs build-logs` streams formatted build log lines. Timestamps are
 # reformatted into the local timezone without a tz suffix; TZ is pinned to UTC

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -143,22 +143,25 @@ snouty runs property $R_run_id 'Counter value stays below limit'
 # even though the API returns them 10.0-then-5.0), failing before passing.
 [!staging] stdout '(?s)failing.*-100.*5\.0.*failing.*-200.*10\.0.*passing.*-300.*15\.0'
 
-# A fuzzy (substring) match discloses the substitution on stderr, in both human
-# and --json modes, so a JSON consumer never silently gets a different property.
+# A fuzzy (substring) match discloses the substitution. In human mode the note
+# is printed first on stdout (so it reads above the resolved property); in --json
+# mode it goes to stderr so stdout stays clean JSON.
 mock-runs-server
 snouty runs property $R_run_id counter
-[!staging] stderr 'no exact match for .counter., using closest property: .Counter value stays below limit.'
+[!staging] stdout 'no exact match for .counter., using closest property: .Counter value stays below limit.'
 
 mock-runs-server
 snouty --json runs property $R_run_id counter
 [!staging] stderr 'no exact match for .counter., using closest property: .Counter value stays below limit.'
 [!staging] stdout '"name".*"Counter value stays below limit"'
 
-# Non-event properties drill into a STATUS/VALUE table.
+# Non-event properties render each example value as its own labelled block under
+# an "Examples:" header (no per-moment HASH/VTIME table). Patterns include a
+# regex metacharacter so testscript matches them as a substring search.
 mock-runs-server
 snouty runs property $R_run_id 'Setup completes'
-[!staging] stdout 'STATUS.*VALUE'
-[!staging] stdout 'passing.*'
+[!staging] stdout 'Examples:.*passing:'
+[!staging] stdout '"final_counter".*42'
 
 # An unknown property errors clearly, and points at the full list so the user
 # isn't left at a dead end.

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use color_eyre::Section;
 use color_eyre::eyre::{Context, Report, Result, eyre};
+use color_eyre::{Section, SectionExt};
 use futures_util::stream;
 use log::debug;
 use progenitor_client::{ClientHooks, ClientInfo, Error as ClientError, OperationInfo};
@@ -185,7 +185,7 @@ impl Auth {
         }
         let has_basic = optional_env("ANTITHESIS_USERNAME")?.is_some()
             || optional_env("ANTITHESIS_PASSWORD")?.is_some();
-        let mut err = eyre!("missing environment variable: ANTITHESIS_API_KEY");
+        let mut err = user_error("missing environment variable: ANTITHESIS_API_KEY");
         if has_basic {
             err = err.note(
                 "ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD are set, but this command only \
@@ -722,7 +722,7 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
     for (key, value) in params.as_map() {
         let value = value
             .as_str()
-            .ok_or_else(|| eyre!("launch params must be strings: {key}"))?;
+            .ok_or_else(|| user_error(format!("launch params must be strings: {key}")))?;
 
         builder = match key.as_str() {
             "antithesis.config_image" => builder.antithesis_config_image(Some(value.to_string())),
@@ -758,7 +758,7 @@ fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequ
     for (key, value) in params.as_map() {
         let value = value
             .as_str()
-            .ok_or_else(|| eyre!("debugging params must be strings: {key}"))?;
+            .ok_or_else(|| user_error(format!("debugging params must be strings: {key}")))?;
 
         builder = match key.as_str() {
             "antithesis.debugging.input_hash" => {
@@ -774,7 +774,7 @@ fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequ
             "antithesis.report.recipients" => {
                 builder.antithesis_report_recipients(Some(value.to_string()))
             }
-            _ => return Err(eyre!("unknown debugging param: {key}")),
+            _ => return Err(user_error(format!("unknown debugging param: {key}"))),
         };
     }
 
@@ -812,9 +812,16 @@ fn ensure_resource_supported(run_id: &str, min_version: u32, resource: &str) -> 
     if let Some(version) = run_version(run_id)
         && version < min_version
     {
-        return Err(eyre!(
-            "run {run_id} was generated on a tenant before v{min_version}, which introduced the {resource} API being used. Re-run {run_id} on a more recent version to access {resource}."
-        ));
+        return Err(
+            user_error(format!("{resource} is not available for run {run_id}"))
+                .note(format!(
+                    "the {resource} API was introduced in tenant version v{min_version}; \
+                 run {run_id} was generated on an earlier version"
+                ))
+                .suggestion(format!(
+                    "re-run {run_id} on a more recent version to access {resource}"
+                )),
+        );
     }
     Ok(())
 }
@@ -860,20 +867,30 @@ fn format_api_error(status: u16, body: &str) -> Report {
         msg.push_str(" — ");
         msg.push_str(body);
     }
-    if matches!(status, 401 | 403) {
-        msg.push_str(
-            "\n\nCheck that ANTITHESIS_API_KEY (or ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD) \
-             is set correctly and has access to this tenant.",
-        );
-    }
     // Carry the HTTP status structurally so callers can classify the failure
     // (e.g. "was this a 404?") without sniffing the rendered message string.
-    // `is_user_error` recognises 4xx `ApiError`s, so 4xx still prints as a clean
-    // user-facing message while 5xx and other statuses stay internal faults.
-    Report::new(ApiError {
+    let report = Report::new(ApiError {
         status,
         message: msg,
-    })
+    });
+    // The "what to check" for an auth failure is guidance, not part of the error
+    // statement, so it rides along as a suggestion note.
+    let report = if matches!(status, 401 | 403) {
+        report.suggestion(
+            "check that ANTITHESIS_API_KEY (or ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD) \
+             is set correctly and has access to this tenant",
+        )
+    } else {
+        report
+    };
+    // A 4xx is the user's to fix (bad credentials, unknown run id, invalid
+    // filter, …), so it prints as a clean message — no backtrace, even under
+    // `RUST_BACKTRACE`. 5xx and other statuses are genuine faults and keep theirs.
+    if (400..500).contains(&status) {
+        report.suppress_backtrace(true)
+    } else {
+        report
+    }
 }
 
 fn format_payload_snippet(body: &str, line: usize, column: usize) -> String {
@@ -947,7 +964,7 @@ async fn format_api_client_error(err: ClientError<generated::types::ErrorRespons
                 eyre!("API returned an empty response body where a JSON payload was expected")
             } else {
                 let snippet = format_payload_snippet(&body, err.line(), err.column());
-                eyre!("invalid API response payload: {err}\n{snippet}")
+                eyre!("invalid API response payload: {err}").section(snippet.header("payload:"))
             }
         }
         ClientError::Custom(message) => eyre!(message),
@@ -1166,11 +1183,14 @@ mod tests {
         );
 
         let report = format_api_client_error(err).await;
+        // The message is the bare statement …
         let message = format!("{report}");
-
         assert!(message.starts_with("invalid API response payload: "));
-        assert!(message.contains("not json"));
-        assert!(message.contains('^'));
+        // … and the payload snippet (with its caret) rides along as a section,
+        // rendered by the full report rather than the message.
+        let full = format!("{report:?}");
+        assert!(full.contains("not json"), "got: {full}");
+        assert!(full.contains('^'), "got: {full}");
     }
 
     #[tokio::test]
@@ -1487,15 +1507,6 @@ mod tests {
     }
 
     #[test]
-    fn api_4xx_errors_are_tagged_user_facing() {
-        use crate::error::is_user_error;
-        assert!(is_user_error(&format_api_error(404, "run not found")));
-        assert!(is_user_error(&format_api_error(400, "bad request")));
-        // 5xx is an internal fault, not something the user can fix.
-        assert!(!is_user_error(&format_api_error(500, "boom")));
-    }
-
-    #[test]
     fn format_api_error_carries_structured_status() {
         use crate::error::api_error_status;
         // The status is read structurally, not sniffed from the message — so a
@@ -1722,12 +1733,20 @@ mod tests {
 
     #[test]
     fn properties_rejected_before_v52() {
-        let err = ensure_resource_supported(&rid(40), MIN_PROPERTIES_VERSION, "run properties")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("before v52"));
-        assert!(err.contains("run properties"));
-        assert!(err.contains("Re-run") && err.contains("more recent version"));
+        let report = ensure_resource_supported(&rid(40), MIN_PROPERTIES_VERSION, "run properties")
+            .unwrap_err();
+        // The message states the error; the version detail + remediation are notes.
+        let msg = format!("{report}");
+        assert!(
+            msg.contains("run properties") && msg.contains("not available"),
+            "got: {msg}"
+        );
+        let full = format!("{report:?}");
+        assert!(full.contains("v52"), "got: {full}");
+        assert!(
+            full.contains("re-run") && full.contains("more recent version"),
+            "got: {full}"
+        );
         // v51 is the last version without properties.
         assert!(
             ensure_resource_supported(&rid(51), MIN_PROPERTIES_VERSION, "run properties").is_err()
@@ -1744,11 +1763,14 @@ mod tests {
     fn build_logs_rejected_before_v54() {
         // build logs arrive two versions after properties, so v52/v53 are still rejected.
         assert!(ensure_resource_supported(&rid(52), MIN_BUILD_LOGS_VERSION, "build logs").is_err());
-        let err = ensure_resource_supported(&rid(53), MIN_BUILD_LOGS_VERSION, "build logs")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("before v54"));
-        assert!(err.contains("build logs"));
+        let report =
+            ensure_resource_supported(&rid(53), MIN_BUILD_LOGS_VERSION, "build logs").unwrap_err();
+        let msg = format!("{report}");
+        assert!(
+            msg.contains("build logs") && msg.contains("not available"),
+            "got: {msg}"
+        );
+        assert!(format!("{report:?}").contains("v54"), "got: {report:?}");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -378,8 +378,16 @@ Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
 
 Each table is headed by its group; columns are STATUS, EXAMPLES, NAME (failing
 first). EXAMPLES is the example count, shown as examples/counterexamples when a
-property has counterexamples. Pass a NAME to `runs property`, or use --json for
-automation."#
+property has counterexamples.
+
+Narrow with --name (substring) and/or --group (exact); add --detail to expand
+the matches into their examples and counter-example moments instead of the
+table. Use --json for automation (it always emits the full data).
+
+Examples:
+  snouty runs properties <run_id> --failing
+  snouty runs properties <run_id> --name eventually_validate --detail
+  snouty runs properties <run_id> --group 'Always: Unreachable' --detail"#
     )]
     Properties {
         /// Run ID
@@ -392,22 +400,19 @@ automation."#
         /// Show only failing properties
         #[arg(long)]
         failing: bool,
-    },
 
-    /// Show examples and counter-examples for a single property
-    #[command(
-        long_about = r#"Show a property's examples and counter-examples.
+        /// Only properties whose name contains this substring (case-insensitive)
+        #[arg(long)]
+        name: Option<String>,
 
-For an event property these are moments — a STATUS/HASH/VTIME table; feed a HASH
-and VTIME into `runs logs` to see what happened then. A non-event property lists
-its example values instead."#
-    )]
-    Property {
-        /// Run ID
-        run_id: String,
+        /// Only properties in this group (exact, case-insensitive)
+        #[arg(long)]
+        group: Option<String>,
 
-        /// Property name (exact match preferred; otherwise unique substring match)
-        name: String,
+        /// Expand each matching property into its examples / counter-example
+        /// moments, instead of the summary table
+        #[arg(short = 'd', long)]
+        detail: bool,
     },
 
     /// Stream build logs for a run
@@ -426,7 +431,7 @@ to that moment. Without --begin-vtime, streaming starts at the timeline's
 earliest log entry.
 
 Output: `[vtime] [source] [stream] message`. A moment (HASH/VTIME) comes from
-`runs property` or `runs events`."#)]
+`runs properties --detail` or `runs events`."#)]
     Logs {
         /// Run ID
         run_id: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -294,11 +294,9 @@ pub struct LaunchArgs {
     #[arg(long)]
     pub description: Option<String>,
 
-    /// Test duration
-    // The unit is determined by the webhook configuration on the platform side,
-    // so snouty intentionally stays unit-agnostic. A string lets callers pass
-    // fractional values when the unit is something coarse like minutes; the
-    // numeric format is enforced by the params schema.
+    /// Test duration, in minutes
+    // A string (not a number) lets callers pass fractional minutes; the numeric
+    // format is enforced by the params schema.
     #[arg(long)]
     pub duration: Option<String>,
 
@@ -375,12 +373,14 @@ Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
     },
 
     /// List property results for a run
-    #[command(long_about = r#"List a run's property (assertion) results, one table per group.
+    #[command(
+        long_about = r#"List a run's property (assertion) results, one table per group.
 
 Each table is headed by its group; columns are STATUS, EXAMPLES, NAME (failing
 first). EXAMPLES is the example count, shown as examples/counterexamples when a
 property has counterexamples. Pass a NAME to `runs property`, or use --json for
-automation."#)]
+automation."#
+    )]
     Properties {
         /// Run ID
         run_id: String,
@@ -396,10 +396,11 @@ automation."#)]
 
     /// Show examples and counter-examples for a single property
     #[command(
-        long_about = r#"Show one property's example and counter-example moments.
+        long_about = r#"Show a property's examples and counter-examples.
 
-Columns: STATUS, HASH, VTIME (a non-event property shows VALUE instead). Feed a
-HASH and VTIME into `runs logs` to see what happened at that moment."#
+For an event property these are moments — a STATUS/HASH/VTIME table; feed a HASH
+and VTIME into `runs logs` to see what happened then. A non-event property lists
+its example values instead."#
     )]
     Property {
         /// Run ID

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,12 @@ Using Moment.from (copy from triage report):
     Debug(DebugArgs),
 
     /// Output shell completions
+    #[command(long_about = r#"Output shell completions
+
+Writes a completion script for SHELL to stdout; install it by sourcing it from
+your shell config, e.g.:
+  snouty completions zsh > ~/.zfunc/_snouty
+  snouty completions bash | sudo tee /etc/bash_completion.d/snouty"#)]
     Completions {
         /// Shell to generate completions for
         shell: clap_complete::Shell,
@@ -159,9 +165,23 @@ Example:
     Version,
 
     /// Check for and install updates
+    #[command(long_about = r#"Check for and install updates
+
+Runs the bundled `snouty-update` helper, which checks for a newer release and
+replaces the snouty binary in place. Does nothing if `snouty-update` is not
+installed alongside snouty."#)]
     Update,
 
     /// Search Antithesis documentation
+    #[command(long_about = r#"Search Antithesis documentation
+
+Full-text search over a local copy of the Antithesis docs, auto-updated before
+each use unless --offline. Subcommands: search, tree, show, sqlite.
+
+Examples:
+  snouty docs search fault injection
+  snouty docs tree sdk
+  snouty docs show getting_started"#)]
     Docs {
         /// Don't check for documentation updates
         #[arg(long)]
@@ -355,11 +375,12 @@ Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
     },
 
     /// List property results for a run
-    #[command(long_about = r#"List a run's property (assertion) results.
+    #[command(long_about = r#"List a run's property (assertion) results, one table per group.
 
-Columns: STATUS, EXAMPLES, NAME (failing first). EXAMPLES is the example count,
-shown as examples/counterexamples when a property has counterexamples. Pass a
-NAME to `runs property` to see its example moments."#)]
+Each table is headed by its group; columns are STATUS, EXAMPLES, NAME (failing
+first). EXAMPLES is the example count, shown as examples/counterexamples when a
+property has counterexamples. Pass a NAME to `runs property`, or use --json for
+automation."#)]
     Properties {
         /// Run ID
         run_id: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,11 +20,13 @@ fn parse_run_status(value: &str) -> Result<RunStatus, String> {
 #[command(version)]
 pub struct Cli {
     /// Output JSON where supported (NDJSON for list/stream commands, pretty JSON otherwise)
-    #[arg(long, global = true)]
+    // High display_order so the two global flags sort to the bottom of every
+    // command's option list instead of wedging between that command's own flags.
+    #[arg(long, global = true, display_order = 1000)]
     pub json: bool,
 
     /// Log API requests to stderr (authentication tokens redacted)
-    #[arg(long, global = true)]
+    #[arg(long, global = true, display_order = 1001)]
     pub verbose: bool,
 
     #[command(subcommand)]
@@ -126,7 +128,6 @@ Compose configs:
   discovers test commands from /opt/antithesis/test/v1 inside the
   running containers and validates their structure.
 
-
   Test commands are discovered by scanning /opt/antithesis/test/v1 from each
   running container for {test_name}/{command} entries. Test commands are
   validated to have recognized prefixes and at least one driver or anytime
@@ -178,6 +179,9 @@ pub enum DocsCommands {
 
 Uses full-text search across the Antithesis documentation database.
 The database is automatically updated before each search unless --offline is passed to the docs command.
+
+Prints ranked matches (title and page path); pass a path to `snouty docs show`.
+Use --list to print only the paths.
 
 Examples:
   snouty docs search fault injection
@@ -252,18 +256,9 @@ pub struct LaunchArgs {
     #[arg(short, long)]
     pub webhook: String,
 
-    /// Path to a local config directory containing either docker-compose.yaml
-    /// or a manifests/ subdirectory (Kubernetes manifests). Builds and pushes
-    /// a config image automatically, setting antithesis.config_image. For
-    /// docker-compose configs, every service image must be present in the
-    /// local image store (snouty never pulls); each one is pinned to its
-    /// local digest — served from a registry that already has it, or pushed —
-    /// and the compose file is rewritten with the digest-pinned images before
-    /// being baked into the config image, so the platform runs exactly what
-    /// was on this machine. For Kubernetes configs, images are pulled by the
-    /// platform from the references in the manifests. Requires the
-    /// docker-compose binary (Docker Compose v2) and the ANTITHESIS_REPOSITORY
-    /// environment variable.
+    /// Local config dir (docker-compose.yaml or a manifests/ subdir), auto-built
+    /// and pushed as the config image. Compose service images must already exist
+    /// locally — snouty never pulls.
     #[arg(short, long, conflicts_with = "config_image")]
     pub config: Option<std::path::PathBuf>,
 
@@ -291,11 +286,8 @@ pub struct LaunchArgs {
     #[arg(long)]
     pub ephemeral: bool,
 
-    /// An optional identifier to separate property history in reports.
-    ///
-    /// In the resulting report, each property’s history is generated from all
-    /// previous runs with the same antithesis.source parameter. This allows you
-    /// to (for example) easily see the history of tests on a single branch.
+    /// Identifier that groups property history in reports — runs sharing a
+    /// --source share history (e.g. per-branch)
     #[arg(long)]
     pub source: Option<String>,
 
@@ -338,9 +330,21 @@ pub struct DebugArgs {
 #[derive(Subcommand)]
 pub enum RunsCommands {
     /// List all runs
+    #[command(
+        long_about = r#"List recent runs (the default when `snouty runs` runs with no subcommand).
+
+Columns: RUN ID, STATUS, CREATED, TEST NAME. Use --detail or --json for the
+full description and launcher."#
+    )]
     List(RunsListArgs),
 
     /// Show details of a specific run
+    #[command(
+        long_about = r#"Show a run's metadata: id, status, timestamps, launcher, and description.
+
+Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
+`runs logs`. Use --web to open the triage report in a browser."#
+    )]
     Show {
         /// Run ID
         run_id: String,
@@ -351,6 +355,11 @@ pub enum RunsCommands {
     },
 
     /// List property results for a run
+    #[command(long_about = r#"List a run's property (assertion) results.
+
+Columns: STATUS, EXAMPLES, NAME (failing first). EXAMPLES is the example count,
+shown as examples/counterexamples when a property has counterexamples. Pass a
+NAME to `runs property` to see its example moments."#)]
     Properties {
         /// Run ID
         run_id: String,
@@ -365,6 +374,12 @@ pub enum RunsCommands {
     },
 
     /// Show examples and counter-examples for a single property
+    #[command(
+        long_about = r#"Show one property's example and counter-example moments.
+
+Columns: STATUS, HASH, VTIME (a non-event property shows VALUE instead). Feed a
+HASH and VTIME into `runs logs` to see what happened at that moment."#
+    )]
     Property {
         /// Run ID
         run_id: String,
@@ -374,41 +389,55 @@ pub enum RunsCommands {
     },
 
     /// Stream build logs for a run
+    #[command(long_about = "Stream a run's build and setup logs.\n\n\
+        Output: `timestamp [stream] line`.")]
     BuildLogs {
         /// Run ID
         run_id: String,
     },
 
     /// Stream moment logs for a run
+    #[command(long_about = r#"Stream a timeline's logs up to a moment.
+
+INPUT_HASH and VTIME identify the moment and its timeline; logs are streamed up
+to that moment. Without --begin-vtime, streaming starts at the timeline's
+earliest log entry.
+
+Output: `[vtime] [source] [stream] message`. A moment (HASH/VTIME) comes from
+`runs property` or `runs events`."#)]
     Logs {
         /// Run ID
         run_id: String,
 
-        /// The input hash value identifying the moment
+        /// Input hash of the moment to stream up to (with VTIME, picks the timeline)
         #[arg(allow_hyphen_values = true)]
         input_hash: String,
 
-        /// The virtual time value identifying the moment
+        /// Virtual time of the moment to stream up to
         #[arg(allow_hyphen_values = true)]
         vtime: String,
 
-        /// Start streaming from this virtual time (defaults to the root)
+        /// Start from this virtual time instead of the timeline's earliest log entry
         #[arg(long, allow_hyphen_values = true)]
         begin_vtime: Option<String>,
 
-        /// Start streaming from this input hash (optimization; must be paired with --begin-vtime)
+        /// Start from this input hash (optimization; must be paired with --begin-vtime)
         #[arg(long, allow_hyphen_values = true, requires = "begin_vtime")]
         begin_input_hash: Option<String>,
 
-        /// Emit log lines without any post-processing: with `--json`, skips
-        /// fault annotation (raw NDJSON passthrough); otherwise renders the
-        /// text payload verbatim (ANSI colors and control bytes preserved
-        /// instead of stripped/escaped)
+        /// Skip post-processing: with --json, pass NDJSON through unannotated;
+        /// otherwise print the text payload verbatim (keep ANSI/control bytes)
         #[arg(short = 'r', long)]
         raw: bool,
     },
 
     /// Search events in a run
+    #[command(
+        long_about = r#"Search a run's events for one or more substrings (all must match).
+
+Columns: HASH, VTIME, SOURCE ([container:stream]), OUTPUT. Feed a row's HASH
+and VTIME into `runs logs` to see the surrounding logs."#
+    )]
     Events {
         /// Run ID
         run_id: String,
@@ -417,8 +446,8 @@ pub enum RunsCommands {
         #[arg(short = 'm', long = "match")]
         matches: Vec<String>,
 
-        /// Additional substrings to search for (same effect as `-m`, which is
-        /// the primary form). At least one needle is required.
+        /// Substrings to match, as a positional alias for `-m` (all must match).
+        /// At least one needle (via `-m` or here) is required.
         query: Vec<String>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,7 @@ Examples:
   snouty runs show <run_id>
   snouty runs properties <run_id>
   snouty runs properties --failing <run_id>
-  snouty runs properties --passing <run_id>
+  snouty runs properties <run_id> --name <substring> --detail
   snouty runs build-logs <run_id>
   snouty runs logs <run_id> <hash> <vtime>
   snouty runs events <run_id> -m <query>"#,
@@ -380,14 +380,15 @@ Each table is headed by its group; columns are STATUS, EXAMPLES, NAME (failing
 first). EXAMPLES is the example count, shown as examples/counterexamples when a
 property has counterexamples.
 
-Narrow with --name (substring) and/or --group (exact); add --detail to expand
-the matches into their examples and counter-example moments instead of the
-table. Use --json for automation (it always emits the full data).
+Narrow with --name and/or --group (both case-insensitive substring matches);
+add --detail to expand the matches into their examples and counter-example
+moments instead of the table. Use --json for automation (it always emits the
+full data).
 
 Examples:
   snouty runs properties <run_id> --failing
   snouty runs properties <run_id> --name eventually_validate --detail
-  snouty runs properties <run_id> --group 'Always: Unreachable' --detail"#
+  snouty runs properties <run_id> --group Unreachable --detail"#
     )]
     Properties {
         /// Run ID
@@ -405,7 +406,7 @@ Examples:
         #[arg(long)]
         name: Option<String>,
 
-        /// Only properties in this group (exact, case-insensitive)
+        /// Only properties whose group contains this substring (case-insensitive)
         #[arg(long)]
         group: Option<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use color_eyre::eyre::{Context, Result, bail};
+use color_eyre::Section;
+use color_eyre::eyre::{Context, Result};
+
+use crate::error::user_error;
 
 /// A docker-compose config directory.
 ///
@@ -66,14 +69,18 @@ impl Config {
 /// - `docker-compose.yml` (lowercase `.yml`) → rename hint.
 pub fn detect_config(config_dir: &Path) -> Result<Config> {
     if !config_dir.is_dir() {
-        bail!("'{}' is not a directory", config_dir.display());
+        return Err(user_error(format!(
+            "'{}' is not a directory",
+            config_dir.display()
+        )));
     }
 
     if config_dir.join("docker-compose.yml").is_file() {
-        bail!(
-            "directory '{}' contains docker-compose.yml, but Antithesis requires docker-compose.yaml (rename the file)",
+        return Err(user_error(format!(
+            "directory '{}' contains docker-compose.yml, not the required docker-compose.yaml",
             config_dir.display()
-        );
+        ))
+        .suggestion("rename it to docker-compose.yaml"));
     }
 
     let has_compose = config_dir.join("docker-compose.yaml").is_file();
@@ -81,10 +88,11 @@ pub fn detect_config(config_dir: &Path) -> Result<Config> {
     let has_manifests_dir = manifests_dir.is_dir();
 
     if has_compose && has_manifests_dir {
-        bail!(
-            "directory '{}' contains both docker-compose.yaml and a manifests/ subdirectory; pick one",
+        return Err(user_error(format!(
+            "directory '{}' contains both docker-compose.yaml and a manifests/ subdirectory",
             config_dir.display()
-        );
+        ))
+        .suggestion("provide one or the other, not both"));
     }
 
     if has_compose {
@@ -100,20 +108,20 @@ pub fn detect_config(config_dir: &Path) -> Result<Config> {
             .next()
             .is_some();
         if !is_non_empty {
-            bail!(
+            return Err(user_error(format!(
                 "directory '{}' contains an empty manifests/ subdirectory",
                 config_dir.display()
-            );
+            )));
         }
         return Ok(Config::Kubernetes(KubernetesConfig {
             dir: config_dir.to_path_buf(),
         }));
     }
 
-    bail!(
+    Err(user_error(format!(
         "directory '{}' does not contain a docker-compose.yaml file or a manifests/ subdirectory",
         config_dir.display()
-    );
+    )))
 }
 
 #[cfg(test)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::Write as _;
 use std::path::PathBuf;
 
+use color_eyre::Section;
 use color_eyre::eyre::{OptionExt, Result, bail};
 use ptree::print_config::UTF_CHARS_BOLD;
 use ptree::{PrintConfig, write_tree_with};
@@ -12,6 +13,7 @@ use tempfile::NamedTempFile;
 mod snippet;
 
 use crate::cli::DocsCommands;
+use crate::error::user_error;
 
 const DEFAULT_DOCS_URL: &str = "https://antithesis.com/docs";
 const SEARCH_STOPWORDS: &[&str] = &[
@@ -63,7 +65,7 @@ pub async fn cmd_docs(command: DocsCommands, offline: bool, json: bool) -> Resul
     match command {
         DocsCommands::Search { query, list, limit } => {
             if query.is_empty() {
-                bail!("search query required");
+                return Err(user_error("search query required"));
             }
             search(&query.join(" "), json, list, limit)
         }
@@ -92,17 +94,22 @@ fn ensure_docs_db_available(offline: bool) -> Result<()> {
     }
 
     if env_db_path_is_set() {
-        bail!(
-            "Documentation database not found at {}. Point ANTITHESIS_DOCS_DB_PATH at an existing file.",
+        return Err(user_error(format!(
+            "Documentation database not found at {}",
             db.display()
-        );
+        ))
+        .suggestion("point ANTITHESIS_DOCS_DB_PATH at an existing file"));
     }
 
     if offline {
-        bail!("Documentation database not found. Remove --offline to download it.");
+        return Err(user_error("Documentation database not found")
+            .suggestion("remove --offline to download it"));
     }
 
-    bail!("Documentation database not found at {}.", db.display());
+    Err(user_error(format!(
+        "Documentation database not found at {}",
+        db.display()
+    )))
 }
 
 async fn download_and_cache_db() -> Result<()> {
@@ -490,7 +497,9 @@ fn show(path: &str) -> Result<()> {
         .query_map([&path], |row| row.get(0))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
-    let mut msg = format!("page not found: {}", db_path);
+    // The message states the error; the live-docs pointer and the close-match
+    // candidates are guidance, so they ride along as notes.
+    let mut report = user_error(format!("page not found: {db_path}"));
     let sdk_lang = path
         .strip_prefix("generated/sdk/")
         .and_then(|rest| rest.split('/').next())
@@ -499,32 +508,30 @@ fn show(path: &str) -> Result<()> {
         // Recognized generated SDK language: point at its live HTML index to
         // crawl directly. An unrecognized language falls through to the normal
         // not-found suggestions below.
-        msg.push_str(&format!(
-            "\n\nThe {lang} SDK reference docs are not part of the offline docs. \
-             They are published as HTML and can be crawled directly over the network, \
-             starting from:\n  {}/{}",
+        report = report.note(format!(
+            "the {lang} SDK reference docs are not part of the offline docs; they are \
+             published as HTML and can be crawled directly over the network, starting from {}/{}",
             docs_url(),
             rel,
         ));
     } else if path == "generated" || path.starts_with("generated/") {
         // Other generated pages, including SDK languages we don't recognize
         // (our alias table may simply be out of date): point at the live docs.
-        msg.push_str(
-            "\n\nNote: generated pages (e.g. SDK references) are not included in the offline docs.",
-        );
-        msg.push_str(&format!(
-            "\nIf this is a valid page, try: {}/{}/",
-            docs_url(),
-            path
-        ));
+        report = report
+            .note("generated pages (e.g. SDK references) are not included in the offline docs")
+            .note(format!(
+                "if this is a valid page, try {}/{}/",
+                docs_url(),
+                path
+            ));
     }
     if !suggestions.is_empty() {
-        msg.push_str("\n\nDid you mean one of these?");
-        for s in &suggestions {
-            msg.push_str(&format!("\n  {}", s));
-        }
+        report = report.suggestion(format!(
+            "did you mean one of these?\n  {}",
+            suggestions.join("\n  ")
+        ));
     }
-    bail!("{}", msg)
+    Err(report)
 }
 
 fn sqlite_path() -> Result<()> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,8 +1,9 @@
 use std::env;
 
-use color_eyre::eyre::{Result, bail};
+use color_eyre::eyre::Result;
 
 use crate::container;
+use crate::error::user_error;
 
 struct Check {
     name: &'static str,
@@ -81,7 +82,7 @@ pub fn cmd_doctor() -> Result<()> {
 
     eprintln!();
     if checks.iter().any(|c| !c.passed) {
-        bail!("doctor found problems");
+        return Err(user_error("doctor found problems"));
     }
     eprintln!("All checks passed");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,18 @@
-//! User-facing error tagging.
+//! User-facing errors.
 //!
 //! Most failures snouty hits are the user's to fix: a bad flag, a missing
 //! environment variable, a 4xx from the API. Those should print as a clean
-//! message, not a color_eyre report with a "Backtrace omitted" footer. Wrapping
-//! such errors in [`UserError`] lets `main` tell them apart from genuine
-//! internal faults (which still get the full report).
+//! message, not a color_eyre report with a backtrace footer. We mark such
+//! errors with [`Report::suppress_backtrace`] at the point they're built, so
+//! `main` can render every error the same way and the report itself carries
+//! whether it's worth a backtrace — no out-of-band classification needed.
 
+use color_eyre::Section;
 use color_eyre::eyre::Report;
 
 /// Marker error wrapping a user-facing message.
 ///
-/// Construct reports with [`user_error`] and detect them with [`is_user_error`].
+/// Construct reports with [`user_error`].
 #[derive(Debug)]
 pub struct UserError(pub String);
 
@@ -22,25 +24,12 @@ impl std::fmt::Display for UserError {
 
 impl std::error::Error for UserError {}
 
-/// Build an `eyre` report that `main` will print as a clean user-facing message.
+/// Build an `eyre` report that prints as a clean user-facing message — no
+/// backtrace, even under `RUST_BACKTRACE`. Attach `.note(...)`/`.suggestion(...)`
+/// (the [`color_eyre::Section`] API) for follow-up hints; they render below the
+/// message automatically.
 pub fn user_error(message: impl Into<String>) -> Report {
-    Report::new(UserError(message.into()))
-}
-
-/// Returns `true` when any link in the report's chain is a [`UserError`].
-///
-/// Works through `wrap_err` context so callers can add context to a user error
-/// without losing the tag.
-pub fn is_user_error(report: &Report) -> bool {
-    report.chain().any(|cause| {
-        cause.is::<UserError>()
-            // A 4xx API failure is the user's to fix (bad credentials, unknown
-            // run id, invalid filter, …), so it prints as a clean message just
-            // like an explicit `UserError`. 5xx and other statuses stay internal.
-            || cause
-                .downcast_ref::<ApiError>()
-                .is_some_and(|e| (400..500).contains(&e.status))
-    })
+    Report::new(UserError(message.into())).suppress_backtrace(true)
 }
 
 /// Error carrying the HTTP status of a failed API call structurally, so callers
@@ -62,8 +51,8 @@ impl std::fmt::Display for ApiError {
 impl std::error::Error for ApiError {}
 
 /// Returns the HTTP status of the first [`ApiError`] in the report's chain, if
-/// any. Works through `wrap_err` context like [`is_user_error`], so callers can
-/// add context without losing the structured status.
+/// any. Works through `wrap_err` context, so callers can add context without
+/// losing the structured status.
 pub fn api_error_status(report: &Report) -> Option<u16> {
     report
         .chain()
@@ -75,25 +64,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tagged_report_is_detected() {
-        let report = user_error("missing environment variable: ANTITHESIS_TENANT");
-        assert!(is_user_error(&report));
-    }
-
-    #[test]
-    fn tag_survives_added_context() {
+    fn user_error_message_survives_added_context() {
         let report = user_error("API error: 400").wrap_err("while listing runs");
-        assert!(is_user_error(&report));
         // Alternate Display renders the full chain without a backtrace footer.
         let rendered = format!("{report:#}");
         assert!(rendered.contains("while listing runs"));
         assert!(rendered.contains("API error: 400"));
-    }
-
-    #[test]
-    fn plain_report_is_not_user_error() {
-        let report = color_eyre::eyre::eyre!("internal explosion");
-        assert!(!is_user_error(&report));
     }
 
     fn api_error(status: u16, message: &str) -> Report {
@@ -127,13 +103,5 @@ mod tests {
     fn api_error_status_is_none_for_plain_report() {
         let report = color_eyre::eyre::eyre!("internal explosion");
         assert_eq!(api_error_status(&report), None);
-    }
-
-    #[test]
-    fn api_4xx_is_user_facing_but_5xx_is_not() {
-        assert!(is_user_error(&api_error(404, "not found")));
-        assert!(is_user_error(&api_error(400, "bad request")));
-        // A 5xx is an internal fault even when its body mentions a 404.
-        assert!(!is_user_error(&api_error(500, "upstream 404 page")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,18 @@
-use std::io::{self, ErrorKind, Read};
+use std::io::{self, ErrorKind, IsTerminal, Read};
 use std::process::Command;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use log::{debug, info};
 
-use color_eyre::eyre::{Context, Result, bail};
+use color_eyre::Section;
+use color_eyre::eyre::{Context, Result};
 use snouty::api::AntithesisApi;
 use snouty::cli::{Cli, Commands, DebugArgs, LaunchArgs};
 use snouty::config;
 use snouty::container;
 use snouty::docs;
+use snouty::error::user_error;
 use snouty::moment;
 use snouty::params::Params;
 use snouty::validate;
@@ -43,7 +45,23 @@ fn get_stdin_params(use_stdin: bool, support_moment: bool) -> Result<Option<Para
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    color_eyre::install().unwrap();
+    // Drop the "Backtrace omitted. Run with RUST_BACKTRACE=1…" footer: it's noise
+    // on every error, and outright misleading on user errors built with
+    // `suppress_backtrace` (where RUST_BACKTRACE does nothing). A genuine fault
+    // still prints its backtrace when RUST_BACKTRACE is set.
+    //
+    // Color the report only on a real terminal — piped/redirected stderr (and the
+    // test/gallery captures) gets plain text, not ANSI escapes.
+    let theme = if std::io::stderr().is_terminal() {
+        color_eyre::config::Theme::dark()
+    } else {
+        color_eyre::config::Theme::new()
+    };
+    color_eyre::config::HookBuilder::default()
+        .theme(theme)
+        .display_env_section(false)
+        .install()
+        .unwrap();
     env_logger::Builder::from_default_env()
         .format(|buf, record| {
             use std::io::Write;
@@ -53,14 +71,11 @@ async fn main() {
     let cli = Cli::parse();
 
     if let Err(report) = run(cli).await {
-        if snouty::error::is_user_error(&report) {
-            // User-facing problem (bad flag, missing env var, 4xx). Print the
-            // message chain only — no backtrace footer or internal noise.
-            eprintln!("error: {report:#}");
-        } else {
-            // Genuine internal fault: keep the full color_eyre report.
-            eprintln!("Error: {report:?}");
-        }
+        // One rendering for every error: color_eyre's report format. User-facing
+        // failures are built with `user_error`/4xx `suppress_backtrace`, so they
+        // print message + any `.note()`/`.suggestion()` hints with no backtrace;
+        // genuine internal faults keep theirs.
+        eprintln!("Error: {report:?}");
         std::process::exit(1);
     }
 }
@@ -167,7 +182,7 @@ async fn cmd_launch(args: LaunchArgs, json: bool, verbose: bool) -> Result<()> {
         let config = config::detect_config(&config_dir)?;
 
         let registry = std::env::var("ANTITHESIS_REPOSITORY")
-            .wrap_err("missing environment variable: ANTITHESIS_REPOSITORY")?;
+            .map_err(|_| user_error("missing environment variable: ANTITHESIS_REPOSITORY"))?;
 
         let image_ref = container::generate_image_ref(&registry);
         params.insert("antithesis.config_image", &image_ref);
@@ -182,10 +197,10 @@ async fn cmd_launch(args: LaunchArgs, json: bool, verbose: bool) -> Result<()> {
         // Check for conflicts with typed flags already set in params
         for key in extra.as_map().keys() {
             if params.contains_key(key) {
-                bail!(
-                    "invalid arguments: '{}' cannot be overridden via --param (use the dedicated flag instead)",
-                    key
-                );
+                return Err(user_error(format!(
+                    "invalid arguments: '{key}' cannot be overridden via --param"
+                ))
+                .suggestion("use the dedicated flag instead"));
             }
         }
 
@@ -193,11 +208,13 @@ async fn cmd_launch(args: LaunchArgs, json: bool, verbose: bool) -> Result<()> {
     }
 
     if params.contains_key("antithesis.images") {
-        bail!("invalid argument: antithesis.images cannot be set via --param");
+        return Err(user_error(
+            "invalid argument: antithesis.images cannot be set via --param",
+        ));
     }
 
     if params.is_empty() {
-        bail!("invalid arguments: no parameters provided");
+        return Err(user_error("invalid arguments: no parameters provided"));
     }
 
     if !has_source {
@@ -285,7 +302,7 @@ fn debug_params(args: DebugArgs) -> Result<Params> {
     params.merge(debug_typed_params(&args));
 
     if params.is_empty() {
-        bail!("invalid arguments: no parameters provided");
+        return Err(user_error("invalid arguments: no parameters provided"));
     }
 
     Ok(params)

--- a/src/moment.rs
+++ b/src/moment.rs
@@ -3,8 +3,10 @@
 use log::debug;
 use serde_json::{Map, Value};
 
+use crate::error::user_error;
 use crate::params::Params;
-use color_eyre::eyre::{Context, OptionExt, Result, bail};
+use color_eyre::Section;
+use color_eyre::eyre::Result;
 
 /// Parse a Moment.from format string into Params.
 ///
@@ -16,18 +18,21 @@ pub fn parse(input: &str) -> Result<Params> {
     let input = input.trim();
 
     if !input.starts_with("Moment.from(") || !input.ends_with(")") {
-        bail!("invalid arguments: expected Moment.from({{ ... }}) format");
+        return Err(user_error(
+            "invalid arguments: expected Moment.from({ ... }) format",
+        ));
     }
 
     let inner = &input[12..input.len() - 1];
     debug!("parsing Moment.from inner: {}", inner);
 
-    let value: Value =
-        json5::from_str(inner).wrap_err("invalid arguments: invalid Moment.from format")?;
+    let value: Value = json5::from_str(inner).map_err(|e| {
+        user_error("invalid arguments: invalid Moment.from format").note(e.to_string())
+    })?;
 
     let obj = value
         .as_object()
-        .ok_or_eyre("invalid arguments: Moment.from must contain an object")?;
+        .ok_or_else(|| user_error("invalid arguments: Moment.from must contain an object"))?;
 
     // Convert keys to antithesis.debugging.* format
     let mut map = Map::new();

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,7 +2,10 @@ use jsonschema::Validator;
 use log::debug;
 use serde_json::{Map, Value};
 
-use color_eyre::eyre::{OptionExt, Result, bail, eyre};
+use color_eyre::Section;
+use color_eyre::eyre::Result;
+
+use crate::error::user_error;
 
 const SCHEMA: &str = include_str!("params_schema.json");
 
@@ -42,11 +45,15 @@ impl Params {
         let mut inner = Map::new();
         for pair in pairs {
             let pair = pair.as_ref();
-            let (key, value) = pair
-                .split_once('=')
-                .ok_or_else(|| eyre!("invalid parameter: expected key=value, got: {}", pair))?;
+            let (key, value) = pair.split_once('=').ok_or_else(|| {
+                user_error(format!(
+                    "invalid parameter: expected key=value, got: {pair}"
+                ))
+            })?;
             if key.is_empty() {
-                bail!("invalid parameter: empty key in: {}", pair);
+                return Err(user_error(format!(
+                    "invalid parameter: empty key in: {pair}"
+                )));
             }
             inner.insert(key.to_string(), Value::String(value.to_string()));
         }
@@ -61,7 +68,7 @@ impl Params {
     pub fn from_json(value: &Value) -> Result<Self> {
         let obj = value
             .as_object()
-            .ok_or_eyre("invalid arguments: expected JSON object")?;
+            .ok_or_else(|| user_error("invalid arguments: expected JSON object"))?;
 
         let inner = if obj.len() == 1
             && let Some(Value::Object(nested)) = obj.get("params")
@@ -153,16 +160,18 @@ where
 
         if let Some(key) = arg.strip_prefix("--") {
             if key.is_empty() {
-                bail!("invalid arguments: empty key after --");
+                return Err(user_error("invalid arguments: empty key after --"));
             }
 
-            let value = iter
-                .next()
-                .ok_or_else(|| eyre!("invalid arguments: missing value for --{}", key))?;
+            let value = iter.next().ok_or_else(|| {
+                user_error(format!("invalid arguments: missing value for --{key}"))
+            })?;
 
             map.insert(key.to_string(), Value::String(value.as_ref().to_string()));
         } else {
-            bail!("invalid arguments: unexpected argument: {}", arg);
+            return Err(user_error(format!(
+                "invalid arguments: unexpected argument: {arg}"
+            )));
         }
     }
 
@@ -188,10 +197,13 @@ fn validate_against_def(params: &Map<String, Value>, def_name: &str) -> Result<(
 
     if !errors.is_empty() {
         debug!("validation failed with {} errors", errors.len());
+        // The message states the failure; each schema violation is its own note.
+        let mut report = user_error("validation failed");
         for err in &errors {
             debug!("  - {}", err);
+            report = report.note(err.clone());
         }
-        bail!("validation failed:\n  {}", errors.join("\n  "));
+        return Err(report);
     }
 
     debug!("validation passed");

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -77,6 +77,17 @@ impl std::str::FromStr for Stream {
 }
 
 pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) -> Result<()> {
+    // `--detail` produces human formatting, so it can't combine with `--json`.
+    // It rides on more than one subcommand (`runs list`, `runs properties`), so
+    // the conflict is checked once here — a global `--json` vs a per-subcommand
+    // flag can't be expressed with clap's `conflicts_with`.
+    let detail = match &command {
+        Some(RunsCommands::List(args)) => args.detail,
+        Some(RunsCommands::Properties { detail, .. }) => *detail,
+        _ => false,
+    };
+    reject_detail_with_json(json, detail)?;
+
     match command {
         None => cmd_runs_list(RunsListArgs::default(), json, verbose).await,
         Some(RunsCommands::List(args)) => cmd_runs_list(args, json, verbose).await,
@@ -141,7 +152,6 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
 }
 
 async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<()> {
-    reject_detail_with_json(json, args.detail)?;
     debug!("listing runs");
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
@@ -353,8 +363,8 @@ struct PropertyFilter<'a> {
 
 /// `--detail` formats human output, so it conflicts with `--json` (which always
 /// emits the full structured data). Reject the combination with a clear error
-/// rather than silently ignoring one. Shared by `runs properties` and
-/// `runs list`, which both carry `--detail`.
+/// rather than silently ignoring one. Called once from [`cmd_runs`] for whichever
+/// subcommand carries `--detail` (`runs list`, `runs properties`).
 fn reject_detail_with_json(json: bool, detail: bool) -> Result<()> {
     if json && detail {
         return Err(user_error("--detail and --json cannot be combined")
@@ -370,7 +380,6 @@ async fn cmd_runs_properties(
     json: bool,
     verbose: bool,
 ) -> Result<()> {
-    reject_detail_with_json(json, detail)?;
     debug!("listing properties for run: {}", run_id);
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
@@ -680,23 +689,27 @@ fn render_properties_detail(properties: &[Property]) -> String {
         .join("\n\n")
 }
 
-/// One property's detail within a group section: a key/value header (no Group
-/// line — the section heading carries it) and, indented beneath it, its examples.
-/// A property whose only example is a single number renders that inline instead.
+/// One property's detail within a group section: a `Name`/`Status`/`Details`
+/// header (no `Group` line — the section heading carries it) followed by its
+/// examples. Every field goes through [`render_field`], so a short value sits
+/// inline against the value column while a long or multi-line one drops to an
+/// indented block beneath its label.
 fn render_property_detail(property: &Property) -> String {
     let mut out = String::new();
-    out.push_str(&format!("Name      {}\n", sanitize(property.name())));
-    out.push_str(&format!(
-        "Status    {}\n",
-        property_status_label(property.status())
+    out.push_str(&render_field("Name", &sanitize(property.name())));
+    out.push('\n');
+    out.push_str(&render_field(
+        "Status",
+        property_status_label(property.status()),
     ));
+    out.push('\n');
     let description = match property {
         Property::EventProperty(p) => p.description.as_deref(),
         Property::NonEventProperty(p) => p.description.as_deref(),
     };
     if let Some(desc) = description {
-        // Details is free-form prose, wrapped under a 10-char label column so
-        // continuation lines hang-indent to match the value column above.
+        // Details is free-form prose, wrapped under the value column so
+        // continuation lines hang-indent to match the values above.
         out.push_str(&render_prose_block(
             "Details",
             desc,
@@ -708,14 +721,13 @@ fn render_property_detail(property: &Property) -> String {
     }
     match property {
         // Event properties have moments — the user feeds a HASH/VTIME into
-        // `runs logs`, so they get an `Examples:` table.
+        // `runs logs` — so the `Examples` field holds a STATUS/HASH/VTIME table
+        // (or, when there are none, the inline "unreachable" note).
         Property::EventProperty(p) => {
-            out.push_str("Examples:\n");
-            out.push_str(&indent_lines(&render_moments_table(p), "  "));
+            out.push_str(&render_field("Examples", &render_moments_table(p)));
         }
-        // Non-event "system" properties have no moments; their examples chunk
-        // just carries detail values, so show them under a `Result` label rather
-        // than conflating with examples/counter-examples.
+        // Non-event "system" properties have no moments; their values show under
+        // a `Result` (or, when failing, labelled Counter-examples/Examples).
         Property::NonEventProperty(p) => out.push_str(&render_result(p)),
     }
     out
@@ -750,44 +762,107 @@ fn render_moments_table(p: &EventProperty) -> String {
     render_table(&headers, &rows)
 }
 
-/// The `Result` for a non-event property — its example values. A lone value is
-/// rendered directly (scalar inline, object/array as indented JSON); multiple
-/// values are rendered as a single indented JSON array.
+/// The values of a non-event ("system") property under a `Result` label. A
+/// passing property has only example values, shown directly. A failing property
+/// also has counterexamples — the values that violated it — so those are
+/// labelled and shown first (mirroring the event table's failing-first order)
+/// instead of being merged into one unlabelled list where the offending value
+/// can't be told from the rest.
 fn render_result(p: &NonEventProperty) -> String {
-    let values: Vec<&Value> = p.examples.iter().chain(p.counterexamples.iter()).collect();
-    match values.as_slice() {
-        [] => "Result    (none)".to_string(),
-        [one] => render_single_result(one),
-        // Multiple values are collapsed into a single JSON array.
-        many => render_json_result(&Value::Array(many.iter().map(|v| (*v).clone()).collect())),
+    if p.counterexamples.is_empty() {
+        return render_result_values(&p.examples);
+    }
+    let mut out = render_value_group("Counter-examples", &p.counterexamples);
+    if !p.examples.is_empty() {
+        out.push('\n');
+        out.push_str(&render_value_group("Examples", &p.examples));
+    }
+    out
+}
+
+/// The example values of a passing non-event property under a single `Result`
+/// field: a lone scalar (or small object) inline, several values (or a large one)
+/// as a block, none as a placeholder.
+fn render_result_values(values: &[Value]) -> String {
+    match values {
+        [] => render_field("Result", "(none)"),
+        [one] => render_result_value("Result", one),
+        // Several values render as one JSON array; serialize the slice of
+        // references directly rather than cloning into an owned `Value::Array`.
+        many => render_json_field("Result", &many),
     }
 }
 
-/// A single `Result` value: a scalar inline next to an aligned `Result` label, an
-/// object/array via [`render_json_result`].
-fn render_single_result(value: &Value) -> String {
+/// A labelled group of non-event values for the failing case — the `label` on its
+/// own line with each value indented beneath. Always a block (never inline) so the
+/// violating counterexamples and the satisfying examples read consistently.
+/// Scalars print verbatim; objects/arrays as compact one-line JSON.
+fn render_value_group(label: &str, values: &[Value]) -> String {
+    let body = values
+        .iter()
+        .map(value_token)
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{label}\n{}", indent_lines(&body, "  "))
+}
+
+/// A single non-event value under `label`: a scalar (or small object/array)
+/// inline, a large object/array as a pretty-printed block.
+fn render_result_value(label: &str, value: &Value) -> String {
     match value {
-        Value::Array(_) | Value::Object(_) => render_json_result(value),
-        Value::String(s) => format!("Result    {}", sanitize(s)),
-        Value::Number(n) => format!("Result    {n}"),
-        Value::Bool(b) => format!("Result    {b}"),
-        Value::Null => "Result    null".to_string(),
+        Value::Array(_) | Value::Object(_) => render_json_field(label, value),
+        scalar => render_field(label, &value_token(scalar)),
     }
 }
 
-/// Render a JSON object/array `Result`: inline (`Result: {...}`) when its compact
-/// one-line form fits the terminal (capped at 100 cols, so piped output where the
-/// width is unbounded still inlines only genuinely small values), otherwise as an
-/// indented pretty-printed block under `Result:`.
-fn render_json_result(value: &Value) -> String {
-    let compact = serde_json::to_string(value).unwrap_or_default();
-    let inline = format!("Result: {compact}");
-    if inline.chars().count() <= terminal_width().min(100) {
-        inline
-    } else {
-        let pretty = serde_json::to_string_pretty(value).unwrap_or_default();
-        format!("Result:\n{}", indent_lines(&pretty, "  "))
+/// A non-event value as a single inline token: a string sanitised, other scalars
+/// via their `Display`, an object/array as compact one-line JSON.
+fn value_token(value: &Value) -> String {
+    match value {
+        Value::String(s) => sanitize(s),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
     }
+}
+
+/// Render a JSON object/array (or a slice of values) under `label`: inline when
+/// its compact one-line form fits the value column, otherwise pretty-printed as an
+/// indented block. The inline-vs-block layout is delegated to [`render_field`].
+fn render_json_field<T: serde::Serialize>(label: &str, value: &T) -> String {
+    let compact = serde_json::to_string(value).unwrap_or_default();
+    if fits_inline(label, &compact) {
+        render_field(label, &compact)
+    } else {
+        render_field(
+            label,
+            &serde_json::to_string_pretty(value).unwrap_or_default(),
+        )
+    }
+}
+
+/// Render a `label` + `value` field in a property detail block. A single-line
+/// value that fits sits inline, aligned to the [`PROPERTY_LABEL_WIDTH`] value
+/// column (like `Name`/`Status`); a taller or wider value goes on the lines below
+/// the label, indented. No trailing `:` — the column does the separating, matching
+/// every other field.
+fn render_field(label: &str, value: &str) -> String {
+    if fits_inline(label, value) {
+        format!("{label:<width$}{value}", width = PROPERTY_LABEL_WIDTH)
+    } else {
+        format!("{label}\n{}", indent_lines(value, "  "))
+    }
+}
+
+/// Whether `value` can sit inline after `label` in the value column: it must be a
+/// single line, the label must leave at least one space before the column, and the
+/// whole line must fit (capped at 100 cols so piped output — where the width is
+/// unbounded — still inlines only genuinely short values).
+fn fits_inline(label: &str, value: &str) -> bool {
+    !value.contains('\n')
+        && label.chars().count() < PROPERTY_LABEL_WIDTH
+        && PROPERTY_LABEL_WIDTH + value.chars().count() <= terminal_width().min(100)
 }
 
 /// Width of the label column in `render_property_detail` (`"Details   "`).
@@ -942,6 +1017,9 @@ fn render_properties_table(properties: &[Property]) -> String {
 }
 
 fn print_run_detail(run: &RunDetail) -> Result<()> {
+    // Bound once and reused for both the Failure Hash/VTime rows and the deferred
+    // "view logs" hint below, so the two can't drift apart.
+    let failure = run.failure_moment.as_ref();
     let mut rows: Vec<(&str, String)> = Vec::new();
 
     // Lead with the identifier; the human labels follow.
@@ -962,7 +1040,7 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
 
     rows.push(("Launcher", run.launcher.clone()));
 
-    if let Some(ref moment) = run.failure_moment {
+    if let Some(moment) = failure {
         // Hash before VTime to match the `runs logs <hash> <vtime>` argument
         // order, so the values read top-to-bottom in the order you paste them.
         rows.push(("Failure Hash", moment.input_hash.clone()));
@@ -991,7 +1069,7 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
     // Hand the user the exact command to read logs at the failure moment, the
     // same way the `--web` hint below hands over the report link. Both can fire
     // when an incomplete run still has a report — they're complementary.
-    if let Some(ref moment) = run.failure_moment {
+    if let Some(moment) = failure {
         outln!(
             "\nview logs at the failure moment:\n  snouty runs logs {} {} {}",
             run.run_id,
@@ -1343,8 +1421,15 @@ async fn cmd_runs_logs(
     result
 }
 
-const LOG_SOURCE_MIN_WIDTH: usize = 20;
-const LOG_VTIME_WIDTH: usize = 14;
+/// The source column is sized to fit `antithesis_test_composer` — the built-in
+/// test-composer source present in nearly every run's logs — so those lines align
+/// instead of overflowing. Longer sources still overflow on their own lines
+/// rather than widening the column for everyone.
+const LOG_SOURCE_MIN_WIDTH: usize = "antithesis_test_composer".len();
+/// vtime is shown truncated to 3 decimals. Sized for runs up to ~9999 vsec
+/// (`"9999.999"`, 8 chars), which covers the vast majority; longer runs overflow
+/// this width on their lines rather than padding every shorter line to match.
+const LOG_VTIME_WIDTH: usize = 8;
 const LOG_STREAM_WIDTH: usize = 3;
 
 fn format_log_entry(entry: &Value, raw: bool) -> String {
@@ -2338,26 +2423,46 @@ fn render_columns(
 /// Earliest case-insensitive occurrence of any needle in `text`, as the
 /// `(char_start, char_len)` of the match. Used to keep a search hit visible when
 /// a cell is windowed.
+///
+/// The scan runs in the original text's char space — comparing char-by-char
+/// case-insensitively — so the returned index is always a valid offset into the
+/// same `chars()` vec the caller windows. (Searching a `to_lowercase()` copy and
+/// reusing its offsets would drift for the few characters whose lowercase form
+/// has a different char count, e.g. `İ` → `i` + a combining dot.)
 fn first_needle_span(text: &str, needles: &[String]) -> Option<(usize, usize)> {
-    let lower = text.to_lowercase();
+    let chars: Vec<char> = text.chars().collect();
     needles
         .iter()
-        .filter(|n| !n.is_empty())
         .filter_map(|n| {
-            let needle = n.to_lowercase();
-            lower.find(&needle).map(|byte| {
-                let start = lower[..byte].chars().count();
-                (start, needle.chars().count())
-            })
+            let needle: Vec<char> = n.chars().collect();
+            if needle.is_empty() || needle.len() > chars.len() {
+                return None;
+            }
+            (0..=chars.len() - needle.len())
+                .find(|&i| {
+                    chars[i..i + needle.len()]
+                        .iter()
+                        .zip(&needle)
+                        .all(|(a, b)| chars_eq_ignore_case(*a, *b))
+                })
+                .map(|start| (start, needle.len()))
         })
         .min_by_key(|(start, _)| *start)
 }
 
-/// Truncate `text` to at most `width` display columns, keeping the region around
-/// the first matching needle in view. A too-long cell is windowed and centered on
-/// the match, with `…` marking each truncated edge; when no needle lands in this
-/// cell (it matched another column) the head is kept instead. Returns `text`
-/// unchanged when it already fits.
+/// Case-insensitive comparison of two characters, comparing their full lowercase
+/// mappings (so it works beyond ASCII).
+fn chars_eq_ignore_case(a: char, b: char) -> bool {
+    a == b || a.to_lowercase().eq(b.to_lowercase())
+}
+
+/// Truncate `text` to at most `width` characters, keeping the region around the
+/// first matching needle in view. A too-long cell is windowed and centered on the
+/// match, with `…` marking each truncated edge; when no needle lands in this cell
+/// (it matched another column) the head is kept instead. Returns `text` unchanged
+/// when it already fits. (Width is counted in characters, not display columns, so
+/// a cell of double-width glyphs can render wider — acceptable for the ASCII log
+/// output this serves.)
 fn truncate_around(text: &str, needles: &[String], width: usize) -> String {
     const ELL: char = '…';
     let chars: Vec<char> = text.chars().collect();
@@ -3086,12 +3191,13 @@ mod tests {
             vec![],
         );
         let out = render_property_detail(&property);
-        // A non-event property's value shows under a `Result:` label as pretty
-        // JSON — never the moment-oriented `Examples:`/`passing:` machinery.
-        assert!(out.contains("Result:"), "got: {out}");
+        // A non-event property's value shows under a `Result` label (no `:`) —
+        // never the moment-oriented `Examples` table.
+        assert!(out.contains("Result"), "got: {out}");
         assert!(out.contains("maximum_used_bytes"));
-        assert!(!out.contains("Examples:"));
-        assert!(!out.contains("passing:"));
+        assert!(!out.contains("Examples"));
+        // The label carries no colon, matching Name/Status/Details.
+        assert!(!out.contains("Result:"), "got: {out}");
     }
 
     #[test]
@@ -3120,11 +3226,11 @@ mod tests {
         assert!(!out.contains("Group     Safety"));
         assert!(!out.contains('─'));
         // Each property keeps its header and an Examples section whose table is
-        // indented beneath the (column-0) "Examples:" label.
+        // indented beneath the (column-0) "Examples" label (no `:`).
         assert!(out.contains("Name      First"));
-        assert_eq!(out.matches("Examples:").count(), 2);
+        assert_eq!(out.matches("Examples\n").count(), 2);
         assert!(
-            out.contains("Examples:\n  STATUS"),
+            out.contains("Examples\n  STATUS"),
             "examples table should be indented\n{out}"
         );
     }
@@ -3140,22 +3246,23 @@ mod tests {
             let p = non_event_property("Metric", PropertyStatus::Passing, vec![value], vec![]);
             let out = render_property_detail(&p);
             assert!(out.contains(expected), "got: {out}");
-            assert!(!out.contains("Examples:"));
+            assert!(!out.contains("Examples"));
         }
 
-        // Tiny objects/arrays are inlined after `Result:` (compact one-line JSON).
+        // Tiny objects/arrays inline against the `Result` column (compact JSON,
+        // no `:` — same value column as a scalar).
         let empty = non_event_property("E", PropertyStatus::Passing, vec![json!([])], vec![]);
         assert!(
-            render_property_detail(&empty).contains("Result: []"),
+            render_property_detail(&empty).contains("Result    []"),
             "empty array"
         );
         let tiny = non_event_property("T", PropertyStatus::Passing, vec![json!({"k": 1})], vec![]);
         assert!(
-            render_property_detail(&tiny).contains(r#"Result: {"k":1}"#),
+            render_property_detail(&tiny).contains(r#"Result    {"k":1}"#),
             "tiny object"
         );
 
-        // A large object spills to an indented pretty-printed block.
+        // A large object spills to an indented pretty-printed block under `Result`.
         let big = non_event_property(
             "Big",
             PropertyStatus::Passing,
@@ -3168,11 +3275,11 @@ mod tests {
         );
         let out = render_property_detail(&big);
         assert!(
-            out.contains("Result:\n  {"),
+            out.contains("Result\n  {"),
             "big object should be a block\n{out}"
         );
         assert!(out.contains("total_output_mb"));
-        assert!(!out.contains("Examples:"));
+        assert!(!out.contains("Examples"));
 
         // Several small values collapse into one inline JSON array.
         let multi = non_event_property(
@@ -3182,7 +3289,7 @@ mod tests {
             vec![],
         );
         assert!(
-            render_property_detail(&multi).contains("Result: [1,2]"),
+            render_property_detail(&multi).contains("Result    [1,2]"),
             "multi inline"
         );
     }
@@ -3197,7 +3304,7 @@ mod tests {
         });
         assert_eq!(
             format_log_entry(&entry, false),
-            "[         9.093] [      fault_injector] [   ]  - {\"info\":{\"details\":{\"started\":true},\"message\":\"status\"}}"
+            "[   9.093] [          fault_injector] [   ]  - {\"info\":{\"details\":{\"started\":true},\"message\":\"status\"}}"
         );
     }
 
@@ -3210,7 +3317,7 @@ mod tests {
         });
         assert_eq!(
             format_log_entry(&entry, false),
-            "[        15.174] [ bank/first_setup.sh] [inf] NbmXgEki  INFO main lsm_tree::tree::ingest: Finished ingestion writer"
+            "[  15.174] [     bank/first_setup.sh] [inf] NbmXgEki  INFO main lsm_tree::tree::ingest: Finished ingestion writer"
         );
     }
 
@@ -3251,7 +3358,7 @@ mod tests {
         let rendered = format_log_entry(&entry, false);
         // Fixed 3 decimals (so the column stays aligned), truncated not rounded:
         // 18.9148… -> 18.914 (rounding would give 18.915).
-        assert!(rendered.starts_with("[        18.914] "), "got: {rendered}");
+        assert!(rendered.starts_with("[  18.914] "), "got: {rendered}");
     }
 
     #[test]
@@ -3264,7 +3371,7 @@ mod tests {
             "output_text": "hello"
         });
         assert!(
-            format_log_entry(&entry, false).starts_with("[        12.500] "),
+            format_log_entry(&entry, false).starts_with("[  12.500] "),
             "got: {}",
             format_log_entry(&entry, false)
         );
@@ -3297,7 +3404,23 @@ mod tests {
         });
         assert_eq!(
             format_log_entry(&entry, false),
-            "[        14.284] [antithesis/pods/client/sdk.jsonl] [   ]  - {\"antithesis_setup\":{\"details\":null,\"status\":\"complete\"}}"
+            "[  14.284] [antithesis/pods/client/sdk.jsonl] [   ]  - {\"antithesis_setup\":{\"details\":null,\"status\":\"complete\"}}"
+        );
+    }
+
+    #[test]
+    fn format_log_line_fits_test_composer_source_exactly() {
+        // The source column is sized to `antithesis_test_composer`, a built-in
+        // source in nearly every run, so it fills the column exactly — no leading
+        // pad before it and no overflow past it.
+        let entry = json!({
+            "moment": {"vtime": "401.500"},
+            "source": {"name": "antithesis_test_composer"},
+            "output_text": "started"
+        });
+        assert_eq!(
+            format_log_entry(&entry, false),
+            "[ 401.500] [antithesis_test_composer] [   ] started"
         );
     }
 
@@ -3370,7 +3493,51 @@ mod tests {
         let empty = non_event_property("Empty", PropertyStatus::Passing, vec![], vec![]);
         let out = render_property_detail(&empty);
         assert!(out.contains("Result    (none)"), "got: {out}");
-        assert!(!out.contains("Examples:"));
+        assert!(!out.contains("Examples"));
+    }
+
+    #[test]
+    fn render_result_labels_failing_non_event_counterexamples() {
+        // A failing non-event property carries the violating value(s) in
+        // `counterexamples`. They must be labelled and shown first, so the
+        // offending value isn't lost among the satisfying `examples`.
+        let p = non_event_property(
+            "Peak memory below limit",
+            PropertyStatus::Failing,
+            vec![json!(720), json!(880)], // satisfying
+            vec![json!(1340)],            // violating
+        );
+        let out = render_property_detail(&p);
+        // Both groups are labelled (no `:`), with counterexamples first.
+        let cex = out
+            .find("Counter-examples\n")
+            .expect("counter-examples label");
+        let ex = out.find("\nExamples\n").expect("examples label");
+        assert!(cex < ex, "counterexamples should come first\n{out}");
+        // The violating value sits under the Counter-examples heading, the
+        // satisfying ones under Examples — not merged into one unlabelled list.
+        assert!(out.contains("Counter-examples\n  1340"), "got: {out}");
+        assert!(out.contains("Examples\n  720\n  880"), "got: {out}");
+        // No anonymous `Result` blob in the failing case.
+        assert!(!out.contains("Result"), "got: {out}");
+    }
+
+    #[test]
+    fn render_result_failing_non_event_without_examples_only_shows_counterexamples() {
+        let p = non_event_property(
+            "Invariant held",
+            PropertyStatus::Failing,
+            vec![],
+            vec![json!("n2-standard-4")],
+        );
+        let out = render_property_detail(&p);
+        assert!(
+            out.contains("Counter-examples\n  n2-standard-4"),
+            "got: {out}"
+        );
+        // No standalone Examples group (there are no satisfying examples). Guard
+        // against the "Examples" inside "Counter-examples" by anchoring on `\n`.
+        assert!(!out.contains("\nExamples"), "got: {out}");
     }
 
     #[test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -857,59 +857,94 @@ fn indent_lines(text: &str, prefix: &str) -> String {
         .join("\n")
 }
 
+fn is_failing(p: &Property) -> bool {
+    matches!(p.status(), PropertyStatus::Failing)
+}
+
+/// The EXAMPLES cell for a property: the example count, SI-shortened so big
+/// counts stay narrow (`18496678` -> `18M`), with counterexamples appended
+/// inline (`examples/counterexamples`) only when a property actually has some —
+/// so the common all-zero-counterexample rows aren't cluttered with `/0`.
+fn property_examples_cell(p: &Property) -> String {
+    let (examples, counters) = property_example_counts(p);
+    if counters == 0 {
+        format_count_si(examples)
+    } else {
+        format!("{}/{}", format_count_si(examples), format_count_si(counters))
+    }
+}
+
 fn render_properties_table(properties: &[Property]) -> String {
-    // STATUS and EXAMPLES are narrow and fixed; NAME is the long, variable
-    // column and goes last so it can wrap to the terminal instead of one long
-    // name forcing the whole table wider than the screen. Full names are kept —
-    // `runs property` takes a name, so truncating would break the follow-up.
+    // One table per group — far more scannable than a single flat table, and it
+    // mirrors the report UI. The group is the section heading, so the NAME column
+    // shows just the property's own name (the exact string `runs property`
+    // resolves); folding the group into NAME would have made the displayed name
+    // un-copyable. Properties with no group go in a final "(ungrouped)" section.
+    // This is human-facing output; use `--json` for automation.
     let headers = vec![
         "STATUS".to_string(),
         "EXAMPLES".to_string(),
         "NAME".to_string(),
     ];
-
-    // Failing properties first so triage doesn't require scanning the whole
-    // (otherwise alphabetical) list; relative order is otherwise preserved.
-    let mut ordered: Vec<&Property> = properties.iter().collect();
-    ordered.sort_by_key(|p| match p.status() {
-        PropertyStatus::Failing => 0,
-        _ => 1,
-    });
-
-    let rows = ordered
-        .iter()
-        .map(|p| {
-            // Fold the group into the name (`group ▸ detail`) instead of padding
-            // a mostly-empty GROUP column out to its widest label.
-            let name = match property_group(p) {
-                Some(group) => format!("{} ▸ {}", sanitize(group), sanitize(p.name())),
-                None => sanitize(p.name()),
-            };
-            // Show the example count, SI-shortened so big counts stay narrow
-            // (`18496678` -> `18M`). Surface counterexamples inline only when a
-            // property actually has some (`examples/counterexamples`), so the
-            // common all-zero-counterexample rows aren't cluttered with `/0`.
-            let (examples, counters) = property_example_counts(p);
-            let examples_cell = if counters == 0 {
-                format_count_si(examples)
-            } else {
-                format!(
-                    "{}/{}",
-                    format_count_si(examples),
-                    format_count_si(counters)
-                )
-            };
-            vec![
-                property_status_label(p.status()).to_string(),
-                examples_cell,
-                name,
-            ]
-        })
-        .collect::<Vec<_>>();
     // Right-align the numeric EXAMPLES column so magnitudes line up; STATUS and
     // the wrapped NAME column stay left-aligned.
     let aligns = [Align::Left, Align::Right, Align::Left];
-    render_table_wrap_last(&headers, &rows, terminal_width(), &aligns)
+    let width = terminal_width();
+
+    // Bucket into named groups (alphabetical via BTreeMap) and an ungrouped pile.
+    // An empty-string group is treated as no group.
+    let mut grouped: std::collections::BTreeMap<&str, Vec<&Property>> = Default::default();
+    let mut ungrouped: Vec<&Property> = Vec::new();
+    for p in properties {
+        match property_group(p).filter(|g| !g.is_empty()) {
+            Some(g) => grouped.entry(g).or_default().push(p),
+            None => ungrouped.push(p),
+        }
+    }
+
+    // Named groups containing a failing property sort first (so triage surfaces
+    // broken assertion groups), then the rest; alphabetical within each tier.
+    let mut named: Vec<(&str, Vec<&Property>)> = grouped.into_iter().collect();
+    named.sort_by(|(a, aps), (b, bps)| {
+        bps.iter()
+            .any(|p| is_failing(p))
+            .cmp(&aps.iter().any(|p| is_failing(p)))
+            .then_with(|| a.cmp(b))
+    });
+
+    let render_section = |title: &str, props: &[&Property]| -> String {
+        // Failing rows first within a section, then alphabetical by name.
+        let mut ps: Vec<&Property> = props.to_vec();
+        ps.sort_by(|a, b| {
+            is_failing(b)
+                .cmp(&is_failing(a))
+                .then_with(|| a.name().cmp(b.name()))
+        });
+        let rows: Vec<Vec<String>> = ps
+            .iter()
+            .map(|p| {
+                vec![
+                    property_status_label(p.status()).to_string(),
+                    property_examples_cell(p),
+                    sanitize(p.name()),
+                ]
+            })
+            .collect();
+        format!(
+            "{}\n{}",
+            sanitize(title),
+            render_table_wrap_last(&headers, &rows, width, &aligns)
+        )
+    };
+
+    let mut sections: Vec<String> = named
+        .iter()
+        .map(|(name, props)| render_section(name, props))
+        .collect();
+    if !ungrouped.is_empty() {
+        sections.push(render_section("(ungrouped)", &ungrouped));
+    }
+    sections.join("\n\n")
 }
 
 fn print_run_detail(run: &RunDetail) -> Result<()> {
@@ -934,8 +969,10 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
     rows.push(("Launcher", run.launcher.clone()));
 
     if let Some(ref moment) = run.failure_moment {
-        rows.push(("Failure VTime", moment.vtime.clone()));
+        // Hash before VTime to match the `runs logs <hash> <vtime>` argument
+        // order, so the values read top-to-bottom in the order you paste them.
         rows.push(("Failure Hash", moment.input_hash.clone()));
+        rows.push(("Failure VTime", moment.vtime.clone()));
     }
 
     if let Some(ref creator) = run.creator
@@ -955,6 +992,18 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
         if !block.is_empty() {
             out!("\n{block}")?;
         }
+    }
+
+    // Hand the user the exact command to read logs at the failure moment, the
+    // same way the `--web` hint below hands over the report link. Both can fire
+    // when an incomplete run still has a report — they're complementary.
+    if let Some(ref moment) = run.failure_moment {
+        outln!(
+            "\nview logs at the failure moment:\n  snouty runs logs {} {} {}",
+            run.run_id,
+            moment.input_hash,
+            moment.vtime
+        )?;
     }
 
     // Point at the obvious next step instead of dumping the huge signed report
@@ -2798,7 +2847,7 @@ mod tests {
     }
 
     #[test]
-    fn properties_table_groups_status_word_and_totals() {
+    fn properties_table_renders_one_table_per_group() {
         let properties = vec![
             event_property(
                 "Counter value stays below limit",
@@ -2818,27 +2867,27 @@ mod tests {
 
         let table = render_properties_table(&properties);
         let lines: Vec<&str> = table.lines().collect();
-        assert!(lines[0].contains("STATUS"));
-        assert!(lines[0].contains("NAME"));
-        assert!(lines[0].contains("EXAMPLES"));
-        // The GROUP column is gone — the group is folded into NAME instead.
-        assert!(!lines[0].contains("GROUP"));
 
-        // Failing properties sort to the top, ahead of passing ones.
-        assert!(lines[1].contains("Counter value"));
+        // One table per group: the failing "Safety" group leads with its name as
+        // a heading, followed by a STATUS/EXAMPLES/NAME table.
+        assert_eq!(lines[0], "Safety");
+        assert!(table.contains("\nSTATUS"), "expected a column header\n{table}");
+        assert!(table.contains("EXAMPLES"));
+        assert!(table.contains("NAME"));
+        assert!(!table.contains("GROUP"));
+        // The group is the heading, not folded into NAME — so the displayed name
+        // is exactly what `runs property` resolves.
+        assert!(!table.contains('▸'), "group should not be folded into NAME\n{table}");
 
-        // Two property rows. Counter property has 1 example + 2 counterexamples,
-        // rendered inline as `examples/counterexamples` (`1/2`). Its group is
-        // folded into the name as `group ▸ detail`.
+        // Counter property: 1 example + 2 counterexamples -> `1/2`, name only.
         let counter_row = lines.iter().find(|l| l.contains("Counter value")).unwrap();
         assert!(counter_row.contains("failing"));
-        assert!(counter_row.contains("Safety ▸ Counter value stays below limit"));
         assert!(counter_row.contains("1/2"));
+        assert!(counter_row.trim_end().ends_with("Counter value stays below limit"));
 
-        let setup_row = lines
-            .iter()
-            .find(|l| l.contains("Setup completes"))
-            .unwrap();
+        // Ungrouped properties land in a trailing "(ungrouped)" section.
+        assert!(table.contains("(ungrouped)"), "expected an ungrouped section\n{table}");
+        let setup_row = lines.iter().find(|l| l.contains("Setup completes")).unwrap();
         assert!(setup_row.contains("passing"));
         assert!(setup_row.contains("1"));
     }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1254,15 +1254,25 @@ async fn cmd_runs_events(
         return Ok(());
     }
 
-    // Auto-width HASH/VTIME/SOURCE columns with OUTPUT emitted verbatim as the
-    // final column — the shared renderer's `Raw` last-column policy.
+    // Auto-width HASH/VTIME/SOURCE columns; OUTPUT is the final column, windowed
+    // around the matched needle so the hit stays visible on a narrow terminal. On
+    // a non-tty `terminal_width()` is `usize::MAX`, so piped output isn't truncated.
     let headers = [
         "HASH".to_string(),
         "VTIME".to_string(),
         "SOURCE".to_string(),
         "OUTPUT".to_string(),
     ];
-    writeln!(stdout, "{}", render_table(&headers, &rows))?;
+    let table = render_columns(
+        &headers,
+        &rows,
+        LastColumn::TruncateAround {
+            total_width: terminal_width(),
+            needles: matches.to_vec(),
+        },
+        &left_aligned(headers.len()),
+    );
+    writeln!(stdout, "{table}")?;
     stdout.flush()?;
 
     // Now that buffered rows are rendered, surface any mid-stream error.
@@ -1972,12 +1982,14 @@ fn render_event_entry(entry: &Value) -> RenderedEventEntry {
     let name = entry["source"]["name"].as_str().unwrap_or("");
     let stream = entry["source"]["stream"].as_str().unwrap_or("");
 
+    // Trim the OUTPUT cell: container log lines often carry leading indentation
+    // (e.g. `    GORACE: …`) that would ragged-align the column against neighbours.
     if let Some(summary) = parse_assertion_summary(entry) {
         return RenderedEventEntry {
             input_hash,
             vtime,
             source: render_source(container, name, Some("assert")),
-            output: render_assertion_summary(&summary),
+            output: render_assertion_summary(&summary).trim().to_string(),
         };
     }
 
@@ -1985,7 +1997,7 @@ fn render_event_entry(entry: &Value) -> RenderedEventEntry {
         input_hash,
         vtime,
         source: render_source(container, name, (!stream.is_empty()).then_some(stream)),
-        output: render_event_output(entry),
+        output: render_event_output(entry).trim().to_string(),
     }
 }
 
@@ -2186,6 +2198,14 @@ enum LastColumn {
     /// multiple lines with a hanging indent under the column start (floored at a
     /// readable minimum width).
     Wrap { total_width: usize },
+    /// Bound the final column like [`Truncate`], but window a too-long cell
+    /// *around* the first matching needle (centering on the match) rather than
+    /// always keeping the head — so the user sees the substring they searched for.
+    /// `needles` are the raw search terms, matched case-insensitively.
+    TruncateAround {
+        total_width: usize,
+        needles: Vec<String>,
+    },
 }
 
 /// Per-column horizontal alignment for the leading (fixed-width) columns. The
@@ -2289,7 +2309,93 @@ fn render_columns(
             }
             output.trim_end().to_string()
         }
+        LastColumn::TruncateAround {
+            total_width,
+            needles,
+        } => {
+            let last_width = total_width
+                .saturating_sub(prefix_width)
+                .max(headers[last].chars().count());
+            widths[last] = last_width;
+
+            let mut output = String::new();
+            push_table_row(&mut output, headers, &widths, aligns);
+            for row in rows {
+                let mut row = row.clone();
+                row[last] = truncate_around(&row[last], needles, last_width);
+                push_table_row(&mut output, &row, &widths, aligns);
+            }
+            output.trim_end().to_string()
+        }
     }
+}
+
+/// Earliest case-insensitive occurrence of any needle in `text`, as the
+/// `(char_start, char_len)` of the match. Used to keep a search hit visible when
+/// a cell is windowed.
+fn first_needle_span(text: &str, needles: &[String]) -> Option<(usize, usize)> {
+    let lower = text.to_lowercase();
+    needles
+        .iter()
+        .filter(|n| !n.is_empty())
+        .filter_map(|n| {
+            let needle = n.to_lowercase();
+            lower.find(&needle).map(|byte| {
+                let start = lower[..byte].chars().count();
+                (start, needle.chars().count())
+            })
+        })
+        .min_by_key(|(start, _)| *start)
+}
+
+/// Truncate `text` to at most `width` display columns, keeping the region around
+/// the first matching needle in view. A too-long cell is windowed and centered on
+/// the match, with `…` marking each truncated edge; when no needle lands in this
+/// cell (it matched another column) the head is kept instead. Returns `text`
+/// unchanged when it already fits.
+fn truncate_around(text: &str, needles: &[String], width: usize) -> String {
+    const ELL: char = '…';
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    if len <= width {
+        return text.to_string();
+    }
+    // Too narrow to fit an ellipsis beside content: just clip the head.
+    if width <= 1 {
+        return chars[..width].iter().collect();
+    }
+    let Some((m, mlen)) = first_needle_span(text, needles) else {
+        // No hit in this cell — keep the head, like a plain truncation.
+        let head: String = chars[..width - 1].iter().collect();
+        return format!("{head}{ELL}");
+    };
+
+    // Center an inner window on the match midpoint, reserving a column for an
+    // ellipsis on each (initially assumed) truncated edge.
+    let inner = width - 2;
+    let center = (m + mlen / 2).min(len - 1);
+    let mut start = center.saturating_sub(inner / 2);
+    if start + inner > len {
+        start = len - inner;
+    }
+    let mut end = start + inner;
+    // Reclaim the reserved ellipsis column on any edge that isn't truncated after
+    // all (the window reached the start or end of the text).
+    if start == 0 && end < len {
+        end = (end + 1).min(len);
+    } else if end == len && start > 0 {
+        start -= 1;
+    }
+
+    let mut out = String::new();
+    if start > 0 {
+        out.push(ELL);
+    }
+    out.extend(chars[start..end].iter());
+    if end < len {
+        out.push(ELL);
+    }
+    out
 }
 
 fn render_runs_table(runs: &[RunSummary], width: usize) -> String {
@@ -4557,6 +4663,82 @@ mod tests {
                 "line exceeds width {width}: {line}"
             );
         }
+    }
+
+    #[test]
+    fn truncate_around_returns_short_text_unchanged() {
+        let n = vec!["err".to_string()];
+        assert_eq!(
+            truncate_around("short error here", &n, 80),
+            "short error here"
+        );
+        // Exactly at the width bound: still unchanged, no ellipsis.
+        assert_eq!(truncate_around("abcdef", &n, 6), "abcdef");
+    }
+
+    #[test]
+    fn truncate_around_centers_on_a_mid_string_match() {
+        let needles = vec!["NEEDLE".to_string()];
+        let text = "xxxxxxxxxxxxxxxxxxxxxxxxx NEEDLE yyyyyyyyyyyyyyyyyyyyyyyyy";
+        let out = truncate_around(text, &needles, 20);
+        // Windowed on both sides and the match stays visible.
+        assert!(out.starts_with('…'), "want leading ellipsis: {out:?}");
+        assert!(out.ends_with('…'), "want trailing ellipsis: {out:?}");
+        assert!(out.contains("NEEDLE"), "match must remain visible: {out:?}");
+        assert_eq!(out.chars().count(), 20);
+    }
+
+    #[test]
+    fn truncate_around_keeps_head_when_match_is_near_the_start() {
+        let needles = vec!["abc".to_string()];
+        let text = "abc def ghi jkl mno pqr stu vwx yz0 123 456 789";
+        let out = truncate_around(text, &needles, 20);
+        // No leading ellipsis (window reached the start); trailing edge truncated.
+        assert!(
+            !out.starts_with('…'),
+            "no leading ellipsis expected: {out:?}"
+        );
+        assert!(out.starts_with("abc"), "head retained: {out:?}");
+        assert!(out.ends_with('…'), "trailing ellipsis expected: {out:?}");
+        assert_eq!(out.chars().count(), 20);
+    }
+
+    #[test]
+    fn truncate_around_keeps_tail_when_match_is_near_the_end() {
+        let needles = vec!["xyz".to_string()];
+        let text = "000 111 222 333 444 555 666 777 888 999 last xyz";
+        let out = truncate_around(text, &needles, 20);
+        assert!(out.starts_with('…'), "leading ellipsis expected: {out:?}");
+        assert!(
+            !out.ends_with('…'),
+            "no trailing ellipsis expected: {out:?}"
+        );
+        assert!(out.ends_with("xyz"), "tail retained: {out:?}");
+        assert_eq!(out.chars().count(), 20);
+    }
+
+    #[test]
+    fn truncate_around_head_truncates_when_no_needle_in_cell() {
+        // The needle matched another column, so this cell has no hit — keep the
+        // head, like a plain ellipsis truncation.
+        let needles = vec!["error".to_string()];
+        let text = "[raft] failed to get previous log: previous-index=1 last-index=0";
+        let out = truncate_around(text, &needles, 24);
+        assert!(out.starts_with("[raft]"), "head retained: {out:?}");
+        assert!(out.ends_with('…'), "trailing ellipsis expected: {out:?}");
+        assert_eq!(out.chars().count(), 24);
+    }
+
+    #[test]
+    fn truncate_around_is_case_insensitive() {
+        let needles = vec!["ERROR".to_string()];
+        let text = "aaaaaaaaaaaaaaaaaaaaaaaaa fatal error occurred bbbbbbbbbbbbbbbbbbbbbbbbb";
+        let out = truncate_around(text, &needles, 24);
+        assert!(
+            out.to_lowercase().contains("error"),
+            "match visible: {out:?}"
+        );
+        assert_eq!(out.chars().count(), 24);
     }
 
     #[test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -556,26 +556,32 @@ async fn cmd_runs_property(run_id: &str, name: &str, json: bool, verbose: bool) 
     };
 
     let resolved = resolve_property(&properties, name, run_id)?;
-    let property = match resolved {
-        Resolved::Exact(p) => p,
-        Resolved::Fuzzy(p) => {
-            // Always disclose the substitution, on stderr in both modes: a
-            // `--json` consumer otherwise silently receives a different property
-            // than it asked for, and stderr keeps it out of the JSON on stdout.
-            eprintln!(
-                "note: no exact match for '{}', using closest property: '{}'",
-                name,
+    let (property, fuzzy_note) = match resolved {
+        Resolved::Exact(p) => (p, None),
+        Resolved::Fuzzy(p) => (
+            p,
+            Some(format!(
+                "note: no exact match for '{name}', using closest property: '{}'",
                 p.name()
-            );
-            p
-        }
+            )),
+        ),
     };
 
     if json {
+        // Disclose the substitution on stderr so a `--json` consumer isn't
+        // silently handed a different property, while stdout stays clean JSON.
+        if let Some(note) = &fuzzy_note {
+            eprintln!("{note}");
+        }
         outln!("{}", serde_json::to_string_pretty(property)?)?;
         return Ok(());
     }
 
+    // Human mode: print the note first, on stdout, so it reads in order *above*
+    // the property it resolved to (rather than stranded after the table).
+    if let Some(note) = &fuzzy_note {
+        outln!("{note}")?;
+    }
     print_property_header(property)?;
     outln!("{}", render_property_examples(property))?;
     Ok(())
@@ -754,11 +760,11 @@ fn sorted_by_vtime(events: &[Event]) -> Vec<&Event> {
 
 fn render_property_examples(property: &Property) -> String {
     match property {
+        // Event properties are moments — a STATUS/HASH/VTIME table (the API
+        // guarantees no ordering, so sort each group numerically by vtime;
+        // counterexamples first, then examples). A moment feeds `runs logs`.
         Property::EventProperty(p) => {
             let mut rows: Vec<Vec<String>> = Vec::new();
-            // The API guarantees no ordering, so sort each group numerically by
-            // vtime (ascending) for a stable, readable timeline. Counterexamples
-            // (failing) come first, then examples (passing).
             for event in sorted_by_vtime(&p.counterexamples) {
                 rows.push(vec![
                     "failing".to_string(),
@@ -774,79 +780,48 @@ fn render_property_examples(property: &Property) -> String {
                 ]);
             }
             if rows.is_empty() {
-                rows.push(vec![
-                    "unreachable".to_string(),
-                    "-".to_string(),
-                    "-".to_string(),
-                ]);
+                return "Examples:\n  (none — property was unreachable)".to_string();
             }
             let headers = vec![
                 "STATUS".to_string(),
                 "HASH".to_string(),
                 "VTIME".to_string(),
             ];
-            render_table(&headers, &rows)
+            format!("Examples:\n{}", render_table(&headers, &rows))
         }
+        // Non-event properties carry arbitrary JSON values, so render each
+        // example/counterexample as its own labelled block — the values *are*
+        // the content, and a `{N fields}` placeholder table only hid them.
         Property::NonEventProperty(p) => {
-            let mut rows: Vec<Vec<String>> = Vec::new();
-            let mut detail_blocks: Vec<(usize, String)> = Vec::new();
-
+            let mut blocks: Vec<String> = Vec::new();
             for value in &p.counterexamples {
-                push_value_row(&mut rows, &mut detail_blocks, "failing", value);
+                blocks.push(render_value_example("failing", value));
             }
             for value in &p.examples {
-                push_value_row(&mut rows, &mut detail_blocks, "passing", value);
+                blocks.push(render_value_example("passing", value));
             }
-            if rows.is_empty() {
-                rows.push(vec!["unreachable".to_string(), "-".to_string()]);
+            if blocks.is_empty() {
+                return "Examples:\n  (none — property was unreachable)".to_string();
             }
-            let headers = vec!["STATUS".to_string(), "VALUE".to_string()];
-            let mut out = render_table(&headers, &rows);
-            for (row_index, block) in detail_blocks {
-                out.push_str(&format!(
-                    "\n\nrow {} details:\n{}",
-                    row_index + 1,
-                    indent_lines(&block, "  ")
-                ));
-            }
-            out
+            format!("Examples:\n\n{}", blocks.join("\n\n"))
         }
     }
 }
 
-fn push_value_row(
-    rows: &mut Vec<Vec<String>>,
-    detail_blocks: &mut Vec<(usize, String)>,
-    status: &str,
-    value: &Value,
-) {
-    let row_index = rows.len();
-    let (cell, detail) = render_property_value(value);
-    rows.push(vec![status.to_string(), cell]);
-    if let Some(detail) = detail {
-        detail_blocks.push((row_index, detail));
-    }
-}
-
-fn render_property_value(value: &Value) -> (String, Option<String>) {
+/// Render one non-event example/counterexample: a `<status>:` label followed by
+/// its value — a scalar inline, an object/array as indented pretty JSON.
+fn render_value_example(status: &str, value: &Value) -> String {
     match value {
-        Value::Null => ("null".to_string(), None),
-        Value::Bool(b) => (b.to_string(), None),
-        Value::Number(n) => (n.to_string(), None),
-        Value::String(s) => (sanitize(s), None),
-        // An empty collection has nothing to expand — render it inline rather
-        // than as a "[0 items]" summary trailed by an empty "row N details" block.
-        Value::Array(items) if items.is_empty() => ("(no example value)".to_string(), None),
-        Value::Object(map) if map.is_empty() => ("(no example value)".to_string(), None),
+        Value::Array(items) if items.is_empty() => format!("{status}: (no value)"),
+        Value::Object(map) if map.is_empty() => format!("{status}: (no value)"),
         Value::Array(_) | Value::Object(_) => {
-            let summary = match value {
-                Value::Array(items) => format!("[{} items]", items.len()),
-                Value::Object(map) => format!("{{{} fields}}", map.len()),
-                _ => unreachable!(),
-            };
             let pretty = serde_json::to_string_pretty(value).unwrap_or_default();
-            (summary, Some(pretty))
+            format!("{status}:\n{}", indent_lines(&pretty, "  "))
         }
+        Value::Null => format!("{status}: null"),
+        Value::Bool(b) => format!("{status}: {b}"),
+        Value::Number(n) => format!("{status}: {n}"),
+        Value::String(s) => format!("{status}: {}", sanitize(s)),
     }
 }
 
@@ -870,7 +845,11 @@ fn property_examples_cell(p: &Property) -> String {
     if counters == 0 {
         format_count_si(examples)
     } else {
-        format!("{}/{}", format_count_si(examples), format_count_si(counters))
+        format!(
+            "{}/{}",
+            format_count_si(examples),
+            format_count_si(counters)
+        )
     }
 }
 
@@ -2871,23 +2850,39 @@ mod tests {
         // One table per group: the failing "Safety" group leads with its name as
         // a heading, followed by a STATUS/EXAMPLES/NAME table.
         assert_eq!(lines[0], "Safety");
-        assert!(table.contains("\nSTATUS"), "expected a column header\n{table}");
+        assert!(
+            table.contains("\nSTATUS"),
+            "expected a column header\n{table}"
+        );
         assert!(table.contains("EXAMPLES"));
         assert!(table.contains("NAME"));
         assert!(!table.contains("GROUP"));
         // The group is the heading, not folded into NAME — so the displayed name
         // is exactly what `runs property` resolves.
-        assert!(!table.contains('▸'), "group should not be folded into NAME\n{table}");
+        assert!(
+            !table.contains('▸'),
+            "group should not be folded into NAME\n{table}"
+        );
 
         // Counter property: 1 example + 2 counterexamples -> `1/2`, name only.
         let counter_row = lines.iter().find(|l| l.contains("Counter value")).unwrap();
         assert!(counter_row.contains("failing"));
         assert!(counter_row.contains("1/2"));
-        assert!(counter_row.trim_end().ends_with("Counter value stays below limit"));
+        assert!(
+            counter_row
+                .trim_end()
+                .ends_with("Counter value stays below limit")
+        );
 
         // Ungrouped properties land in a trailing "(ungrouped)" section.
-        assert!(table.contains("(ungrouped)"), "expected an ungrouped section\n{table}");
-        let setup_row = lines.iter().find(|l| l.contains("Setup completes")).unwrap();
+        assert!(
+            table.contains("(ungrouped)"),
+            "expected an ungrouped section\n{table}"
+        );
+        let setup_row = lines
+            .iter()
+            .find(|l| l.contains("Setup completes"))
+            .unwrap();
         assert!(setup_row.contains("passing"));
         assert!(setup_row.contains("1"));
     }
@@ -3057,11 +3052,13 @@ mod tests {
             vec![],
         );
         let out = render_property_examples(&property);
-        // Summary cell collapses the object…
-        assert!(out.contains("{2 fields}"));
-        // …with the full pretty body shown below.
-        assert!(out.contains("row 1 details:"));
+        // No placeholder table — each example renders as its own labelled block
+        // under an "Examples:" header, with the object shown as pretty JSON.
+        assert!(out.contains("Examples:"), "got: {out}");
+        assert!(out.contains("passing:"));
         assert!(out.contains("maximum_used_bytes"));
+        assert!(!out.contains("{2 fields}"));
+        assert!(!out.contains("row 1 details:"));
     }
 
     #[test]
@@ -3243,19 +3240,16 @@ mod tests {
     }
 
     #[test]
-    fn render_property_value_renders_empty_collection_inline() {
-        // An empty array/object collapses to "(no example value)" with no detail
-        // block, so a fuzzy hit on a property with no examples doesn't print the
-        // confusing "[0 items]" + "row N details: []" pair.
-        assert_eq!(
-            render_property_value(&json!([])),
-            ("(no example value)".to_string(), None)
-        );
-        assert_eq!(
-            render_property_value(&json!({})),
-            ("(no example value)".to_string(), None)
-        );
+    fn render_non_event_example_renders_empty_collection_inline() {
+        // An empty array/object renders as "(no value)" rather than an empty
+        // pretty-printed block.
+        assert_eq!(render_value_example("passing", &json!([])), "passing: (no value)");
+        assert_eq!(render_value_example("passing", &json!({})), "passing: (no value)");
+        // A scalar renders inline; an object renders as an indented JSON block.
+        assert_eq!(render_value_example("failing", &json!(42)), "failing: 42");
+        assert!(render_value_example("passing", &json!({"k": 1})).starts_with("passing:\n  {"));
     }
+
     #[test]
     fn ansi_sgr() {
         assert_eq!(strip_ansi("\x1b[1mbold\x1b[0m"), "bold");

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -86,6 +86,9 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             run_id,
             passing,
             failing,
+            name,
+            group,
+            detail,
         }) => {
             let status = if passing {
                 Some(PropertyStatus::Passing)
@@ -94,10 +97,12 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
             } else {
                 None
             };
-            cmd_runs_properties(&run_id, status, json, verbose).await
-        }
-        Some(RunsCommands::Property { run_id, name }) => {
-            cmd_runs_property(&run_id, &name, json, verbose).await
+            let filter = PropertyFilter {
+                status,
+                name: name.as_deref(),
+                group: group.as_deref(),
+            };
+            cmd_runs_properties(&run_id, filter, detail, json, verbose).await
         }
         Some(RunsCommands::BuildLogs { run_id }) => {
             cmd_runs_build_logs(&run_id, json, verbose).await
@@ -135,6 +140,7 @@ pub async fn cmd_runs(command: Option<RunsCommands>, json: bool, verbose: bool) 
 }
 
 async fn cmd_runs_list(args: RunsListArgs, json: bool, verbose: bool) -> Result<()> {
+    reject_detail_with_json(json, args.detail)?;
     debug!("listing runs");
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
@@ -336,17 +342,41 @@ fn launch_browser(url: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Filters applied to `runs properties`. `status` is served by the API;
+/// `name` (substring) and `group` (exact) are applied client-side. All
+/// case-insensitive.
+struct PropertyFilter<'a> {
+    status: Option<PropertyStatus>,
+    name: Option<&'a str>,
+    group: Option<&'a str>,
+}
+
+/// `--detail` formats human output, so it conflicts with `--json` (which always
+/// emits the full structured data). Reject the combination with a clear error
+/// rather than silently ignoring one. Shared by `runs properties` and
+/// `runs list`, which both carry `--detail`.
+fn reject_detail_with_json(json: bool, detail: bool) -> Result<()> {
+    if json && detail {
+        return Err(user_error(
+            "--detail and --json cannot be combined: --json already emits the full data",
+        ));
+    }
+    Ok(())
+}
+
 async fn cmd_runs_properties(
     run_id: &str,
-    status: Option<PropertyStatus>,
+    filter: PropertyFilter<'_>,
+    detail: bool,
     json: bool,
     verbose: bool,
 ) -> Result<()> {
+    reject_detail_with_json(json, detail)?;
     debug!("listing properties for run: {}", run_id);
 
     let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
     let mut properties = match api
-        .stream_run_properties(run_id, status)
+        .stream_run_properties(run_id, filter.status)
         .try_collect::<Vec<_>>()
         .await
     {
@@ -356,6 +386,17 @@ async fn cmd_runs_properties(
         // Fetch the run to say which, instead of leaking a bare "404 Not Found".
         Err(err) => return Err(explain_properties_error(&api, run_id, err).await),
     };
+
+    // Apply the client-side filters: group is an exact (case-insensitive) match,
+    // name a (case-insensitive) substring.
+    if let Some(group) = filter.group {
+        let needle = group.to_lowercase();
+        properties.retain(|p| property_group(p).is_some_and(|g| g.to_lowercase() == needle));
+    }
+    if let Some(name) = filter.name {
+        let needle = name.to_lowercase();
+        properties.retain(|p| p.name().to_lowercase().contains(&needle));
+    }
 
     properties.sort_by(|a, b| {
         property_group(a)
@@ -369,17 +410,35 @@ async fn cmd_runs_properties(
             outln!("{}", serde_json::to_string(property)?)?;
         }
     } else if properties.is_empty() {
-        let message = match status {
-            Some(PropertyStatus::Passing) => "No passing properties found.",
-            Some(PropertyStatus::Failing) => "No failing properties found.",
-            None => "No properties found.",
-        };
-        outln!("{message}")?;
+        outln!("{}", no_properties_message(&filter))?;
+    } else if detail {
+        outln!("{}", render_properties_detail(&properties))?;
     } else {
         outln!("{}", render_properties_table(&properties))?;
     }
 
     Ok(())
+}
+
+/// The empty-result message, naming whichever filters were active.
+fn no_properties_message(filter: &PropertyFilter) -> String {
+    let mut parts = Vec::new();
+    match filter.status {
+        Some(PropertyStatus::Passing) => parts.push("passing".to_string()),
+        Some(PropertyStatus::Failing) => parts.push("failing".to_string()),
+        None => {}
+    }
+    if let Some(name) = filter.name {
+        parts.push(format!("name containing '{name}'"));
+    }
+    if let Some(group) = filter.group {
+        parts.push(format!("group '{group}'"));
+    }
+    if parts.is_empty() {
+        "No properties found.".to_string()
+    } else {
+        format!("No properties match ({}).", parts.join(", "))
+    }
 }
 
 /// Outcome of probing a run-scoped 404 with `get_run`: does the run itself not
@@ -540,102 +599,6 @@ fn property_status_label(status: PropertyStatus) -> &'static str {
     }
 }
 
-async fn cmd_runs_property(run_id: &str, name: &str, json: bool, verbose: bool) -> Result<()> {
-    debug!("looking up property '{}' for run: {}", name, run_id);
-
-    let api = AntithesisApi::from_env_requiring_api_key(verbose)?;
-    let properties = match api
-        .stream_run_properties(run_id, None)
-        .try_collect::<Vec<_>>()
-        .await
-    {
-        Ok(properties) => properties,
-        // Same 404-on-incomplete-run contract as `cmd_runs_properties`: explain
-        // why there are no properties instead of leaking a bare "404 Not Found".
-        Err(err) => return Err(explain_properties_error(&api, run_id, err).await),
-    };
-
-    let resolved = resolve_property(&properties, name, run_id)?;
-    let (property, fuzzy_note) = match resolved {
-        Resolved::Exact(p) => (p, None),
-        Resolved::Fuzzy(p) => (
-            p,
-            Some(format!(
-                "note: no exact match for '{name}', using closest property: '{}'",
-                p.name()
-            )),
-        ),
-    };
-
-    if json {
-        // Disclose the substitution on stderr so a `--json` consumer isn't
-        // silently handed a different property, while stdout stays clean JSON.
-        if let Some(note) = &fuzzy_note {
-            eprintln!("{note}");
-        }
-        outln!("{}", serde_json::to_string_pretty(property)?)?;
-        return Ok(());
-    }
-
-    // Human mode: print the note first, on stdout, so it reads in order *above*
-    // the property it resolved to (rather than stranded after the table).
-    if let Some(note) = &fuzzy_note {
-        outln!("{note}")?;
-    }
-    print_property_header(property)?;
-    outln!("{}", render_property_examples(property))?;
-    Ok(())
-}
-
-#[derive(Debug)]
-enum Resolved<'a> {
-    Exact(&'a Property),
-    Fuzzy(&'a Property),
-}
-
-fn resolve_property<'a>(
-    properties: &'a [Property],
-    query: &str,
-    run_id: &str,
-) -> Result<Resolved<'a>> {
-    // Match case-insensitively throughout: an exact name in any case is an
-    // exact hit (no "closest property" note), and the substring fallback
-    // ignores case too.
-    let needle = query.to_lowercase();
-
-    if let Some(p) = properties
-        .iter()
-        .find(|p| p.name().to_lowercase() == needle)
-    {
-        return Ok(Resolved::Exact(p));
-    }
-
-    let matches: Vec<&Property> = properties
-        .iter()
-        .filter(|p| p.name().to_lowercase().contains(&needle))
-        .collect();
-
-    match matches.as_slice() {
-        // No hit at all: point at the full list so the user can find the real
-        // name rather than hitting a dead end (the closest-match note only fires
-        // on a *single* substring hit, above).
-        [] => Err(user_error(format!(
-            "no property matches '{query}'\nrun 'snouty runs properties {run_id}' to see the available properties"
-        ))),
-        [only] => Ok(Resolved::Fuzzy(only)),
-        many => {
-            let names = many
-                .iter()
-                .map(|p| format!("  - {}", p.name()))
-                .collect::<Vec<_>>()
-                .join("\n");
-            Err(user_error(format!(
-                "multiple properties match '{query}', did you mean one of:\n{names}"
-            )))
-        }
-    }
-}
-
 /// How a wrapped free-text block lays its label out (see [`render_prose_block`]).
 enum ProseLayout {
     /// Label sits in a fixed-width column; the first body line follows it and
@@ -696,11 +659,27 @@ fn render_prose_block(label: &str, text: &str, layout: ProseLayout) -> String {
     out
 }
 
-fn print_property_header(property: &Property) -> Result<()> {
-    outln!("Name      {}", sanitize(property.name()))?;
-    outln!("Status    {}", property_status_label(property.status()))?;
+/// `runs properties --detail`: render each matched property's full detail —
+/// header (name/status/group/details) plus its examples — separated by a rule
+/// so multiple properties read as distinct blocks.
+fn render_properties_detail(properties: &[Property]) -> String {
+    let blocks: Vec<String> = properties.iter().map(render_property_detail).collect();
+    // A modest rule between blocks; capped so piped output (terminal_width =
+    // usize::MAX) doesn't try to draw an enormous line.
+    let rule = "─".repeat(terminal_width().min(72));
+    blocks.join(&format!("\n\n{rule}\n\n"))
+}
+
+/// One property's detail block: a key/value header followed by its examples.
+fn render_property_detail(property: &Property) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Name      {}\n", sanitize(property.name())));
+    out.push_str(&format!(
+        "Status    {}\n",
+        property_status_label(property.status())
+    ));
     if let Some(group) = property_group(property) {
-        outln!("Group     {}", sanitize(group))?;
+        out.push_str(&format!("Group     {}\n", sanitize(group)));
     }
     let description = match property {
         Property::EventProperty(p) => p.description.as_deref(),
@@ -709,23 +688,21 @@ fn print_property_header(property: &Property) -> Result<()> {
     if let Some(desc) = description {
         // Details is free-form prose, wrapped under a 10-char label column so
         // continuation lines hang-indent to match the value column above.
-        out!(
-            "{}",
-            render_prose_block(
-                "Details",
-                desc,
-                ProseLayout::HangingIndent {
-                    label_col: PROPERTY_LABEL_WIDTH,
-                    min_body_width: 20,
-                },
-            )
-        )?;
+        out.push_str(&render_prose_block(
+            "Details",
+            desc,
+            ProseLayout::HangingIndent {
+                label_col: PROPERTY_LABEL_WIDTH,
+                min_body_width: 20,
+            },
+        ));
     }
-    outln!()?;
-    Ok(())
+    out.push('\n');
+    out.push_str(&render_property_examples(property));
+    out
 }
 
-/// Width of the label column in `print_property_header` (`"Details   "`).
+/// Width of the label column in `render_property_detail` (`"Details   "`).
 const PROPERTY_LABEL_WIDTH: usize = 10;
 
 /// Drop leading and trailing blank lines, keeping interior ones.
@@ -856,8 +833,8 @@ fn property_examples_cell(p: &Property) -> String {
 fn render_properties_table(properties: &[Property]) -> String {
     // One table per group — far more scannable than a single flat table, and it
     // mirrors the report UI. The group is the section heading, so the NAME column
-    // shows just the property's own name (the exact string `runs property`
-    // resolves); folding the group into NAME would have made the displayed name
+    // shows just the property's own name (the string a `--name`/`--detail` filter
+    // matches); folding the group into NAME would have made the displayed name
     // un-copyable. Properties with no group go in a final "(ungrouped)" section.
     // This is human-facing output; use `--json` for automation.
     let headers = vec![
@@ -2858,7 +2835,7 @@ mod tests {
         assert!(table.contains("NAME"));
         assert!(!table.contains("GROUP"));
         // The group is the heading, not folded into NAME — so the displayed name
-        // is exactly what `runs property` resolves.
+        // is exactly what a `--name` filter matches.
         assert!(
             !table.contains('▸'),
             "group should not be folded into NAME\n{table}"
@@ -2888,80 +2865,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_property_prefers_exact_match() {
-        let properties = vec![
-            event_property("Setup ran", PropertyStatus::Passing, None, vec![], vec![]),
-            event_property(
-                "Setup completes",
-                PropertyStatus::Passing,
-                None,
-                vec![],
-                vec![],
-            ),
-        ];
-        let resolved = resolve_property(&properties, "Setup ran", "run-54-8").unwrap();
-        assert!(matches!(resolved, Resolved::Exact(_)));
-    }
-
-    #[test]
-    fn resolve_property_exact_match_ignores_case() {
-        let properties = vec![
-            event_property("Setup ran", PropertyStatus::Passing, None, vec![], vec![]),
-            event_property(
-                "Counter limit",
-                PropertyStatus::Passing,
-                None,
-                vec![],
-                vec![],
-            ),
-        ];
-        // Differs only by case: still an exact hit, not a fuzzy "closest" match.
-        let resolved = resolve_property(&properties, "setup RAN", "run-54-8").unwrap();
-        match resolved {
-            Resolved::Exact(p) => assert_eq!(p.name(), "Setup ran"),
-            other => panic!("expected exact match, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn resolve_property_falls_back_to_single_substring_match() {
-        let properties = vec![
-            event_property("Setup ran", PropertyStatus::Passing, None, vec![], vec![]),
-            event_property(
-                "Counter limit",
-                PropertyStatus::Passing,
-                None,
-                vec![],
-                vec![],
-            ),
-        ];
-        let resolved = resolve_property(&properties, "counter", "run-54-8").unwrap();
-        match resolved {
-            Resolved::Fuzzy(p) => assert_eq!(p.name(), "Counter limit"),
-            _ => panic!("expected fuzzy match"),
-        }
-    }
-
-    #[test]
-    fn resolve_property_errors_on_multiple_substring_matches() {
-        let properties = vec![
-            event_property("Setup ran", PropertyStatus::Passing, None, vec![], vec![]),
-            event_property(
-                "Setup completes",
-                PropertyStatus::Passing,
-                None,
-                vec![],
-                vec![],
-            ),
-        ];
-        let err = resolve_property(&properties, "setup", "run-54-8").unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("did you mean"));
-        assert!(msg.contains("Setup ran"));
-        assert!(msg.contains("Setup completes"));
-    }
-
-    #[test]
     fn format_count_si_shortens_large_counts() {
         // Under 1000: exact.
         assert_eq!(format_count_si(0), "0");
@@ -2978,25 +2881,6 @@ mod tests {
         // Rounding that tips a boundary steps up cleanly (never "10.0k"/"1000k").
         assert_eq!(format_count_si(9950), "10k");
         assert_eq!(format_count_si(999999), "1.0M");
-    }
-
-    #[test]
-    fn resolve_property_not_found_points_at_the_full_list() {
-        let properties = vec![event_property(
-            "Setup ran",
-            PropertyStatus::Passing,
-            None,
-            vec![],
-            vec![],
-        )];
-        let err = resolve_property(&properties, "nonexistent", "run-54-8").unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("no property matches 'nonexistent'"));
-        // The dead-end error points the user at the full property list.
-        assert!(
-            msg.contains("snouty runs properties run-54-8"),
-            "got: {msg}"
-        );
     }
 
     #[test]
@@ -3059,6 +2943,25 @@ mod tests {
         assert!(out.contains("maximum_used_bytes"));
         assert!(!out.contains("{2 fields}"));
         assert!(!out.contains("row 1 details:"));
+    }
+
+    #[test]
+    fn render_properties_detail_separates_multiple_with_a_rule() {
+        let properties = vec![
+            event_property("First", PropertyStatus::Failing, Some("G"), vec![], vec![event("h", "1.0")]),
+            event_property("Second", PropertyStatus::Passing, None, vec![event("h2", "2.0")], vec![]),
+        ];
+        let out = render_properties_detail(&properties);
+        // Both property headers render, each with its own Examples section…
+        assert!(out.contains("Name      First"), "got: {out}");
+        assert!(out.contains("Name      Second"));
+        assert_eq!(out.matches("Examples:").count(), 2);
+        // …separated by a horizontal rule so they read as distinct blocks.
+        assert!(out.contains('─'), "expected a rule separator\n{out}");
+
+        // A single property gets no separator rule.
+        let one = render_properties_detail(&properties[..1]);
+        assert!(!one.contains('─'));
     }
 
     #[test]
@@ -3243,8 +3146,14 @@ mod tests {
     fn render_non_event_example_renders_empty_collection_inline() {
         // An empty array/object renders as "(no value)" rather than an empty
         // pretty-printed block.
-        assert_eq!(render_value_example("passing", &json!([])), "passing: (no value)");
-        assert_eq!(render_value_example("passing", &json!({})), "passing: (no value)");
+        assert_eq!(
+            render_value_example("passing", &json!([])),
+            "passing: (no value)"
+        );
+        assert_eq!(
+            render_value_example("passing", &json!({})),
+            "passing: (no value)"
+        );
         // A scalar renders inline; an object renders as an indented JSON block.
         assert_eq!(render_value_example("failing", &json!(42)), "failing: 42");
         assert!(render_value_example("passing", &json!({"k": 1})).starts_with("passing:\n  {"));

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -342,9 +342,8 @@ fn launch_browser(url: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Filters applied to `runs properties`. `status` is served by the API;
-/// `name` (substring) and `group` (exact) are applied client-side. All
-/// case-insensitive.
+/// Filters applied to `runs properties`. `status` is served by the API; `name`
+/// and `group` are case-insensitive substring matches applied client-side.
 struct PropertyFilter<'a> {
     status: Option<PropertyStatus>,
     name: Option<&'a str>,
@@ -387,11 +386,11 @@ async fn cmd_runs_properties(
         Err(err) => return Err(explain_properties_error(&api, run_id, err).await),
     };
 
-    // Apply the client-side filters: group is an exact (case-insensitive) match,
-    // name a (case-insensitive) substring.
+    // Apply the client-side filters: both group and name are (case-insensitive)
+    // substring matches.
     if let Some(group) = filter.group {
         let needle = group.to_lowercase();
-        properties.retain(|p| property_group(p).is_some_and(|g| g.to_lowercase() == needle));
+        properties.retain(|p| property_group(p).is_some_and(|g| g.to_lowercase().contains(&needle)));
     }
     if let Some(name) = filter.name {
         let needle = name.to_lowercase();
@@ -659,18 +658,24 @@ fn render_prose_block(label: &str, text: &str, layout: ProseLayout) -> String {
     out
 }
 
-/// `runs properties --detail`: render each matched property's full detail —
-/// header (name/status/group/details) plus its examples — separated by a rule
-/// so multiple properties read as distinct blocks.
+/// `runs properties --detail`: the same per-group sections as the summary table,
+/// but each property is expanded into its examples (indented beneath it) rather
+/// than a one-line row. The group heading is shown once per section, separate
+/// from the property details.
 fn render_properties_detail(properties: &[Property]) -> String {
-    let blocks: Vec<String> = properties.iter().map(render_property_detail).collect();
-    // A modest rule between blocks; capped so piped output (terminal_width =
-    // usize::MAX) doesn't try to draw an enormous line.
-    let rule = "─".repeat(terminal_width().min(72));
-    blocks.join(&format!("\n\n{rule}\n\n"))
+    group_property_sections(properties)
+        .iter()
+        .map(|(title, props)| {
+            let blocks: Vec<String> = props.iter().map(|p| render_property_detail(p)).collect();
+            format!("{}\n\n{}", sanitize(title), blocks.join("\n\n"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
-/// One property's detail block: a key/value header followed by its examples.
+/// One property's detail within a group section: a key/value header (no Group
+/// line — the section heading carries it) and, indented beneath it, its examples.
+/// A property whose only example is a single number renders that inline instead.
 fn render_property_detail(property: &Property) -> String {
     let mut out = String::new();
     out.push_str(&format!("Name      {}\n", sanitize(property.name())));
@@ -678,9 +683,6 @@ fn render_property_detail(property: &Property) -> String {
         "Status    {}\n",
         property_status_label(property.status())
     ));
-    if let Some(group) = property_group(property) {
-        out.push_str(&format!("Group     {}\n", sanitize(group)));
-    }
     let description = match property {
         Property::EventProperty(p) => p.description.as_deref(),
         Property::NonEventProperty(p) => p.description.as_deref(),
@@ -697,9 +699,32 @@ fn render_property_detail(property: &Property) -> String {
             },
         ));
     }
-    out.push('\n');
-    out.push_str(&render_property_examples(property));
+    if let Some(value) = single_numeric_value(property) {
+        // A single-metric property (e.g. "Total non-blank lines") — show the
+        // number inline rather than a whole Examples section.
+        out.push_str(&format!("Example   {value}"));
+    } else {
+        out.push('\n');
+        out.push_str(&indent_lines(&render_property_examples(property), "  "));
+    }
     out
+}
+
+/// The lone numeric value of a non-event property, when its examples and
+/// counterexamples together are exactly one number.
+fn single_numeric_value(property: &Property) -> Option<String> {
+    let Property::NonEventProperty(p) = property else {
+        return None;
+    };
+    let mut values = p.examples.iter().chain(p.counterexamples.iter());
+    let first = values.next()?;
+    if values.next().is_some() {
+        return None;
+    }
+    match first {
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
 }
 
 /// Width of the label column in `render_property_detail` (`"Details   "`).
@@ -804,7 +829,14 @@ fn render_value_example(status: &str, value: &Value) -> String {
 
 fn indent_lines(text: &str, prefix: &str) -> String {
     text.lines()
-        .map(|line| format!("{prefix}{line}"))
+        .map(|line| {
+            // Don't indent blank lines — that would leave trailing whitespace.
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{prefix}{line}")
+            }
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -830,13 +862,56 @@ fn property_examples_cell(p: &Property) -> String {
     }
 }
 
+/// Order properties into display sections shared by the table and `--detail`
+/// views: named groups containing a failing property first (then the rest,
+/// alphabetical), with ungrouped properties in a final "(ungrouped)" section.
+/// Within each section, failing entries sort first, then by name. An
+/// empty-string group counts as no group.
+fn group_property_sections(properties: &[Property]) -> Vec<(String, Vec<&Property>)> {
+    fn sort_section(props: &mut [&Property]) {
+        props.sort_by(|a, b| {
+            is_failing(b)
+                .cmp(&is_failing(a))
+                .then_with(|| a.name().cmp(b.name()))
+        });
+    }
+
+    // BTreeMap keeps named groups alphabetical before the failing-first re-sort.
+    let mut grouped: std::collections::BTreeMap<&str, Vec<&Property>> = Default::default();
+    let mut ungrouped: Vec<&Property> = Vec::new();
+    for p in properties {
+        match property_group(p).filter(|g| !g.is_empty()) {
+            Some(g) => grouped.entry(g).or_default().push(p),
+            None => ungrouped.push(p),
+        }
+    }
+
+    let mut named: Vec<(&str, Vec<&Property>)> = grouped.into_iter().collect();
+    named.sort_by(|(a, aps), (b, bps)| {
+        bps.iter()
+            .any(|p| is_failing(p))
+            .cmp(&aps.iter().any(|p| is_failing(p)))
+            .then_with(|| a.cmp(b))
+    });
+
+    let mut sections: Vec<(String, Vec<&Property>)> = Vec::new();
+    for (name, mut props) in named {
+        sort_section(&mut props);
+        sections.push((name.to_string(), props));
+    }
+    if !ungrouped.is_empty() {
+        sort_section(&mut ungrouped);
+        sections.push(("(ungrouped)".to_string(), ungrouped));
+    }
+    sections
+}
+
 fn render_properties_table(properties: &[Property]) -> String {
     // One table per group — far more scannable than a single flat table, and it
     // mirrors the report UI. The group is the section heading, so the NAME column
     // shows just the property's own name (the string a `--name`/`--detail` filter
     // matches); folding the group into NAME would have made the displayed name
-    // un-copyable. Properties with no group go in a final "(ungrouped)" section.
-    // This is human-facing output; use `--json` for automation.
+    // un-copyable. This is human-facing output; use `--json` for automation.
     let headers = vec![
         "STATUS".to_string(),
         "EXAMPLES".to_string(),
@@ -847,60 +922,27 @@ fn render_properties_table(properties: &[Property]) -> String {
     let aligns = [Align::Left, Align::Right, Align::Left];
     let width = terminal_width();
 
-    // Bucket into named groups (alphabetical via BTreeMap) and an ungrouped pile.
-    // An empty-string group is treated as no group.
-    let mut grouped: std::collections::BTreeMap<&str, Vec<&Property>> = Default::default();
-    let mut ungrouped: Vec<&Property> = Vec::new();
-    for p in properties {
-        match property_group(p).filter(|g| !g.is_empty()) {
-            Some(g) => grouped.entry(g).or_default().push(p),
-            None => ungrouped.push(p),
-        }
-    }
-
-    // Named groups containing a failing property sort first (so triage surfaces
-    // broken assertion groups), then the rest; alphabetical within each tier.
-    let mut named: Vec<(&str, Vec<&Property>)> = grouped.into_iter().collect();
-    named.sort_by(|(a, aps), (b, bps)| {
-        bps.iter()
-            .any(|p| is_failing(p))
-            .cmp(&aps.iter().any(|p| is_failing(p)))
-            .then_with(|| a.cmp(b))
-    });
-
-    let render_section = |title: &str, props: &[&Property]| -> String {
-        // Failing rows first within a section, then alphabetical by name.
-        let mut ps: Vec<&Property> = props.to_vec();
-        ps.sort_by(|a, b| {
-            is_failing(b)
-                .cmp(&is_failing(a))
-                .then_with(|| a.name().cmp(b.name()))
-        });
-        let rows: Vec<Vec<String>> = ps
-            .iter()
-            .map(|p| {
-                vec![
-                    property_status_label(p.status()).to_string(),
-                    property_examples_cell(p),
-                    sanitize(p.name()),
-                ]
-            })
-            .collect();
-        format!(
-            "{}\n{}",
-            sanitize(title),
-            render_table_wrap_last(&headers, &rows, width, &aligns)
-        )
-    };
-
-    let mut sections: Vec<String> = named
+    group_property_sections(properties)
         .iter()
-        .map(|(name, props)| render_section(name, props))
-        .collect();
-    if !ungrouped.is_empty() {
-        sections.push(render_section("(ungrouped)", &ungrouped));
-    }
-    sections.join("\n\n")
+        .map(|(title, props)| {
+            let rows: Vec<Vec<String>> = props
+                .iter()
+                .map(|p| {
+                    vec![
+                        property_status_label(p.status()).to_string(),
+                        property_examples_cell(p),
+                        sanitize(p.name()),
+                    ]
+                })
+                .collect();
+            format!(
+                "{}\n{}",
+                sanitize(title),
+                render_table_wrap_last(&headers, &rows, width, &aligns)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 fn print_run_detail(run: &RunDetail) -> Result<()> {
@@ -2946,22 +2988,56 @@ mod tests {
     }
 
     #[test]
-    fn render_properties_detail_separates_multiple_with_a_rule() {
+    fn render_properties_detail_groups_and_indents_examples() {
         let properties = vec![
-            event_property("First", PropertyStatus::Failing, Some("G"), vec![], vec![event("h", "1.0")]),
-            event_property("Second", PropertyStatus::Passing, None, vec![event("h2", "2.0")], vec![]),
+            event_property(
+                "First",
+                PropertyStatus::Failing,
+                Some("Safety"),
+                vec![],
+                vec![event("h", "1.0")],
+            ),
+            event_property(
+                "Second",
+                PropertyStatus::Passing,
+                None,
+                vec![event("h2", "2.0")],
+                vec![],
+            ),
         ];
         let out = render_properties_detail(&properties);
-        // Both property headers render, each with its own Examples section…
-        assert!(out.contains("Name      First"), "got: {out}");
-        assert!(out.contains("Name      Second"));
+        // Grouped: the "Safety" group heads its section, ungrouped trails.
+        assert!(out.contains("Safety"), "got: {out}");
+        assert!(out.contains("(ungrouped)"));
+        // No Group key/value line (the heading carries it) and no rule separator.
+        assert!(!out.contains("Group     Safety"));
+        assert!(!out.contains('─'));
+        // Each property keeps its header and an Examples section, indented.
+        assert!(out.contains("Name      First"));
         assert_eq!(out.matches("Examples:").count(), 2);
-        // …separated by a horizontal rule so they read as distinct blocks.
-        assert!(out.contains('─'), "expected a rule separator\n{out}");
+        assert!(out.contains("  Examples:"), "examples should be indented\n{out}");
+    }
 
-        // A single property gets no separator rule.
-        let one = render_properties_detail(&properties[..1]);
-        assert!(!one.contains('─'));
+    #[test]
+    fn render_property_detail_inlines_a_single_numeric_value() {
+        let property = non_event_property(
+            "Total non-blank lines in notebook file",
+            PropertyStatus::Passing,
+            vec![json!(1234)],
+            vec![],
+        );
+        let out = render_property_detail(&property);
+        // A lone numeric value is shown inline after the header, no Examples block.
+        assert!(out.contains("Example   1234"), "got: {out}");
+        assert!(!out.contains("Examples:"));
+        // An object value still renders as an Examples block.
+        let obj = non_event_property(
+            "Build did not exceed expected limit",
+            PropertyStatus::Passing,
+            vec![json!({"target": "x", "kb": 0})],
+            vec![],
+        );
+        assert!(render_property_detail(&obj).contains("Examples:"));
     }
 
     #[test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -2,6 +2,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::OnceLock;
 
+use color_eyre::Section;
 use color_eyre::eyre::{Result, eyre};
 use futures_util::{StreamExt, TryStreamExt};
 use indexmap::IndexMap;
@@ -281,9 +282,9 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
         .as_ref()
         .and_then(|l| l.triage_report.as_deref())
         .ok_or_else(|| {
-            user_error(format!(
-                "no report available for run {} with status {}",
-                run.run_id, run.status
+            user_error(format!("no report available for run {}", run.run_id)).note(format!(
+                "reports are generated when a run completes; this run is {}",
+                run.status
             ))
         })?;
 
@@ -356,9 +357,8 @@ struct PropertyFilter<'a> {
 /// `runs list`, which both carry `--detail`.
 fn reject_detail_with_json(json: bool, detail: bool) -> Result<()> {
     if json && detail {
-        return Err(user_error(
-            "--detail and --json cannot be combined: --json already emits the full data",
-        ));
+        return Err(user_error("--detail and --json cannot be combined")
+            .note("--json already emits the full data"));
     }
     Ok(())
 }
@@ -448,8 +448,10 @@ fn no_properties_message(filter: &PropertyFilter) -> String {
 enum RunProbe {
     /// The run id is bad: `get_run` also returned a structured 404.
     NotFound,
-    /// The run exists; carries its status so the caller can tailor the message.
-    Exists(RunStatus),
+    /// The run exists; carries its full detail so callers can tailor the message
+    /// (status, and the failure moment for incomplete runs). Boxed to keep the
+    /// enum small.
+    Exists(Box<RunDetail>),
     /// `get_run` failed for some other reason (timeout, 502, auth). Propagate
     /// this rather than claiming the run doesn't exist.
     ProbeFailed(color_eyre::eyre::Report),
@@ -461,7 +463,7 @@ enum RunProbe {
 /// not found".
 async fn probe_run(api: &AntithesisApi, run_id: &str) -> RunProbe {
     match api.get_run(run_id).await {
-        Ok(run) => RunProbe::Exists(run.status),
+        Ok(run) => RunProbe::Exists(Box::new(run)),
         Err(err) if api_error_status(&err) == Some(404) => RunProbe::NotFound,
         Err(err) => RunProbe::ProbeFailed(err),
     }
@@ -524,20 +526,24 @@ async fn explain_properties_error(
         RunProbe::ProbeFailed(probe_err) => probe_err,
         // Completed runs are expected to have properties; if one 404s anyway,
         // that's a genuine surprise — keep the original error.
-        RunProbe::Exists(RunStatus::Completed) => err,
-        RunProbe::Exists(status) => {
-            let mut msg = format!(
-                "no properties for run {run_id} — properties are generated when a run completes, \
-                 and this run is {}",
-                status_label(status)
-            );
-            if status == RunStatus::Incomplete {
-                msg.push_str(&format!(
-                    ". See the failure moment with `snouty runs show {run_id}`, \
-                     then `snouty runs logs`/`runs events` around it"
-                ));
+        RunProbe::Exists(run) if run.status == RunStatus::Completed => err,
+        RunProbe::Exists(run) => {
+            // The message states the error; the *why* and the concrete next steps
+            // hang off it as notes. For an incomplete run we already fetched the
+            // failure moment while probing, so prefill it into the `runs logs` hint.
+            let report = user_error(format!("no properties for run {run_id}"))
+                .note(format!(
+                    "properties are generated when a run completes; this run is {}",
+                    status_label(run.status)
+                ))
+                .note(format!("inspect the run with `snouty runs show {run_id}`"));
+            match run.failure_moment.as_ref() {
+                Some(moment) => report.note(format!(
+                    "view logs at the failure with `snouty runs logs {run_id} {} {}`",
+                    moment.input_hash, moment.vtime
+                )),
+                None => report,
             }
-            user_error(msg)
         }
     }
 }
@@ -1185,9 +1191,8 @@ async fn cmd_runs_events(
     debug!("searching events for run: {}", run_id);
 
     if matches.is_empty() {
-        return Err(user_error(
-            "no search term given: pass at least one needle via `-m/--match` or as a positional argument",
-        ));
+        return Err(user_error("no search term given")
+            .suggestion("pass at least one needle via `-m/--match` or as a positional argument"));
     }
 
     // The server endpoint takes a single `q` substring and streams only a capped
@@ -4860,7 +4865,7 @@ mod tests {
     mod run_scoped_errors {
         use super::*;
         use crate::api::{Auth, Config};
-        use crate::error::{ApiError, is_user_error};
+        use crate::error::ApiError;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -4894,7 +4899,6 @@ mod tests {
             let rewritten = explain_run_not_found("BAD-ID", api_error(404, "API error: 404"));
             let msg = format!("{rewritten:#}");
             assert_eq!(msg, "run not found: BAD-ID");
-            assert!(is_user_error(&rewritten));
         }
 
         #[test]
@@ -4986,10 +4990,14 @@ mod tests {
             let api = test_api(&server.uri());
             let result =
                 explain_properties_error(&api, "run-3", api_error(404, "API error: 404")).await;
+            // The message is a clean statement of the error …
             let msg = format!("{result:#}");
-            assert!(msg.contains("no properties for run run-3"), "got: {msg}");
-            assert!(msg.contains("this run is incomplete"), "got: {msg}");
-            assert!(!msg.contains("run not found"), "got: {msg}");
+            assert_eq!(msg, "no properties for run run-3", "got: {msg}");
+            // … while the *why* and the next step ride along as notes (rendered by
+            // the full report, not the message chain).
+            let report = format!("{result:?}");
+            assert!(report.contains("this run is incomplete"), "got: {report}");
+            assert!(report.contains("snouty runs show run-3"), "got: {report}");
         }
 
         #[tokio::test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -490,12 +490,47 @@ fn property_group(p: &Property) -> Option<&str> {
     }
 }
 
-fn property_example_total(p: &Property) -> u64 {
+/// `(examples, counterexamples)` for a property, defaulting a missing count to 0.
+fn property_example_counts(p: &Property) -> (u64, u64) {
     let (ex, cex) = match p {
         Property::EventProperty(p) => (p.example_count, p.counterexample_count),
         Property::NonEventProperty(p) => (p.example_count, p.counterexample_count),
     };
-    u64::from(ex.unwrap_or(0)) + u64::from(cex.unwrap_or(0))
+    (u64::from(ex.unwrap_or(0)), u64::from(cex.unwrap_or(0)))
+}
+
+/// Format a count in short SI-style notation so the EXAMPLES column stays narrow
+/// and scannable: values under 1000 print exactly (`0`, `20`, `885`); larger
+/// ones use ~3 significant figures with a k/M/G/T suffix (`2.3k`, `13k`, `18M`).
+fn format_count_si(n: u64) -> String {
+    if n < 1000 {
+        return n.to_string();
+    }
+    const UNITS: [&str; 4] = ["k", "M", "G", "T"];
+    let mut value = n as f64;
+    let mut unit = 0;
+    while value >= 1000.0 && unit < UNITS.len() {
+        value /= 1000.0;
+        unit += 1;
+    }
+    // `value` is now in [1, 1000). One decimal below 10 (`2.3k`), none at/above
+    // (`13k`). If rounding tips it over a boundary, step up a unit / drop the
+    // decimal so we never emit `10.0k` or `1000k`.
+    if value < 10.0 {
+        let rounded = (value * 10.0).round() / 10.0;
+        if rounded >= 10.0 {
+            format!("{:.0}{}", rounded, UNITS[unit - 1])
+        } else {
+            format!("{rounded:.1}{}", UNITS[unit - 1])
+        }
+    } else {
+        let rounded = value.round();
+        if rounded >= 1000.0 && unit < UNITS.len() {
+            format!("{:.1}{}", rounded / 1000.0, UNITS[unit])
+        } else {
+            format!("{rounded:.0}{}", UNITS[unit - 1])
+        }
+    }
 }
 
 fn property_status_label(status: PropertyStatus) -> &'static str {
@@ -520,7 +555,7 @@ async fn cmd_runs_property(run_id: &str, name: &str, json: bool, verbose: bool) 
         Err(err) => return Err(explain_properties_error(&api, run_id, err).await),
     };
 
-    let resolved = resolve_property(&properties, name)?;
+    let resolved = resolve_property(&properties, name, run_id)?;
     let property = match resolved {
         Resolved::Exact(p) => p,
         Resolved::Fuzzy(p) => {
@@ -552,7 +587,11 @@ enum Resolved<'a> {
     Fuzzy(&'a Property),
 }
 
-fn resolve_property<'a>(properties: &'a [Property], query: &str) -> Result<Resolved<'a>> {
+fn resolve_property<'a>(
+    properties: &'a [Property],
+    query: &str,
+    run_id: &str,
+) -> Result<Resolved<'a>> {
     // Match case-insensitively throughout: an exact name in any case is an
     // exact hit (no "closest property" note), and the substring fallback
     // ignores case too.
@@ -571,7 +610,12 @@ fn resolve_property<'a>(properties: &'a [Property], query: &str) -> Result<Resol
         .collect();
 
     match matches.as_slice() {
-        [] => Err(user_error(format!("no property matches '{query}'"))),
+        // No hit at all: point at the full list so the user can find the real
+        // name rather than hitting a dead end (the closest-match note only fires
+        // on a *single* substring hit, above).
+        [] => Err(user_error(format!(
+            "no property matches '{query}'\nrun 'snouty runs properties {run_id}' to see the available properties"
+        ))),
         [only] => Ok(Resolved::Fuzzy(only)),
         many => {
             let names = many
@@ -841,14 +885,31 @@ fn render_properties_table(properties: &[Property]) -> String {
                 Some(group) => format!("{} ▸ {}", sanitize(group), sanitize(p.name())),
                 None => sanitize(p.name()),
             };
+            // Show the example count, SI-shortened so big counts stay narrow
+            // (`18496678` -> `18M`). Surface counterexamples inline only when a
+            // property actually has some (`examples/counterexamples`), so the
+            // common all-zero-counterexample rows aren't cluttered with `/0`.
+            let (examples, counters) = property_example_counts(p);
+            let examples_cell = if counters == 0 {
+                format_count_si(examples)
+            } else {
+                format!(
+                    "{}/{}",
+                    format_count_si(examples),
+                    format_count_si(counters)
+                )
+            };
             vec![
                 property_status_label(p.status()).to_string(),
-                property_example_total(p).to_string(),
+                examples_cell,
                 name,
             ]
         })
         .collect::<Vec<_>>();
-    render_table_wrap_last(&headers, &rows, terminal_width())
+    // Right-align the numeric EXAMPLES column so magnitudes line up; STATUS and
+    // the wrapped NAME column stay left-aligned.
+    let aligns = [Align::Left, Align::Right, Align::Left];
+    render_table_wrap_last(&headers, &rows, terminal_width(), &aligns)
 }
 
 fn print_run_detail(run: &RunDetail) -> Result<()> {
@@ -1281,45 +1342,58 @@ fn moment_vtime_seconds(entry: &Value) -> Option<f64> {
         .or_else(|| vtime.as_f64())
 }
 
-/// Render a log line's vtime in seconds with at most 3 decimal places (trailing
-/// zeros trimmed). Full-precision vtimes overflow the fixed `LOG_VTIME_WIDTH`
-/// column and desync the source column; trimming keeps every row aligned.
+/// Render a log line's vtime in seconds with exactly 3 decimal places,
+/// truncated — never rounded. Fixed precision keeps the decimal point and right
+/// edge aligned down the fixed `LOG_VTIME_WIDTH` column (full-precision vtimes
+/// would overflow it and desync the source column). Truncating rather than
+/// rounding means a vtime copied off the screen and pasted back as
+/// `--begin-vtime` lands on — never just past — the line you saw.
 fn format_log_vtime(entry: &Value) -> String {
-    match moment_vtime_seconds(entry) {
-        Some(seconds) => trim_decimals(seconds, 3),
-        // Not a parseable number — show whatever the server sent rather than "".
-        None => entry["moment"]["vtime"].as_str().unwrap_or("").to_string(),
+    let raw = &entry["moment"]["vtime"];
+    match raw.as_str() {
+        // The API sends vtime as a seconds string; truncate it directly so f64
+        // round-trips can't nudge the displayed value.
+        Some(s) => truncate_decimals(s, 3),
+        // A JSON-number vtime: format with surplus precision, then truncate the
+        // string, so the kept 3 decimals are never perturbed by rounding.
+        None => match raw.as_f64() {
+            Some(v) => truncate_decimals(&format!("{v:.9}"), 3),
+            None => String::new(),
+        },
     }
 }
 
-/// Format `value` with at most `max_decimals` decimal places, trimming trailing
-/// zeros and a dangling decimal point (e.g. `19.0` -> `19`, `18.9140` -> `18.914`).
-///
-/// A *nonzero* value too small to survive the trim (it would otherwise render as
-/// `0` or `-0`, losing the fact that something happened) renders as `<0.001` for
-/// positives and `>-0.001` for negatives — short, unambiguous, and the same
-/// width regardless of magnitude. An exact `0.0`/`-0.0` renders `0`.
-fn trim_decimals(value: f64, max_decimals: usize) -> String {
-    let mut s = format!("{value:.max_decimals$}");
-    if s.contains('.') {
-        let trimmed = s.trim_end_matches('0').trim_end_matches('.').len();
-        s.truncate(trimmed);
-    }
-    // A nonzero input that rounded to "0"/"-0" would misrepresent it as exactly
-    // zero; flag it as a below-threshold magnitude instead.
-    if (s == "0" || s == "-0") && value != 0.0 {
-        let threshold = format!("0.{}1", "0".repeat(max_decimals.saturating_sub(1)));
-        return if value < 0.0 {
-            format!(">-{threshold}")
-        } else {
-            format!("<{threshold}")
+/// Truncate (never round) the decimal string `s` to exactly `decimals`
+/// fractional digits, zero-padding a short or missing fraction (`"19"` ->
+/// `"19.000"`, `"14.78"` -> `"14.780"`, `"1814.71357"` -> `"1814.713"`). Fixed
+/// width keeps a column of these aligned on the decimal point. Only a plain
+/// decimal string is sliced; anything else (scientific notation) falls back to
+/// rounded fixed-point, and a non-number is passed through verbatim.
+fn truncate_decimals(s: &str, decimals: usize) -> String {
+    let t = s.trim();
+    let (int_part, frac_part) = match t.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (t, ""),
+    };
+    let is_plain = !int_part.is_empty()
+        && int_part
+            .char_indices()
+            .all(|(i, c)| c.is_ascii_digit() || (i == 0 && (c == '-' || c == '+')))
+        && frac_part.chars().all(|c| c.is_ascii_digit());
+    if !is_plain {
+        return match t.parse::<f64>() {
+            Ok(v) => format!("{v:.decimals$}"),
+            Err(_) => t.to_string(),
         };
     }
-    // Normalise an exact -0.0 (rounds to "-0") to plain "0".
-    if s == "-0" {
-        return "0".to_string();
+    if decimals == 0 {
+        return int_part.to_string();
     }
-    s
+    let mut frac: String = frac_part.chars().take(decimals).collect();
+    while frac.len() < decimals {
+        frac.push('0');
+    }
+    format!("{int_part}.{frac}")
 }
 
 fn abbreviate_stream(stream: &str) -> std::borrow::Cow<'static, str> {
@@ -2077,11 +2151,33 @@ enum LastColumn {
     Wrap { total_width: usize },
 }
 
+/// Per-column horizontal alignment for the leading (fixed-width) columns. The
+/// final column is never padded, so its alignment is ignored.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Align {
+    Left,
+    Right,
+}
+
+/// Pad `cell` to `width` columns on the side dictated by `align`.
+fn pad_cell(cell: &str, width: usize, align: Align) -> String {
+    match align {
+        Align::Left => format!("{cell:<width$}"),
+        Align::Right => format!("{cell:>width$}"),
+    }
+}
+
 /// Shared column-sizing core for every table snouty renders. Leading columns are
-/// sized to their widest cell (header included, counted in chars); the final
-/// column follows `last_column`. Lines are right-trimmed, so a `Raw` final
-/// column never leaves trailing padding.
-fn render_columns(headers: &[String], rows: &[Vec<String>], last_column: LastColumn) -> String {
+/// sized to their widest cell (header included, counted in chars) and aligned per
+/// `aligns`; the final column follows `last_column`. Lines are right-trimmed, so
+/// a `Raw` final column never leaves trailing padding. `aligns` must have one
+/// entry per header (the last entry is ignored — the final column isn't padded).
+fn render_columns(
+    headers: &[String],
+    rows: &[Vec<String>],
+    last_column: LastColumn,
+    aligns: &[Align],
+) -> String {
     let last = headers.len() - 1;
 
     // Size every leading column to the widest of its header and cells. The final
@@ -2105,9 +2201,9 @@ fn render_columns(headers: &[String], rows: &[Vec<String>], last_column: LastCol
             // Final column unbounded: `push_table_row` emits it unpadded, so its
             // width never matters — leave `widths[last]` at the header width.
             let mut output = String::new();
-            push_table_row(&mut output, headers, &widths);
+            push_table_row(&mut output, headers, &widths, aligns);
             for row in rows {
-                push_table_row(&mut output, row, &widths);
+                push_table_row(&mut output, row, &widths, aligns);
             }
             output.trim_end().to_string()
         }
@@ -2118,11 +2214,11 @@ fn render_columns(headers: &[String], rows: &[Vec<String>], last_column: LastCol
             widths[last] = last_width;
 
             let mut output = String::new();
-            push_table_row(&mut output, headers, &widths);
+            push_table_row(&mut output, headers, &widths, aligns);
             for row in rows {
                 let mut row = row.clone();
                 row[last] = console::truncate_str(&row[last], last_width, "…").into_owned();
-                push_table_row(&mut output, &row, &widths);
+                push_table_row(&mut output, &row, &widths, aligns);
             }
             output.trim_end().to_string()
         }
@@ -2133,7 +2229,7 @@ fn render_columns(headers: &[String], rows: &[Vec<String>], last_column: LastCol
                 .max(20);
 
             let mut output = String::new();
-            push_table_row(&mut output, headers, &widths);
+            push_table_row(&mut output, headers, &widths, aligns);
             for row in rows {
                 let wrapped = wrap_text(&row[last], last_width);
                 let wrapped = if wrapped.is_empty() {
@@ -2144,11 +2240,8 @@ fn render_columns(headers: &[String], rows: &[Vec<String>], last_column: LastCol
                 for (line_index, line) in wrapped.iter().enumerate() {
                     if line_index == 0 {
                         for index in 0..last {
-                            output.push_str(&format!(
-                                "{:<width$}  ",
-                                row[index],
-                                width = widths[index]
-                            ));
+                            output.push_str(&pad_cell(&row[index], widths[index], aligns[index]));
+                            output.push_str("  ");
                         }
                         output.push_str(line);
                     } else {
@@ -2166,7 +2259,9 @@ fn render_runs_table(runs: &[RunSummary], width: usize) -> String {
     // The default view omits the description entirely — it never fit usefully
     // beside the (necessarily full) run id, and `runs list --detail` shows it in
     // full. Test name is the final, width-bounded column truncated with an
-    // ellipsis (a `runs show RUN` follow-up still works off the full id).
+    // ellipsis (a `runs show RUN` follow-up still works off the full id). A
+    // launcher filter doesn't add a column — every row would carry the same
+    // value; `--detail`/`--json` surface the launcher when it's actually wanted.
     let headers = vec![
         "RUN ID".to_string(),
         "STATUS".to_string(),
@@ -2187,24 +2282,41 @@ fn render_runs_table(runs: &[RunSummary], width: usize) -> String {
         })
         .collect();
 
-    render_columns(&headers, &rows, LastColumn::Truncate { total_width: width })
+    render_columns(
+        &headers,
+        &rows,
+        LastColumn::Truncate { total_width: width },
+        &left_aligned(headers.len()),
+    )
+}
+
+/// All-left-aligned alignment vector for a table with `n` columns — the default
+/// for tables that don't right-align any column.
+fn left_aligned(n: usize) -> Vec<Align> {
+    vec![Align::Left; n]
 }
 
 /// Auto-width table whose final column is emitted verbatim (no padding, no
-/// width bound).
+/// width bound). All leading columns are left-aligned.
 fn render_table(headers: &[String], rows: &[Vec<String>]) -> String {
-    render_columns(headers, rows, LastColumn::Raw)
+    render_columns(headers, rows, LastColumn::Raw, &left_aligned(headers.len()))
 }
 
 /// Like [`render_table`], but the final column wraps to whatever width is left
 /// over after the (fixed-width) leading columns, so a single long cell can't
 /// push the table past `total_width`. Continuation lines indent to the start of
-/// the final column. Leading columns are sized to their widest cell.
-fn render_table_wrap_last(headers: &[String], rows: &[Vec<String>], total_width: usize) -> String {
-    render_columns(headers, rows, LastColumn::Wrap { total_width })
+/// the final column. Leading columns are sized to their widest cell and aligned
+/// per `aligns` (one entry per header; the final, wrapped column isn't padded).
+fn render_table_wrap_last(
+    headers: &[String],
+    rows: &[Vec<String>],
+    total_width: usize,
+    aligns: &[Align],
+) -> String {
+    render_columns(headers, rows, LastColumn::Wrap { total_width }, aligns)
 }
 
-fn push_table_row(output: &mut String, row: &[String], widths: &[usize]) {
+fn push_table_row(output: &mut String, row: &[String], widths: &[usize], aligns: &[Align]) {
     let last = row.len().saturating_sub(1);
     for (index, cell) in row.iter().enumerate() {
         if index > 0 {
@@ -2213,7 +2325,7 @@ fn push_table_row(output: &mut String, row: &[String], widths: &[usize]) {
         if index == last {
             output.push_str(cell);
         } else {
-            output.push_str(&format!("{cell:<width$}", width = widths[index]));
+            output.push_str(&pad_cell(cell, widths[index], aligns[index]));
         }
     }
     output.push('\n');
@@ -2715,12 +2827,13 @@ mod tests {
         // Failing properties sort to the top, ahead of passing ones.
         assert!(lines[1].contains("Counter value"));
 
-        // Two property rows. Counter property has 1 example + 2 counterexamples = 3 total.
-        // Its group is folded into the name as `group ▸ detail`.
+        // Two property rows. Counter property has 1 example + 2 counterexamples,
+        // rendered inline as `examples/counterexamples` (`1/2`). Its group is
+        // folded into the name as `group ▸ detail`.
         let counter_row = lines.iter().find(|l| l.contains("Counter value")).unwrap();
         assert!(counter_row.contains("failing"));
         assert!(counter_row.contains("Safety ▸ Counter value stays below limit"));
-        assert!(counter_row.contains("3"));
+        assert!(counter_row.contains("1/2"));
 
         let setup_row = lines
             .iter()
@@ -2742,7 +2855,7 @@ mod tests {
                 vec![],
             ),
         ];
-        let resolved = resolve_property(&properties, "Setup ran").unwrap();
+        let resolved = resolve_property(&properties, "Setup ran", "run-54-8").unwrap();
         assert!(matches!(resolved, Resolved::Exact(_)));
     }
 
@@ -2759,7 +2872,7 @@ mod tests {
             ),
         ];
         // Differs only by case: still an exact hit, not a fuzzy "closest" match.
-        let resolved = resolve_property(&properties, "setup RAN").unwrap();
+        let resolved = resolve_property(&properties, "setup RAN", "run-54-8").unwrap();
         match resolved {
             Resolved::Exact(p) => assert_eq!(p.name(), "Setup ran"),
             other => panic!("expected exact match, got {other:?}"),
@@ -2778,7 +2891,7 @@ mod tests {
                 vec![],
             ),
         ];
-        let resolved = resolve_property(&properties, "counter").unwrap();
+        let resolved = resolve_property(&properties, "counter", "run-54-8").unwrap();
         match resolved {
             Resolved::Fuzzy(p) => assert_eq!(p.name(), "Counter limit"),
             _ => panic!("expected fuzzy match"),
@@ -2797,11 +2910,49 @@ mod tests {
                 vec![],
             ),
         ];
-        let err = resolve_property(&properties, "setup").unwrap_err();
+        let err = resolve_property(&properties, "setup", "run-54-8").unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("did you mean"));
         assert!(msg.contains("Setup ran"));
         assert!(msg.contains("Setup completes"));
+    }
+
+    #[test]
+    fn format_count_si_shortens_large_counts() {
+        // Under 1000: exact.
+        assert_eq!(format_count_si(0), "0");
+        assert_eq!(format_count_si(20), "20");
+        assert_eq!(format_count_si(885), "885");
+        // One decimal below 10k, none above.
+        assert_eq!(format_count_si(1000), "1.0k");
+        assert_eq!(format_count_si(2323), "2.3k");
+        assert_eq!(format_count_si(13396), "13k");
+        assert_eq!(format_count_si(74843), "75k");
+        assert_eq!(format_count_si(278493), "278k");
+        // Millions.
+        assert_eq!(format_count_si(18496678), "18M");
+        // Rounding that tips a boundary steps up cleanly (never "10.0k"/"1000k").
+        assert_eq!(format_count_si(9950), "10k");
+        assert_eq!(format_count_si(999999), "1.0M");
+    }
+
+    #[test]
+    fn resolve_property_not_found_points_at_the_full_list() {
+        let properties = vec![event_property(
+            "Setup ran",
+            PropertyStatus::Passing,
+            None,
+            vec![],
+            vec![],
+        )];
+        let err = resolve_property(&properties, "nonexistent", "run-54-8").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no property matches 'nonexistent'"));
+        // The dead-end error points the user at the full property list.
+        assert!(
+            msg.contains("snouty runs properties run-54-8"),
+            "got: {msg}"
+        );
     }
 
     #[test]
@@ -2921,48 +3072,45 @@ mod tests {
     #[test]
     fn format_log_line_truncates_vtime_to_three_decimals() {
         let entry = json!({
-            "moment": {"input_hash": "1", "vtime": "18.9141638034489"},
+            "moment": {"input_hash": "1", "vtime": "18.9148034489"},
             "source": {"name": "client", "stream": "info"},
             "output_text": "hello"
         });
         let rendered = format_log_entry(&entry, false);
-        // Trimmed to 3 decimals so it fits the fixed vtime column and the
-        // source column stays aligned across rows.
+        // Fixed 3 decimals (so the column stays aligned), truncated not rounded:
+        // 18.9148… -> 18.914 (rounding would give 18.915).
         assert!(rendered.starts_with("[        18.914] "), "got: {rendered}");
     }
 
     #[test]
     fn format_log_line_accepts_numeric_vtime() {
-        // A JSON-number vtime (not a string) must still render, not blank out.
+        // A JSON-number vtime (not a string) must still render, not blank out,
+        // and gets the same fixed-3-decimal treatment (12.5 -> 12.500).
         let entry = json!({
             "moment": {"input_hash": "1", "vtime": 12.5},
             "source": {"name": "client", "stream": "info"},
             "output_text": "hello"
         });
         assert!(
-            format_log_entry(&entry, false).starts_with("[          12.5] "),
+            format_log_entry(&entry, false).starts_with("[        12.500] "),
             "got: {}",
             format_log_entry(&entry, false)
         );
     }
 
     #[test]
-    fn trim_decimals_trims_trailing_zeros_and_point() {
-        assert_eq!(trim_decimals(19.0, 3), "19");
-        assert_eq!(trim_decimals(18.5, 3), "18.5");
-        assert_eq!(trim_decimals(18.9141638, 3), "18.914");
-        assert_eq!(trim_decimals(1814.7135719, 3), "1814.714");
-    }
-
-    #[test]
-    fn trim_decimals_flags_subthreshold_nonzero_values() {
-        // A nonzero value smaller than the 3-decimal resolution must not be
-        // rendered as a bare "0"/"-0" (which would read as exactly zero).
-        assert_eq!(trim_decimals(0.0004, 3), "<0.001");
-        assert_eq!(trim_decimals(-0.0002, 3), ">-0.001");
-        // Exact zero (either sign) renders as plain "0".
-        assert_eq!(trim_decimals(0.0, 3), "0");
-        assert_eq!(trim_decimals(-0.0, 3), "0");
+    fn truncate_decimals_keeps_fixed_precision_without_rounding() {
+        // Always exactly 3 decimals, zero-padded, so a column aligns.
+        assert_eq!(truncate_decimals("19", 3), "19.000");
+        assert_eq!(truncate_decimals("19.0", 3), "19.000");
+        assert_eq!(truncate_decimals("14.78", 3), "14.780");
+        // Truncates, never rounds: 1814.7135… -> .713 (rounding would give .714).
+        assert_eq!(truncate_decimals("1814.7135719023645", 3), "1814.713");
+        assert_eq!(truncate_decimals("18.9148034489", 3), "18.914");
+        // Non-plain input: scientific notation falls back to fixed-point, and a
+        // non-number is passed through untouched.
+        assert_eq!(truncate_decimals("1e3", 3), "1000.000");
+        assert_eq!(truncate_decimals("n/a", 3), "n/a");
     }
 
     #[test]
@@ -4446,7 +4594,7 @@ mod tests {
         let long = "Safety ▸ a property name long enough to wrap on any real terminal width";
         let headers = vec!["STATUS".to_string(), "NAME".to_string()];
         let rows = vec![vec!["failing".to_string(), long.to_string()]];
-        let out = render_table_wrap_last(&headers, &rows, usize::MAX);
+        let out = render_table_wrap_last(&headers, &rows, usize::MAX, &[Align::Left, Align::Left]);
         let row = out.lines().find(|l| l.contains("failing")).unwrap();
         assert!(row.contains(long), "name was wrapped: {out}");
     }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -13,12 +13,12 @@ use serde_json::{Map, Value, json};
 
 use chrono::{DateTime, Local, Utc};
 
-use crate::api::{
-    AntithesisApi, Event, Property, PropertyStatus, RunDetail, RunStatus, RunSummary,
-    RunsFilterOptions,
-};
 #[cfg(test)]
-use crate::api::{EventProperty, Moment, NonEventProperty};
+use crate::api::Moment;
+use crate::api::{
+    AntithesisApi, Event, EventProperty, NonEventProperty, Property, PropertyStatus, RunDetail,
+    RunStatus, RunSummary, RunsFilterOptions,
+};
 use crate::cli::{RunsCommands, RunsListArgs};
 use crate::error::{api_error_status, user_error};
 
@@ -390,7 +390,8 @@ async fn cmd_runs_properties(
     // substring matches.
     if let Some(group) = filter.group {
         let needle = group.to_lowercase();
-        properties.retain(|p| property_group(p).is_some_and(|g| g.to_lowercase().contains(&needle)));
+        properties
+            .retain(|p| property_group(p).is_some_and(|g| g.to_lowercase().contains(&needle)));
     }
     if let Some(name) = filter.name {
         let needle = name.to_lowercase();
@@ -699,31 +700,87 @@ fn render_property_detail(property: &Property) -> String {
             },
         ));
     }
-    if let Some(value) = single_numeric_value(property) {
-        // A single-metric property (e.g. "Total non-blank lines") — show the
-        // number inline rather than a whole Examples section.
-        out.push_str(&format!("Example   {value}"));
-    } else {
-        out.push('\n');
-        out.push_str(&indent_lines(&render_property_examples(property), "  "));
+    match property {
+        // Event properties have moments — the user feeds a HASH/VTIME into
+        // `runs logs`, so they get an `Examples:` table.
+        Property::EventProperty(p) => {
+            out.push_str("Examples:\n");
+            out.push_str(&indent_lines(&render_moments_table(p), "  "));
+        }
+        // Non-event "system" properties have no moments; their examples chunk
+        // just carries detail values, so show them under a `Result` label rather
+        // than conflating with examples/counter-examples.
+        Property::NonEventProperty(p) => out.push_str(&render_result(p)),
     }
     out
 }
 
-/// The lone numeric value of a non-event property, when its examples and
-/// counterexamples together are exactly one number.
-fn single_numeric_value(property: &Property) -> Option<String> {
-    let Property::NonEventProperty(p) = property else {
-        return None;
-    };
-    let mut values = p.examples.iter().chain(p.counterexamples.iter());
-    let first = values.next()?;
-    if values.next().is_some() {
-        return None;
+/// The STATUS/HASH/VTIME table for an event property's moments: counterexamples
+/// (failing) first, then examples (passing), each ascending by vtime.
+fn render_moments_table(p: &EventProperty) -> String {
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for event in sorted_by_vtime(&p.counterexamples) {
+        rows.push(vec![
+            "failing".to_string(),
+            sanitize(&event.moment.input_hash),
+            sanitize(&event.moment.vtime),
+        ]);
     }
-    match first {
-        Value::Number(n) => Some(n.to_string()),
-        _ => None,
+    for event in sorted_by_vtime(&p.examples) {
+        rows.push(vec![
+            "passing".to_string(),
+            sanitize(&event.moment.input_hash),
+            sanitize(&event.moment.vtime),
+        ]);
+    }
+    if rows.is_empty() {
+        return "(none — property was unreachable)".to_string();
+    }
+    let headers = vec![
+        "STATUS".to_string(),
+        "HASH".to_string(),
+        "VTIME".to_string(),
+    ];
+    render_table(&headers, &rows)
+}
+
+/// The `Result` for a non-event property — its example values. A lone value is
+/// rendered directly (scalar inline, object/array as indented JSON); multiple
+/// values are rendered as a single indented JSON array.
+fn render_result(p: &NonEventProperty) -> String {
+    let values: Vec<&Value> = p.examples.iter().chain(p.counterexamples.iter()).collect();
+    match values.as_slice() {
+        [] => "Result    (none)".to_string(),
+        [one] => render_single_result(one),
+        // Multiple values are collapsed into a single JSON array.
+        many => render_json_result(&Value::Array(many.iter().map(|v| (*v).clone()).collect())),
+    }
+}
+
+/// A single `Result` value: a scalar inline next to an aligned `Result` label, an
+/// object/array via [`render_json_result`].
+fn render_single_result(value: &Value) -> String {
+    match value {
+        Value::Array(_) | Value::Object(_) => render_json_result(value),
+        Value::String(s) => format!("Result    {}", sanitize(s)),
+        Value::Number(n) => format!("Result    {n}"),
+        Value::Bool(b) => format!("Result    {b}"),
+        Value::Null => "Result    null".to_string(),
+    }
+}
+
+/// Render a JSON object/array `Result`: inline (`Result: {...}`) when its compact
+/// one-line form fits the terminal (capped at 100 cols, so piped output where the
+/// width is unbounded still inlines only genuinely small values), otherwise as an
+/// indented pretty-printed block under `Result:`.
+fn render_json_result(value: &Value) -> String {
+    let compact = serde_json::to_string(value).unwrap_or_default();
+    let inline = format!("Result: {compact}");
+    if inline.chars().count() <= terminal_width().min(100) {
+        inline
+    } else {
+        let pretty = serde_json::to_string_pretty(value).unwrap_or_default();
+        format!("Result:\n{}", indent_lines(&pretty, "  "))
     }
 }
 
@@ -758,73 +815,6 @@ fn sorted_by_vtime(events: &[Event]) -> Vec<&Event> {
         }
     });
     sorted
-}
-
-fn render_property_examples(property: &Property) -> String {
-    match property {
-        // Event properties are moments — a STATUS/HASH/VTIME table (the API
-        // guarantees no ordering, so sort each group numerically by vtime;
-        // counterexamples first, then examples). A moment feeds `runs logs`.
-        Property::EventProperty(p) => {
-            let mut rows: Vec<Vec<String>> = Vec::new();
-            for event in sorted_by_vtime(&p.counterexamples) {
-                rows.push(vec![
-                    "failing".to_string(),
-                    sanitize(&event.moment.input_hash),
-                    sanitize(&event.moment.vtime),
-                ]);
-            }
-            for event in sorted_by_vtime(&p.examples) {
-                rows.push(vec![
-                    "passing".to_string(),
-                    sanitize(&event.moment.input_hash),
-                    sanitize(&event.moment.vtime),
-                ]);
-            }
-            if rows.is_empty() {
-                return "Examples:\n  (none — property was unreachable)".to_string();
-            }
-            let headers = vec![
-                "STATUS".to_string(),
-                "HASH".to_string(),
-                "VTIME".to_string(),
-            ];
-            format!("Examples:\n{}", render_table(&headers, &rows))
-        }
-        // Non-event properties carry arbitrary JSON values, so render each
-        // example/counterexample as its own labelled block — the values *are*
-        // the content, and a `{N fields}` placeholder table only hid them.
-        Property::NonEventProperty(p) => {
-            let mut blocks: Vec<String> = Vec::new();
-            for value in &p.counterexamples {
-                blocks.push(render_value_example("failing", value));
-            }
-            for value in &p.examples {
-                blocks.push(render_value_example("passing", value));
-            }
-            if blocks.is_empty() {
-                return "Examples:\n  (none — property was unreachable)".to_string();
-            }
-            format!("Examples:\n\n{}", blocks.join("\n\n"))
-        }
-    }
-}
-
-/// Render one non-event example/counterexample: a `<status>:` label followed by
-/// its value — a scalar inline, an object/array as indented pretty JSON.
-fn render_value_example(status: &str, value: &Value) -> String {
-    match value {
-        Value::Array(items) if items.is_empty() => format!("{status}: (no value)"),
-        Value::Object(map) if map.is_empty() => format!("{status}: (no value)"),
-        Value::Array(_) | Value::Object(_) => {
-            let pretty = serde_json::to_string_pretty(value).unwrap_or_default();
-            format!("{status}:\n{}", indent_lines(&pretty, "  "))
-        }
-        Value::Null => format!("{status}: null"),
-        Value::Bool(b) => format!("{status}: {b}"),
-        Value::Number(n) => format!("{status}: {n}"),
-        Value::String(s) => format!("{status}: {}", sanitize(s)),
-    }
 }
 
 fn indent_lines(text: &str, prefix: &str) -> String {
@@ -2925,16 +2915,25 @@ mod tests {
         assert_eq!(format_count_si(999999), "1.0M");
     }
 
+    fn event_prop(
+        status: PropertyStatus,
+        examples: Vec<Event>,
+        counterexamples: Vec<Event>,
+    ) -> EventProperty {
+        match event_property("Counter", status, None, examples, counterexamples) {
+            Property::EventProperty(p) => p,
+            _ => unreachable!(),
+        }
+    }
+
     #[test]
-    fn render_event_property_examples_uses_status_column() {
-        let property = event_property(
-            "Counter",
+    fn render_moments_table_uses_status_column() {
+        let p = event_prop(
             PropertyStatus::Failing,
-            None,
             vec![event("ex", "2.0")],
             vec![event("cex", "1.0")],
         );
-        let out = render_property_examples(&property);
+        let out = render_moments_table(&p);
         assert!(out.contains("STATUS"));
         assert!(out.contains("HASH"));
         assert!(out.contains("VTIME"));
@@ -2943,17 +2942,15 @@ mod tests {
     }
 
     #[test]
-    fn render_event_property_examples_sorts_each_group_by_vtime() {
+    fn render_moments_table_sorts_each_group_by_vtime() {
         // API order is arbitrary; rows must come out failing-first, then passing,
         // each ascending by vtime numerically (5.0 < 10.0, not lexically).
-        let property = event_property(
-            "Counter",
+        let p = event_prop(
             PropertyStatus::Failing,
-            None,
             vec![event("ex-b", "20.0"), event("ex-a", "2.0")],
             vec![event("cex-b", "10.0"), event("cex-a", "5.0")],
         );
-        let out = render_property_examples(&property);
+        let out = render_moments_table(&p);
         let rows: Vec<&str> = out
             .lines()
             .filter(|l| l.contains("failing") || l.contains("passing"))
@@ -2967,7 +2964,7 @@ mod tests {
     }
 
     #[test]
-    fn render_non_event_property_examples_pretty_prints_objects() {
+    fn render_non_event_detail_shows_result_not_examples() {
         let property = non_event_property(
             "Determinator Max Memory",
             PropertyStatus::Passing,
@@ -2977,14 +2974,13 @@ mod tests {
             })],
             vec![],
         );
-        let out = render_property_examples(&property);
-        // No placeholder table — each example renders as its own labelled block
-        // under an "Examples:" header, with the object shown as pretty JSON.
-        assert!(out.contains("Examples:"), "got: {out}");
-        assert!(out.contains("passing:"));
+        let out = render_property_detail(&property);
+        // A non-event property's value shows under a `Result:` label as pretty
+        // JSON — never the moment-oriented `Examples:`/`passing:` machinery.
+        assert!(out.contains("Result:"), "got: {out}");
         assert!(out.contains("maximum_used_bytes"));
-        assert!(!out.contains("{2 fields}"));
-        assert!(!out.contains("row 1 details:"));
+        assert!(!out.contains("Examples:"));
+        assert!(!out.contains("passing:"));
     }
 
     #[test]
@@ -3012,32 +3008,72 @@ mod tests {
         // No Group key/value line (the heading carries it) and no rule separator.
         assert!(!out.contains("Group     Safety"));
         assert!(!out.contains('─'));
-        // Each property keeps its header and an Examples section, indented.
+        // Each property keeps its header and an Examples section whose table is
+        // indented beneath the (column-0) "Examples:" label.
         assert!(out.contains("Name      First"));
         assert_eq!(out.matches("Examples:").count(), 2);
-        assert!(out.contains("  Examples:"), "examples should be indented\n{out}");
+        assert!(
+            out.contains("Examples:\n  STATUS"),
+            "examples table should be indented\n{out}"
+        );
     }
 
     #[test]
-    fn render_property_detail_inlines_a_single_numeric_value() {
-        let property = non_event_property(
-            "Total non-blank lines in notebook file",
+    fn render_property_detail_result_forms() {
+        // A lone scalar sits inline next to an aligned `Result` label.
+        for (value, expected) in [
+            (json!(1234), "Result    1234"),
+            (json!("n2-standard-4"), "Result    n2-standard-4"),
+            (json!(true), "Result    true"),
+        ] {
+            let p = non_event_property("Metric", PropertyStatus::Passing, vec![value], vec![]);
+            let out = render_property_detail(&p);
+            assert!(out.contains(expected), "got: {out}");
+            assert!(!out.contains("Examples:"));
+        }
+
+        // Tiny objects/arrays are inlined after `Result:` (compact one-line JSON).
+        let empty = non_event_property("E", PropertyStatus::Passing, vec![json!([])], vec![]);
+        assert!(
+            render_property_detail(&empty).contains("Result: []"),
+            "empty array"
+        );
+        let tiny = non_event_property("T", PropertyStatus::Passing, vec![json!({"k": 1})], vec![]);
+        assert!(
+            render_property_detail(&tiny).contains(r#"Result: {"k":1}"#),
+            "tiny object"
+        );
+
+        // A large object spills to an indented pretty-printed block.
+        let big = non_event_property(
+            "Big",
             PropertyStatus::Passing,
-            vec![json!(1234)],
+            vec![json!({
+                "session_id": "dfa97857ebbbc219f543e423fea597fd-54-8",
+                "total_output_mb": 11773,
+                "total_output_rate": "35.05274518966351"
+            })],
             vec![],
         );
-        let out = render_property_detail(&property);
-        // A lone numeric value is shown inline after the header, no Examples block.
-        assert!(out.contains("Example   1234"), "got: {out}");
+        let out = render_property_detail(&big);
+        assert!(
+            out.contains("Result:\n  {"),
+            "big object should be a block\n{out}"
+        );
+        assert!(out.contains("total_output_mb"));
         assert!(!out.contains("Examples:"));
-        // An object value still renders as an Examples block.
-        let obj = non_event_property(
-            "Build did not exceed expected limit",
+
+        // Several small values collapse into one inline JSON array.
+        let multi = non_event_property(
+            "Two values",
             PropertyStatus::Passing,
-            vec![json!({"target": "x", "kb": 0})],
+            vec![json!(1), json!(2)],
             vec![],
         );
-        assert!(render_property_detail(&obj).contains("Examples:"));
+        assert!(
+            render_property_detail(&multi).contains("Result: [1,2]"),
+            "multi inline"
+        );
     }
 
     #[test]
@@ -3155,10 +3191,9 @@ mod tests {
     }
 
     #[test]
-    fn render_event_property_examples_marks_unreachable_when_empty() {
-        let property = event_property("Maybe ran", PropertyStatus::Passing, None, vec![], vec![]);
-        let out = render_property_examples(&property);
-        assert!(out.contains("unreachable"));
+    fn render_moments_table_marks_unreachable_when_empty() {
+        let p = event_prop(PropertyStatus::Passing, vec![], vec![]);
+        assert!(render_moments_table(&p).contains("unreachable"));
     }
 
     #[test]
@@ -3219,20 +3254,12 @@ mod tests {
     }
 
     #[test]
-    fn render_non_event_example_renders_empty_collection_inline() {
-        // An empty array/object renders as "(no value)" rather than an empty
-        // pretty-printed block.
-        assert_eq!(
-            render_value_example("passing", &json!([])),
-            "passing: (no value)"
-        );
-        assert_eq!(
-            render_value_example("passing", &json!({})),
-            "passing: (no value)"
-        );
-        // A scalar renders inline; an object renders as an indented JSON block.
-        assert_eq!(render_value_example("failing", &json!(42)), "failing: 42");
-        assert!(render_value_example("passing", &json!({"k": 1})).starts_with("passing:\n  {"));
+    fn render_result_handles_no_values() {
+        // A non-event property with no values at all -> "(none)".
+        let empty = non_event_property("Empty", PropertyStatus::Passing, vec![], vec![]);
+        let out = render_property_detail(&empty);
+        assert!(out.contains("Result    (none)"), "got: {out}");
+        assert!(!out.contains("Examples:"));
     }
 
     #[test]

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -619,12 +619,16 @@ fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, St
     let after = mock_query_param(query, "after");
 
     let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"15.0"}}],"counterexamples":[{"moment":{"input_hash":"-200","vtime":"10.0"}},{"moment":{"input_hash":"-100","vtime":"5.0"}}]}"#.to_string();
+    // A failing non-event ("system") property: the violating value lives in
+    // `counterexamples`, so `--detail` must label it apart from the satisfying
+    // `examples`.
+    let failing_nonevent = r#"{"name":"Peak memory stays below cap","description":"Peak memory never exceeds the configured limit","status":"Failing","is_event":false,"group":"Resources","example_count":2,"counterexample_count":1,"examples":[820,910],"counterexamples":[1340]}"#.to_string();
     let passing = r#"{"name":"Setup completes","description":"Setup eventually succeeds","status":"Passing","is_event":false,"example_count":1,"counterexample_count":0,"examples":[{"final_counter":42}]}"#.to_string();
 
     let (data, next_cursor) = match (status.as_deref(), after.as_deref()) {
-        (Some("Failing"), _) => (vec![failing], None),
+        (Some("Failing"), _) => (vec![failing, failing_nonevent], None),
         (Some("Passing"), _) => (vec![passing], None),
-        (None, None) => (vec![failing], Some("props-cursor-1")),
+        (None, None) => (vec![failing, failing_nonevent], Some("props-cursor-1")),
         (None, Some("props-cursor-1")) => (vec![passing], None),
         (None, _) => (vec![], None),
         _ => (vec![], None),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -12,6 +12,7 @@ use tokio::time::{Duration, sleep};
 use crate::cli::ValidateArgs;
 use crate::config::{self, ComposeConfig, Config, KubernetesConfig};
 use crate::container;
+use crate::error::user_error;
 use crate::scripts::{ScriptType, TestScript, scan_scripts};
 
 const K8S_VALIDATOR_IMAGE: &str = "docker.io/antithesishq/k8s-validator:1.0.0";
@@ -45,7 +46,7 @@ fn generate_setup_override(
     temp_dir: &Path,
 ) -> Result<PathBuf> {
     if contents.services.is_empty() {
-        bail!("no services found in docker-compose.yaml");
+        return Err(user_error("no services found in docker-compose.yaml"));
     }
 
     let antithesis_dir = temp_dir.join("antithesis");
@@ -133,12 +134,18 @@ fn generate_setup_override(
 fn mkdir_or_require_empty(path: &Path) -> Result<()> {
     if path.exists() {
         if !path.is_dir() {
-            bail!("{} exists but is not a directory", path.display());
+            return Err(user_error(format!(
+                "{} exists but is not a directory",
+                path.display()
+            )));
         }
         let mut entries = std::fs::read_dir(path)
             .wrap_err_with(|| format!("failed to read directory {}", path.display()))?;
         if entries.next().is_some() {
-            bail!("{} exists but is not empty", path.display());
+            return Err(user_error(format!(
+                "{} exists but is not empty",
+                path.display()
+            )));
         }
         Ok(())
     } else {
@@ -489,7 +496,7 @@ fn discover_scripts(
         && not_executable.is_empty()
         && cp_failures.len() == containers.len()
     {
-        let mut err = eyre!("failed to extract test commands from every container");
+        let mut err = user_error("failed to extract test commands from every container");
         for (label, cause) in &cp_failures {
             err = err.with_section(|| format!("{label}: {cause:?}").header("Container:"));
         }
@@ -515,7 +522,7 @@ fn combined_discovery_error(
     not_executable: BTreeMap<String, BTreeSet<String>>,
     stopped_with_scripts: BTreeSet<String>,
 ) -> color_eyre::Report {
-    let mut err = eyre!("test command discovery failed");
+    let mut err = user_error("test command discovery failed");
 
     for (service, commands) in &unrecognized {
         let listing = commands

--- a/tests/cli_docs.rs
+++ b/tests/cli_docs.rs
@@ -258,9 +258,8 @@ fn docs_search_missing_db_with_offline_tells_user_to_remove_offline() {
         .args(["docs", "--offline", "search", "docker"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "Documentation database not found. Remove --offline to download it.",
-        ));
+        .stderr(predicate::str::contains("Documentation database not found"))
+        .stderr(predicate::str::contains("remove --offline to download it"));
 }
 
 #[test]
@@ -271,7 +270,10 @@ fn docs_sqlite_missing_db_with_env_path_tells_user_to_fix_path() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Documentation database not found at /tmp/does-not-exist-docs.db. Point ANTITHESIS_DOCS_DB_PATH at an existing file.",
+            "Documentation database not found at /tmp/does-not-exist-docs.db",
+        ))
+        .stderr(predicate::str::contains(
+            "point ANTITHESIS_DOCS_DB_PATH at an existing file",
         ));
 }
 
@@ -348,7 +350,7 @@ fn docs_show_partial_match_suggests() {
         .args(["docs", "--offline", "show", "sdk"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Did you mean"))
+        .stderr(predicate::str::contains("did you mean"))
         .stderr(predicate::str::contains("/docs/sdk/python_sdk/"));
 }
 
@@ -364,7 +366,7 @@ fn docs_show_generated_sdk_page_points_at_language_index() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "The rust SDK reference docs are not part of the offline docs.",
+            "the rust SDK reference docs are not part of the offline docs",
         ))
         .stderr(predicate::str::contains(
             "https://antithesis.com/docs/generated/sdk/rust/antithesis_sdk/",
@@ -381,7 +383,7 @@ fn docs_show_generated_sdk_resolves_go_alias_to_golang() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "The golang SDK reference docs are not part of the offline docs.",
+            "the golang SDK reference docs are not part of the offline docs",
         ))
         .stderr(predicate::str::contains(
             "https://antithesis.com/docs/generated/sdk/golang/",
@@ -397,10 +399,10 @@ fn docs_show_generated_sdk_unknown_language_uses_generic_hint() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "generated pages (e.g. SDK references) are not included in the offline docs.",
+            "generated pages (e.g. SDK references) are not included in the offline docs",
         ))
         .stderr(predicate::str::contains(
-            "If this is a valid page, try: https://antithesis.com/docs/generated/sdk/cpp/assert/",
+            "if this is a valid page, try https://antithesis.com/docs/generated/sdk/cpp/assert/",
         ));
 }
 
@@ -416,7 +418,7 @@ fn docs_show_generated_sdk_page_from_full_url_points_at_language_index() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "The golang SDK reference docs are not part of the offline docs.",
+            "the golang SDK reference docs are not part of the offline docs",
         ))
         .stderr(predicate::str::contains(
             "https://antithesis.com/docs/generated/sdk/golang/",
@@ -442,10 +444,10 @@ fn docs_show_generated_root_hints_live_url() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "generated pages (e.g. SDK references) are not included in the offline docs.",
+            "generated pages (e.g. SDK references) are not included in the offline docs",
         ))
         .stderr(predicate::str::contains(
-            "If this is a valid page, try: https://antithesis.com/docs/generated/",
+            "if this is a valid page, try https://antithesis.com/docs/generated/",
         ));
 }
 

--- a/tests/cli_launch_config.rs
+++ b/tests/cli_launch_config.rs
@@ -68,7 +68,7 @@ fn launch_config_rejects_yml_extension() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("requires docker-compose.yaml"));
+        .stderr(predicate::str::contains("rename it to docker-compose.yaml"));
 }
 
 #[test]


### PR DESCRIPTION
Polishes snouty's human-facing CLI output, help text, and error rendering, driven by the gallery satisfaction reviews. The headline change folds the `runs property` subcommand into `runs properties` and reworks how properties and their examples render; alongside it, every error now prints through one clean report format.

- `runs logs` renders vtime at a fixed 3 decimals, **truncated** (not rounded), so a value copied off-screen into `--begin-vtime` lands on — never past — the line you saw, and the decimal column stays aligned.
- `runs events` searches a run's events for one or more substrings and prints the matching rows. SOURCE auto-sizes to its widest cell, the OUTPUT cell is whitespace-trimmed, and on a real terminal the OUTPUT column is windowed around the first match — centered on it with an ellipsis marking each truncated edge — so the hit you searched for stays visible; piped output is left full.
- `runs properties` renders one table per group (the group is the section heading), with the EXAMPLES count right-aligned and SI-shortened (`2.3k`, `18M`) and counterexamples shown inline as `examples/counterexamples` when present. Ungrouped properties go in a trailing "(ungrouped)" section.
- The `runs property` subcommand is removed and folded into `runs properties`: narrow with `--name` (case-insensitive substring) and/or `--group`, and add `--detail` to expand the matches. Appending a filter is far quicker than swapping the subcommand word, and this drops the fuzzy/ambiguous/not-found resolution entirely (a filter that matches nothing just prints a friendly empty state).
- In `--detail`, event properties show an `Examples` moment table (the HASH/VTIME you paste into `runs logs`); non-event "system" properties — which store data, not moments — show their value under a `Result` label instead (a scalar inline, an object/array inline when it fits the terminal, otherwise pretty-printed JSON). A *failing* non-event property carries its violating value in counterexamples, which `--detail` labels under `Counter-examples` (shown first), distinct from the satisfying `Examples`, so the offending value isn't lost in an unlabelled list. `--detail` errors when combined with `--json`, on both `runs properties` and `runs list`.
- `runs show` prints `Failure Hash` before `Failure VTime` (matching the `runs logs <hash> <vtime>` argument order) and hands over a ready-to-paste `snouty runs logs …` command for incomplete runs, the way the `--web` hint does for the report.
- Errors now render through one report format. User-facing failures (and 4xx API errors) print cleanly — a plain statement of what went wrong plus any `.note()`/`.suggestion()`/`.section()` hints, with no backtrace — while genuine internal faults keep theirs. This replaces the `is_user_error` / `{:#}`-vs-`{:?}` branching in `main` with a single rendering, drops the env-section footer, and emits color only to a TTY (pipes and tests get plain text). The why, the remediation, and the diagnostic detail move out of the message and into notes/suggestions/sections; applied across runs, api, main, params, moment, config, docs, validate, and doctor, with bad args, config layout, missing env vars, missing docs db, and version-gated resources classified as user errors while network/runtime/serialization faults stay internal.
- `--help` is overhauled across every command: output legends and examples on the read/stream commands, a consistent option layout, the global `--json`/`--verbose` flags sorted to the bottom so each command's own flags stay grouped, `--duration` documented as minutes, and the `launch --config` wall trimmed.
- `gen-gallery.py` now renders each command's `--help` next to its default output as "help stories", with an automated check that any column the help names actually appears in the output — so the help can be reviewed for clarity and alignment, not just the command output. A help story whose default command exits non-zero now fails the run (doctor excepted). AGENTS.md gains a `scripts/` section (Python helpers run via `uv`, type-checked with `uvx pyright`), a top-level `CLAUDE.md` points at it, and Python bytecode is gitignored. Its non-event property discovery now recognizes snouty's bare `Result` label (the no-colon form used for object/array values) and probes several candidates instead of bailing on the first, so one oddly-rendering property can no longer abort generation of the whole gallery.

Co-Authored-By: Claude <noreply@anthropic.com>

