### PR TITLE
update: accept an explicit version, guard downgrades behind --force

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3"
 pulldown-cmark = "0.13"
 libc = "0.2"
 regex = "1"
+semver = "1"
 ptree = { version = "0.5.2", default-features = false }
 serde_yaml = "0.9"
 

--- a/specs/update.txt
+++ b/specs/update.txt
@@ -7,3 +7,18 @@
 snouty update
 stderr 'snouty \d+\.\d+\.\d+'
 stderr 'https://github.com/antithesishq/snouty/releases'
+
+# A non-semver version argument is rejected before anything is spawned.
+! snouty update not-a-version
+stderr '.*invalid version.*'
+
+# Installing a version older than the current one is a downgrade, refused
+# without --force. The hint points at the flag.
+! snouty update 0.0.1
+stderr '.*downgrade.*'
+stderr '.*--force.*'
+
+# --force allows the downgrade; with no helper installed it then falls back to
+# the manual update instructions.
+snouty update 0.0.1 --force
+stderr '.*https://github.com/antithesishq/snouty/releases.*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,8 +169,16 @@ Example:
 
 Runs the bundled `snouty-update` helper, which checks for a newer release and
 replaces the snouty binary in place. Does nothing if `snouty-update` is not
-installed alongside snouty."#)]
-    Update,
+installed alongside snouty.
+
+Pass a version to install a specific release instead of the latest, including
+pre-releases:
+  snouty update 0.6.0
+  snouty update 0.6.0-rc.1
+
+Installing a version older than the one you're running is a downgrade and
+requires --force."#)]
+    Update(UpdateArgs),
 
     /// Search Antithesis documentation
     #[command(long_about = r#"Search Antithesis documentation
@@ -253,6 +261,16 @@ If the exact path is not found, suggests similar pages."#)]
         /// Page path (e.g. "getting_started/overview")
         path: String,
     },
+}
+
+#[derive(Args)]
+pub struct UpdateArgs {
+    /// Release to install (e.g. 0.6.0 or 0.6.0-rc.1). Defaults to the latest release.
+    pub version: Option<String>,
+
+    /// Install the requested version even if it is older than the current one (a downgrade)
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,9 @@ use log::{debug, info};
 
 use color_eyre::Section;
 use color_eyre::eyre::{Context, Result};
+use semver::Version;
 use snouty::api::AntithesisApi;
-use snouty::cli::{Cli, Commands, DebugArgs, LaunchArgs};
+use snouty::cli::{Cli, Commands, DebugArgs, LaunchArgs, UpdateArgs};
 use snouty::config;
 use snouty::container;
 use snouty::docs;
@@ -108,7 +109,7 @@ async fn run(cli: Cli) -> Result<()> {
             println!("snouty {}", env!("CARGO_PKG_VERSION"));
             Ok(())
         }
-        Commands::Update => cmd_update(),
+        Commands::Update(args) => cmd_update(args),
         Commands::Docs { offline, command } => docs::cmd_docs(command, offline, json).await,
     };
 
@@ -145,7 +146,7 @@ fn json_unaware_command_name(command: &Commands) -> Option<&'static str> {
         Commands::Doctor => Some("doctor"),
         Commands::Completions { .. } => Some("completions"),
         Commands::Version => Some("version"),
-        Commands::Update => Some("update"),
+        Commands::Update(_) => Some("update"),
     }
 }
 
@@ -336,9 +337,43 @@ fn cmd_completions(shell: Shell) -> Result<()> {
     Ok(())
 }
 
