### PR TITLE
config image: report digest-only ref, drop the :tag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -400,8 +400,8 @@ property has counterexamples.
 
 Narrow with --name and/or --group (both case-insensitive substring matches);
 add --detail to expand the matches into their examples and counter-example
-moments instead of the table. Use --json for automation (it always emits the
-full data).
+moments instead of the table. Use --json for automation. --json is mutually
+exclusive with --detail.
 
 Examples:
   snouty runs properties <run_id> --failing

--- a/src/container.rs
+++ b/src/container.rs
@@ -296,7 +296,10 @@ pub trait ContainerRuntime: Send + Sync {
         self.build_image(config_dir, image_ref, None, Some("linux/amd64"))?;
 
         eprintln!("Pushing config image: {}", image_ref);
-        let pinned = self.image_push(image_ref)?;
+        // image_push pins to `name:tag@digest`, but Antithesis's config-image
+        // validator rejects a reference carrying both a :tag and an @digest
+        // (a bug in the validator), so identify the image by digest alone.
+        let pinned = digest_only_ref(&self.image_push(image_ref)?);
         eprintln!("Config image pushed successfully: {pinned}");
         Ok(pinned)
     }
@@ -1194,6 +1197,16 @@ fn pinned_image_ref(image_ref: &str, digest: &str) -> String {
     match image_ref.rfind('@') {
         Some(at) => format!("{}@{}", &image_ref[..at], digest),
         None => format!("{image_ref}@{digest}"),
+    }
+}
+
+/// Drop the `:tag` from a digest-pinned reference, leaving `name@digest`.
+/// The digest fully identifies the image, and Antithesis's config-image
+/// validator rejects a reference that carries both a tag and a digest.
+fn digest_only_ref(image_ref: &str) -> String {
+    match image_ref.rfind('@') {
+        Some(at) => format!("{}{}", image_repo(image_ref), &image_ref[at..]),
+        None => image_ref.to_string(),
     }
 }
 
@@ -2734,6 +2747,38 @@ tag2: digest: sha256:bbb222 size: 200
         assert_eq!(
             pinned_image_ref("registry.example.com/team/service@sha256:old", "sha256:new"),
             "registry.example.com/team/service@sha256:new"
+        );
+    }
+
+    #[test]
+    fn digest_only_ref_strips_tag() {
+        assert_eq!(
+            digest_only_ref("example.com/foo/snouty-config:20260615-abcd@sha256:abc123"),
+            "example.com/foo/snouty-config@sha256:abc123"
+        );
+    }
+
+    #[test]
+    fn digest_only_ref_with_port_strips_tag() {
+        assert_eq!(
+            digest_only_ref("localhost:5000/snouty-config:latest@sha256:abc123"),
+            "localhost:5000/snouty-config@sha256:abc123"
+        );
+    }
+
+    #[test]
+    fn digest_only_ref_already_digest_only() {
+        assert_eq!(
+            digest_only_ref("example.com/foo/snouty-config@sha256:abc123"),
+            "example.com/foo/snouty-config@sha256:abc123"
+        );
+    }
+
+    #[test]
+    fn digest_only_ref_no_digest_unchanged() {
+        assert_eq!(
+            digest_only_ref("example.com/foo/snouty-config:v1"),
+            "example.com/foo/snouty-config:v1"
         );
     }
 


### PR DESCRIPTION
Antithesis's config-image validator rejects a reference that carries both a `:tag` and an `@digest` (a bug in the validator). `image_push` pins the pushed config image to `name:tag@digest`, and that combined ref is what gets sent as the `antithesis.config_image` param — tripping the validator.

This strips the tag from the reported config image ref, leaving `name@digest`. The build and push still use the unique timestamped tag from `generate_image_ref`, so concurrent runs don't clobber each other in the registry; only the ref reported back as the config image drops the tag. Service-image refs baked into the compose YAML are unaffected and keep their tag for provenance.

Also includes a minor help-text tweak noting that `runs properties --json` is mutually exclusive with `--detail`.