-fn cmd_update() -> Result<()> {
-    // Attempt to spawn snouty-update and wait for it to finish
-    match Command::new("snouty-update").status() {
+/// Validate a requested update target against the running version.
+///
+/// Errors if `requested` isn't valid semver, or if it's older than `current`
+/// and the downgrade wasn't forced. `current` is snouty's own
+/// `CARGO_PKG_VERSION`, which is always valid semver. Semver pre-release
+/// ordering applies, so e.g. `0.6.0-rc.1` is a downgrade from `0.6.0`.
+fn check_update_target(requested: &str, current: &str, force: bool) -> Result<()> {
+    let target = Version::parse(requested).map_err(|_| {
+        user_error(format!(
+            "invalid version `{requested}`: expected a semver release like 0.6.0 or 0.6.0-rc.1"
+        ))
+    })?;
+    let current = Version::parse(current).expect("snouty's own version is always valid semver");
+    if target < current && !force {
+        return Err(user_error(format!(
+            "{requested} is older than the installed snouty {current}; this would be a downgrade"
+        ))
+        .suggestion("re-run with --force to install an older version"));
+    }
+    Ok(())
+}
+
+fn cmd_update(args: UpdateArgs) -> Result<()> {
+    // When a specific version is requested, validate it and refuse an unforced
+    // downgrade up front, before bothering to spawn the helper.
+    if let Some(version) = &args.version {
+        check_update_target(version, env!("CARGO_PKG_VERSION"), args.force)?;
+    }
+
+    // Attempt to spawn snouty-update and wait for it to finish. An explicit
+    // version is forwarded via --version; the helper installs it directly
+    // (pre-releases included), so we never need --prerelease here.
+    let mut updater = Command::new("snouty-update");
+    if let Some(version) = &args.version {
+        updater.arg("--version").arg(version);
+    }
+    match updater.status() {
         Ok(status) if status.success() => {
             std::process::exit(0);
         }
@@ -418,5 +453,46 @@ mod tests {
         assert!(report.downcast_ref::<io::Error>().is_none());
         // ...so the report can never be suppressed.
         assert!(suppress_broken_pipe(Err(report)).is_err());
+    }
+
+    #[test]
+    fn check_update_target_allows_upgrade() {
+        assert!(check_update_target("0.6.0", "0.5.0", false).is_ok());
+    }
+
+    #[test]
+    fn check_update_target_allows_reinstalling_same_version() {
+        assert!(check_update_target("0.5.0", "0.5.0", false).is_ok());
+    }
+
+    #[test]
+    fn check_update_target_blocks_unforced_downgrade() {
+        let err = check_update_target("0.4.0", "0.5.0", false).unwrap_err();
+        let rendered = format!("{err}");
+        assert!(rendered.contains("downgrade"), "got: {rendered}");
+    }
+
+    #[test]
+    fn check_update_target_allows_forced_downgrade() {
+        assert!(check_update_target("0.4.0", "0.5.0", true).is_ok());
+    }
+
+    #[test]
+    fn check_update_target_treats_prerelease_as_downgrade_of_release() {
+        // Semver orders 0.6.0-rc.1 before the final 0.6.0, so installing the rc
+        // over the release is a downgrade.
+        let err = check_update_target("0.6.0-rc.1", "0.6.0", false).unwrap_err();
+        assert!(format!("{err}").contains("downgrade"));
+    }
+
+    #[test]
+    fn check_update_target_allows_prerelease_above_current() {
+        assert!(check_update_target("0.6.0-rc.1", "0.5.0", false).is_ok());
+    }
+
+    #[test]
+    fn check_update_target_rejects_invalid_version() {
+        let err = check_update_target("not-a-version", "0.5.0", false).unwrap_err();
+        assert!(format!("{err}").contains("invalid version"));
     }
 }


### PR DESCRIPTION
`snouty update` previously only ever installed the latest release. It now accepts an optional version argument and forwards it to the bundled `snouty-update` helper via `--version`, which installs that exact release — pre-releases included:

```
snouty update 0.6.0
snouty update 0.6.0-rc.1
```

With no argument it still installs the latest release, so existing usage is unchanged.

Before spawning the helper, snouty validates the requested version and refuses to install one older than the version you're running — a downgrade — unless you pass `--force`. Semver pre-release ordering applies, so `0.6.0-rc.1` counts as a downgrade from `0.6.0`. Note that requesting the version you already have is a no-op: the helper compares version numbers, not artifact contents.

Adds a `semver` dependency for the comparison, unit tests for the version check, and spec coverage for the new argument and `--force`.
