### PR TITLE
feat: support --run-id on snouty debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snouty"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snouty"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "A CLI tool for using the Antithesis API"
 license = "Apache-2.0"

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -43,7 +43,7 @@ stderr 'specify --run-id or --session-id.*'
 # Parameters are provided as typed flags. Before sending, the resolved
 #    parameters are printed to stderr with sensitive values redacted. The
 #    target run is identified by --run-id (preferred for new integrations).
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890 --description 'debug this moment' --recipients team@example.com
 stderr '"antithesis.debugging.input_hash": "abc123"'
 stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
@@ -52,7 +52,7 @@ stderr '"antithesis.event_description": "debug this moment"'
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
 # --session-id remains supported for backwards compatibility.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --session-id d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1 --vtime 1234567890
 stderr '"antithesis.debugging.session_id": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1"'
 
@@ -63,7 +63,7 @@ stderr '"antithesis.debugging.session_id": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-
 #    converted to strings. The moment carries whichever identifier the triage
 #    report provides (session_id today, run_id going forward) and is passed
 #    through unchanged.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
@@ -71,7 +71,7 @@ stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 
 # A session-id moment (today's triage report format) still works.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_input.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22"'
@@ -79,14 +79,14 @@ stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 
 # 3b. stdin as JSON
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin debug_json.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.input_hash": "abc"'
 
 # When both stdin and CLI args are provided, CLI args take priority over
 #    stdin values.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty debug --stdin --input-hash override --recipients team@example.com
 stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
@@ -95,13 +95,13 @@ stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
 # On success, a one-line confirmation with the run_id is printed to stdout.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty debug --stdin
 stdout 'Debugging session started: run_id run-123'
 
 # With --json, the full response body is printed as pretty JSON.
-mock-server 202 '{"run_id":"run-123"}'
+mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty --json debug --stdin
 stdout '\s*"run_id": "run-123".*'

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -8,43 +8,70 @@
 #
 # Each successful invocation actually starts a debugging session against the
 # API, so the bulk of this file is gated behind `[staging] skip` to avoid
-# mutating staging. Read-only checks (env-var and schema validation that
-# fail before any API call) run in both modes.
+# mutating staging. Read-only checks (env-var, schema validation, and the
+# run-id/session-id requirement that fail before any API call) run in both
+# modes.
 
 # The command authenticates with the Antithesis API using either
 #    ANTITHESIS_API_KEY and ANTITHESIS_TENANT, or
 #    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT.
-! snouty debug --input-hash abc --session-id sess --vtime 123
+! snouty debug --input-hash abc --run-id run-123 --vtime 123
 stderr 'missing environment variable.*'
 
 # Parameters are validated against the debuggingParams schema before
-#    making any API call. Required fields: session_id, input_hash, vtime.
+#    making any API call. Required fields: input_hash, vtime, and exactly
+#    one of run_id or session_id.
 mock-server 200 '{}'
 ! snouty debug --input-hash abc
 stderr 'validation failed.*'
 
 # Old-style raw --antithesis.* args are not accepted by `debug`.
-! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.session_id sess --antithesis.debugging.vtime 123
+! snouty debug --antithesis.debugging.input_hash abc --antithesis.debugging.run_id run --antithesis.debugging.vtime 123
 stderr 'unexpected argument.*'
+
+# The target run must be identified by exactly one of --run-id or
+#    --session-id. Supplying both, or neither, is an error caught before any
+#    API call (so it is exercised in both mock and staging modes).
+! snouty debug --input-hash abc --vtime 1 --run-id r-1 --session-id s-1
+stderr 'specify exactly one of --run-id / --session-id.*'
+
+! snouty debug --input-hash abc --vtime 1
+stderr 'specify --run-id or --session-id.*'
 
 [staging] skip
 
 # Parameters are provided as typed flags. Before sending, the resolved
-#    parameters are printed to stderr with sensitive values redacted.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
-snouty debug --input-hash abc123 --session-id sess-456 --vtime 1234567890 --description 'debug this moment' --recipients team@example.com
+#    parameters are printed to stderr with sensitive values redacted. The
+#    target run is identified by --run-id (preferred for new integrations).
+mock-server 202 '{"run_id":"run-123"}'
+snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890 --description 'debug this moment' --recipients team@example.com
 stderr '"antithesis.debugging.input_hash": "abc123"'
-stderr '"antithesis.debugging.session_id": "sess-456"'
+stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
 stderr '"antithesis.debugging.vtime": "1234567890"'
 stderr '"antithesis.event_description": "debug this moment"'
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
+# --session-id remains supported for backwards compatibility.
+mock-server 202 '{"run_id":"run-123"}'
+snouty debug --input-hash abc123 --session-id d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1 --vtime 1234567890
+stderr '"antithesis.debugging.session_id": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1"'
+
 # Parameters can alternatively be read from stdin via --stdin, as JSON,
 #    JSON5, or Moment.from format. Moment.from format
-#    (e.g. Moment.from({ session_id: "...", ... })) is auto-detected on
-#    stdin. Keys are mapped to antithesis.debugging.* and numeric values are
-#    converted to strings.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
+#    (e.g. Moment.from({ run_id: "...", ... })) is auto-detected on stdin.
+#    Keys are mapped to antithesis.debugging.* and numeric values are
+#    converted to strings. The moment carries whichever identifier the triage
+#    report provides (session_id today, run_id going forward) and is passed
+#    through unchanged.
+mock-server 202 '{"run_id":"run-123"}'
+stdin moment_run_input.txt
+snouty debug --stdin
+stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
+stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
+stderr '"antithesis.debugging.vtime": "329.8037810830865"'
+
+# A session-id moment (today's triage report format) still works.
+mock-server 202 '{"run_id":"run-123"}'
 stdin moment_input.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22"'
@@ -52,41 +79,43 @@ stderr '"antithesis.debugging.input_hash": "6057726200491963783"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 
 # 3b. stdin as JSON
-mock-server 200 '{"runId":"run-123","statusCode":202}'
+mock-server 202 '{"run_id":"run-123"}'
 stdin debug_json.txt
 snouty debug --stdin
 stderr '"antithesis.debugging.input_hash": "abc"'
 
 # When both stdin and CLI args are provided, CLI args take priority over
 #    stdin values.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
-stdin moment_input.txt
+mock-server 202 '{"run_id":"run-123"}'
+stdin moment_run_input.txt
 snouty debug --stdin --input-hash override --recipients team@example.com
-stderr '"antithesis.debugging.session_id": "f89d5c11f5e3bf5e4bb3641809800cee-44-22"'
+stderr '"antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1"'
 stderr '"antithesis.debugging.input_hash": "override"'
 stderr '"antithesis.debugging.vtime": "329.8037810830865"'
 stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 
 # On success, a one-line confirmation with the run_id is printed to stdout.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
-stdin moment_input.txt
+mock-server 202 '{"run_id":"run-123"}'
+stdin moment_run_input.txt
 snouty debug --stdin
 stdout 'Debugging session started: run_id run-123'
 
 # With --json, the full response body is printed as pretty JSON.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
-stdin moment_input.txt
+mock-server 202 '{"run_id":"run-123"}'
+stdin moment_run_input.txt
 snouty --json debug --stdin
-stdout '\s*"runId": "run-123".*'
+stdout '\s*"run_id": "run-123".*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.
 mock-server 401 '{"message": "unauthorized"}'
-! snouty debug --input-hash abc123 --session-id sess-456 --vtime 1234567890
+! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stderr 'API error: 401.*'
 
 -- moment_input.txt --
 Moment.from({ session_id: "f89d5c11f5e3bf5e4bb3641809800cee-44-22", input_hash: "6057726200491963783", vtime: 329.8037810830865 })
+-- moment_run_input.txt --
+Moment.from({ run_id: "9043254f65c9c65d63fe043a0abfc7fc-53-1", input_hash: "6057726200491963783", vtime: 329.8037810830865 })
 -- debug_json.txt --
 {
     "antithesis.debugging.input_hash": "abc",

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -104,7 +104,7 @@ stdout 'Debugging session started: run_id run-123'
 mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty --json debug --stdin
-stdout '\s*"run_id": "run-123".*'
+stdout '\s*"runId": "run-123".*'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -33,18 +33,18 @@ stderr 'unexpected argument.*'
 stderr 'missing environment variable.*'
 
 # --param cannot override typed flag values.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.duration=60
 stderr 'cannot be overridden via --param.*'
 
 # At least one source of parameters must be provided; otherwise the
 #    command fails.
-mock-server 200 '{}'
+mock-server 202 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
 
 # antithesis.images must not be passed via --param.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.images=app:latest
 stderr 'antithesis.images cannot be set via --param.*'
 
@@ -55,7 +55,7 @@ stderr 'antithesis.images cannot be set via --param.*'
 #    parameters are printed to stderr with sensitive values (tokens, email
 #    recipients) redacted. On success, a one-line confirmation with the
 #    run_id is printed to stdout.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
 stderr '"antithesis.test_name": "my-test"'
 stderr '"antithesis.description": "nightly test run"'
@@ -66,30 +66,30 @@ stderr '"antithesis.source": "ci-pipeline"'
 stdout 'Test run started: run_id run-123'
 
 # With --json, the full response body is printed as pretty JSON.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty --json launch -w basic_test --config-image config:latest --duration 30 --source ci-pipeline
 stdout '\s*"runId": "run-123".*'
 ! stdout 'Test run started.*'
 
 # 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --ephemeral
 stderr '"antithesis.is_ephemeral": "true"'
 
 # 6c. Without --source, is_ephemeral is set automatically and an info message is shown.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30
 stderr '"antithesis.is_ephemeral": "true"'
 stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
 
 # 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --source ci-pipeline
 ! stderr 'is_ephemeral.*'
 ! stderr 'Starting ephemeral run.*'
 
 # 6d. --param flag passes custom properties.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
 stderr '"my.custom.prop": "value"'
 stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
@@ -101,6 +101,6 @@ mock-server 400 '{"message":"bad request"}'
 stderr 'API error: 400.*'
 
 # `snouty run` still works but prints a deprecation warning.
-mock-server 200 '{"runId":"run-123","statusCode":200}'
+mock-server 202 '{"runId":"run-123","statusCode":202}'
 snouty run -w basic_test --duration 30
 stderr 'snouty run.*is deprecated.*snouty launch'

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -33,18 +33,18 @@ stderr 'unexpected argument.*'
 stderr 'missing environment variable.*'
 
 # --param cannot override typed flag values.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.duration=60
 stderr 'cannot be overridden via --param.*'
 
 # At least one source of parameters must be provided; otherwise the
 #    command fails.
-mock-server 202 '{}'
+mock-server 200 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
 
 # antithesis.images must not be passed via --param.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.images=app:latest
 stderr 'antithesis.images cannot be set via --param.*'
 
@@ -55,7 +55,7 @@ stderr 'antithesis.images cannot be set via --param.*'
 #    parameters are printed to stderr with sensitive values (tokens, email
 #    recipients) redacted. On success, a one-line confirmation with the
 #    run_id is printed to stdout.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --test-name my-test --description 'nightly test run' --config-image config:latest --duration 30 --recipients team@example.com --source ci-pipeline
 stderr '"antithesis.test_name": "my-test"'
 stderr '"antithesis.description": "nightly test run"'
@@ -66,30 +66,30 @@ stderr '"antithesis.source": "ci-pipeline"'
 stdout 'Test run started: run_id run-123'
 
 # With --json, the full response body is printed as pretty JSON.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty --json launch -w basic_test --config-image config:latest --duration 30 --source ci-pipeline
 stdout '\s*"runId": "run-123".*'
 ! stdout 'Test run started.*'
 
 # 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --ephemeral
 stderr '"antithesis.is_ephemeral": "true"'
 
 # 6c. Without --source, is_ephemeral is set automatically and an info message is shown.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30
 stderr '"antithesis.is_ephemeral": "true"'
 stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
 
 # 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --source ci-pipeline
 ! stderr 'is_ephemeral.*'
 ! stderr 'Starting ephemeral run.*'
 
 # 6d. --param flag passes custom properties.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
 stderr '"my.custom.prop": "value"'
 stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
@@ -101,6 +101,6 @@ mock-server 400 '{"message":"bad request"}'
 stderr 'API error: 400.*'
 
 # `snouty run` still works but prints a deprecation warning.
-mock-server 202 '{"runId":"run-123","statusCode":202}'
+mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty run -w basic_test --duration 30
 stderr 'snouty run.*is deprecated.*snouty launch'

--- a/src/api.rs
+++ b/src/api.rs
@@ -323,20 +323,23 @@ impl AntithesisApi {
         .await
     }
 
-    pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchMvdResponse> {
+    pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
         let body = launch_mvd_request(params)?;
-        let result = self.client.launch_mvd().body(body).send().await;
-        finish_launch(result, |body| {
-            // Tolerate either `run_id` (spec) or `runId` (live webhook envelope).
-            let run_id = body
-                .get("run_id")
-                .or_else(|| body.get("runId"))
-                .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| eyre!("launch response missing run_id/runId"))?
-                .to_string();
-            Ok(LaunchMvdResponse { run_id })
-        })
-        .await
+        match self.client.launch_mvd().body(body).send().await {
+            // Documented 202 path: the generated type is `LaunchMvdResponse { run_id }`.
+            // Normalize to the `runId`/`statusCode` envelope the live API actually
+            // returns (and that `snouty launch` emits) so `--json` output is consistent.
+            Ok(response) => Ok(LaunchResponse {
+                run_id: response.into_inner().run_id,
+                status_code: 202,
+            }),
+            // Live path: HTTP 200 webhook envelope, body is the LaunchResponse shape.
+            Err(ClientError::UnexpectedResponse(resp)) if resp.status().is_success() => resp
+                .json::<LaunchResponse>()
+                .await
+                .wrap_err("parsing debug launch response"),
+            Err(err) => Err(format_launch_client_error(err).await),
+        }
     }
 
     pub async fn get_run(&self, run_id: &str) -> Result<RunDetail> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -310,25 +310,33 @@ impl AntithesisApi {
 
     pub async fn launch_test(&self, launcher: &str, params: &Params) -> Result<LaunchResponse> {
         let body = launch_request(params)?;
-        match self
+        let result = self
             .client
             .launch_test()
             .launcher_name(launcher)
             .body(body)
             .send()
-            .await
-        {
-            Ok(response) => Ok(response.into_inner()),
-            Err(err) => Err(format_launch_client_error(err).await),
-        }
+            .await;
+        finish_launch(result, |body| {
+            serde_json::from_value(body).wrap_err("unexpected launch response shape")
+        })
+        .await
     }
 
     pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchMvdResponse> {
         let body = launch_mvd_request(params)?;
-        match self.client.launch_mvd().body(body).send().await {
-            Ok(response) => Ok(response.into_inner()),
-            Err(err) => Err(format_launch_client_error(err).await),
-        }
+        let result = self.client.launch_mvd().body(body).send().await;
+        finish_launch(result, |body| {
+            // Tolerate either `run_id` (spec) or `runId` (live webhook envelope).
+            let run_id = body
+                .get("run_id")
+                .or_else(|| body.get("runId"))
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| eyre!("launch response missing run_id/runId"))?
+                .to_string();
+            Ok(LaunchMvdResponse { run_id })
+        })
+        .await
     }
 
     pub async fn get_run(&self, run_id: &str) -> Result<RunDetail> {
@@ -750,6 +758,36 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
         generated::types::builder::LaunchRequest::default().params(typed_params),
     )
     .wrap_err("failed to build launch request")
+}
+
+/// Resolve a launch / debugging-launch webhook response, tolerating spec drift
+/// on the success status code.
+///
+/// These webhooks report their real status in the response *body* and return an
+/// HTTP status the OpenAPI spec under-documents (it lists a single 2xx). The
+/// generated client only accepts the documented code and surfaces any other 2xx
+/// as `UnexpectedResponse`. We treat **any** 2xx as success: on the documented
+/// code we use the client's already-parsed value; on any other 2xx we read the
+/// body and build the response via `from_body`. Genuine failures (4xx/5xx) are
+/// still formatted as errors.
+async fn finish_launch<T>(
+    result: std::result::Result<
+        progenitor_client::ResponseValue<T>,
+        ClientError<generated::types::ErrorResponse>,
+    >,
+    from_body: impl FnOnce(serde_json::Value) -> Result<T>,
+) -> Result<T> {
+    match result {
+        Ok(response) => Ok(response.into_inner()),
+        Err(ClientError::UnexpectedResponse(resp)) if resp.status().is_success() => {
+            let body = resp
+                .json::<serde_json::Value>()
+                .await
+                .wrap_err("parsing launch response body")?;
+            from_body(body)
+        }
+        Err(err) => Err(format_launch_client_error(err).await),
+    }
 }
 
 fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequest> {
@@ -1329,6 +1367,81 @@ mod tests {
                 }
             })
         );
+    }
+
+    // The launch webhooks return HTTP 200 with the real status in the body,
+    // even though the spec documents 202. snouty accepts any 2xx as success.
+    #[tokio::test]
+    async fn launch_test_accepts_200_webhook_envelope() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/basic_test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "runId": "run-123",
+                "statusCode": 202
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = AntithesisApi::with_base_url(test_config(), mock_server.uri()).unwrap();
+        let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
+
+        let response = api.launch_test("basic_test", &params).await.unwrap();
+        assert_eq!(response.run_id, "run-123");
+        assert_eq!(response.status_code, 202);
+    }
+
+    #[tokio::test]
+    async fn launch_debugging_accepts_200_webhook_envelope() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/debugging"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "statusCode": 202,
+                "runId": "debug-run-123"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = AntithesisApi::with_base_url(test_config(), mock_server.uri()).unwrap();
+        let params = Params::from_key_value_pairs([
+            "antithesis.debugging.run_id=a2a4-53-1",
+            "antithesis.debugging.input_hash=-1",
+            "antithesis.debugging.vtime=1.0",
+        ])
+        .unwrap();
+
+        let response = api.launch_debugging(&params).await.unwrap();
+        assert_eq!(response.run_id, "debug-run-123");
+    }
+
+    #[tokio::test]
+    async fn launch_debugging_accepts_202_documented() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/debugging"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "run_id": "debug-run-456"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = AntithesisApi::with_base_url(test_config(), mock_server.uri()).unwrap();
+        let params = Params::from_key_value_pairs([
+            "antithesis.debugging.run_id=a2a4-53-1",
+            "antithesis.debugging.input_hash=-1",
+            "antithesis.debugging.vtime=1.0",
+        ])
+        .unwrap();
+
+        let response = api.launch_debugging(&params).await.unwrap();
+        assert_eq!(response.run_id, "debug-run-456");
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,8 +23,8 @@ mod generated {
 
 pub(crate) use generated::types::Params as RunParams;
 pub use generated::types::{
-    BuildLogLine, Event, EventProperty, LaunchResponse, Moment, NonEventProperty, Property,
-    PropertyStatus, RunDetail, RunStatus, RunSummary,
+    BuildLogLine, Event, EventProperty, LaunchMvdResponse, LaunchResponse, Moment,
+    NonEventProperty, Property, PropertyStatus, RunDetail, RunStatus, RunSummary,
 };
 pub use progenitor_client::ByteStream;
 
@@ -323,7 +323,7 @@ impl AntithesisApi {
         }
     }
 
-    pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
+    pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchMvdResponse> {
         let body = launch_mvd_request(params)?;
         match self.client.launch_mvd().body(body).send().await {
             Ok(response) => Ok(response.into_inner()),
@@ -753,33 +753,51 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
 }
 
 fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequest> {
-    let mut builder = generated::types::builder::MvdParams::default();
+    use generated::types::MvdParams;
 
-    for (key, value) in params.as_map() {
-        let value = value
-            .as_str()
-            .ok_or_else(|| eyre!("debugging params must be strings: {key}"))?;
+    let map = params.as_map();
+    let get = |key: &str| -> Result<Option<String>> {
+        match map.get(key) {
+            None => Ok(None),
+            Some(value) => value
+                .as_str()
+                .map(|s| Some(s.to_string()))
+                .ok_or_else(|| eyre!("debugging params must be strings: {key}")),
+        }
+    };
 
-        builder = match key.as_str() {
-            "antithesis.debugging.input_hash" => {
-                builder.antithesis_debugging_input_hash(value.to_string())
-            }
-            "antithesis.debugging.session_id" => {
-                builder.antithesis_debugging_session_id(value.to_string())
-            }
-            "antithesis.debugging.vtime" => builder.antithesis_debugging_vtime(value.to_string()),
-            "antithesis.event_description" => {
-                builder.antithesis_event_description(Some(value.to_string()))
-            }
-            "antithesis.report.recipients" => {
-                builder.antithesis_report_recipients(Some(value.to_string()))
-            }
-            _ => return Err(eyre!("unknown debugging param: {key}")),
-        };
-    }
+    let input_hash = get("antithesis.debugging.input_hash")?
+        .ok_or_else(|| eyre!("missing antithesis.debugging.input_hash"))?;
+    let vtime = get("antithesis.debugging.vtime")?
+        .ok_or_else(|| eyre!("missing antithesis.debugging.vtime"))?;
+    let event_description = get("antithesis.event_description")?;
+    let recipients = get("antithesis.report.recipients")?;
+    let run_id = get("antithesis.debugging.run_id")?;
+    let session_id = get("antithesis.debugging.session_id")?;
 
-    let typed_params = generated::types::MvdParams::try_from(builder)
-        .wrap_err("failed to build debugging params")?;
+    // The MVD_Params schema is a oneOf, so the target run is identified by
+    // exactly one of run_id or session_id. cmd_debug enforces this with a
+    // friendly message before we get here; the both/neither arms below are a
+    // defensive backstop.
+    let typed_params = match (run_id, session_id) {
+        (Some(run_id), None) => MvdParams::RunId {
+            antithesis_debugging_input_hash: input_hash,
+            antithesis_debugging_run_id: run_id,
+            antithesis_debugging_vtime: vtime,
+            antithesis_event_description: event_description,
+            antithesis_report_recipients: recipients,
+        },
+        (None, Some(session_id)) => MvdParams::SessionId {
+            antithesis_debugging_input_hash: input_hash,
+            antithesis_debugging_session_id: session_id,
+            antithesis_debugging_vtime: vtime,
+            antithesis_event_description: event_description,
+            antithesis_report_recipients: recipients,
+        },
+        (Some(_), Some(_)) => return Err(eyre!("specify exactly one of --run-id / --session-id")),
+        (None, None) => return Err(eyre!("specify --run-id or --session-id")),
+    };
+
     generated::types::LaunchMvdRequest::try_from(
         generated::types::builder::LaunchMvdRequest::default().params(typed_params),
     )
@@ -1242,9 +1260,9 @@ mod tests {
 
         Mock::given(method("POST"))
             .and(path("/api/v1/launch/basic_test"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
                 "runId": "run-123",
-                "statusCode": 200
+                "statusCode": 202
             })))
             .expect(1)
             .mount(&mock_server)
@@ -1271,9 +1289,9 @@ mod tests {
 
         Mock::given(method("POST"))
             .and(path("/api/v1/launch/basic_test"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
                 "runId": "run-123",
-                "statusCode": 200
+                "statusCode": 202
             })))
             .expect(1)
             .mount(&mock_server)
@@ -1290,7 +1308,7 @@ mod tests {
         let requests = mock_server.received_requests().await.unwrap();
 
         assert_eq!(response.run_id, "run-123");
-        assert_eq!(response.status_code, 200);
+        assert_eq!(response.status_code, 202);
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].url.path(), "/api/v1/launch/basic_test");
         assert_eq!(requests[0].method, reqwest::Method::POST);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,16 +98,19 @@ Examples:
     /// Launch a debugging session
     #[command(long_about = r#"Launch a debugging session
 
+Identify the target run with exactly one of --run-id (preferred) or
+--session-id.
+
 Using CLI arguments:
   snouty debug \
-    --session-id f89d5c11f5e3bf5e4bb3641809800cee-44-22 \
+    --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 \
     --input-hash 6057726200491963783 \
     --vtime 329.8037810830865 \
     --description "debug this moment" \
     --recipients "team@example.com"
 
 Using Moment.from (copy from triage report):
-  echo 'Moment.from({ session_id: "...", input_hash: "...", vtime: ... })' | \
+  echo 'Moment.from({ run_id: "...", input_hash: "...", vtime: ... })' | \
     snouty debug --stdin --recipients "team@example.com""#)]
     Debug(DebugArgs),
 
@@ -314,7 +317,11 @@ pub struct DebugArgs {
     #[arg(long)]
     pub stdin: bool,
 
-    /// Session ID of the test run to debug
+    /// Run ID of the test run to debug (preferred; mutually exclusive with --session-id)
+    #[arg(long)]
+    pub run_id: Option<String>,
+
+    /// Session ID of the test run to debug (mutually exclusive with --run-id)
     #[arg(long)]
     pub session_id: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,9 @@ async fn launch_webhook(
 fn debug_typed_params(args: &DebugArgs) -> Params {
     let mut params = Params::new();
 
+    if let Some(run_id) = &args.run_id {
+        params.insert("antithesis.debugging.run_id", run_id.as_str());
+    }
     if let Some(session_id) = &args.session_id {
         params.insert("antithesis.debugging.session_id", session_id.as_str());
     }
@@ -294,6 +297,7 @@ fn debug_params(args: DebugArgs) -> Result<Params> {
 async fn cmd_debug(args: DebugArgs, json: bool, verbose: bool) -> Result<()> {
     let params = debug_params(args)?;
     params.validate_debugging_params()?;
+    params.ensure_single_debug_target()?;
 
     eprintln!(
         "\nRequesting the Antithesis multiverse debugger with params:\n{}",

--- a/src/moment.rs
+++ b/src/moment.rs
@@ -8,10 +8,13 @@ use color_eyre::eyre::{Context, OptionExt, Result, bail};
 
 /// Parse a Moment.from format string into Params.
 ///
-/// The format is: `Moment.from({ session_id: "...", input_hash: "...", vtime: 123.456 })`
+/// The format is: `Moment.from({ run_id: "...", input_hash: "...", vtime: 123.456 })`
+/// (older triage reports use `session_id` in place of `run_id`).
 ///
 /// This is JSON5 object syntax with unquoted keys. The keys are converted
 /// to `antithesis.debugging.*` format and numeric values are converted to strings.
+/// The parser is identifier-agnostic: whichever of `run_id` / `session_id` the
+/// moment carries is passed through unchanged.
 pub fn parse(input: &str) -> Result<Params> {
     let input = input.trim();
 
@@ -95,6 +98,29 @@ mod tests {
             Some(&Value::String("6057726200491963783".to_string()))
         );
         // Numbers are converted to strings
+        assert_eq!(
+            params.as_map().get("antithesis.debugging.vtime"),
+            Some(&Value::String("329.8037810830865".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_run_id_moment() {
+        // The triage report's copy-moment payload will carry run_id instead of
+        // session_id going forward; the parser passes it through unchanged.
+        let input = r#"Moment.from({ run_id: "9043254f65c9c65d63fe043a0abfc7fc-53-1", input_hash: "6057726200491963783", vtime: 329.8037810830865 })"#;
+        let params = parse(input).unwrap();
+
+        assert_eq!(
+            params.as_map().get("antithesis.debugging.run_id"),
+            Some(&Value::String(
+                "9043254f65c9c65d63fe043a0abfc7fc-53-1".to_string()
+            ))
+        );
+        assert_eq!(
+            params.as_map().get("antithesis.debugging.input_hash"),
+            Some(&Value::String("6057726200491963783".to_string()))
+        );
         assert_eq!(
             params.as_map().get("antithesis.debugging.vtime"),
             Some(&Value::String("329.8037810830865".to_string()))

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Antithesis API",
     "version": "1.0.0",
-    "description": "The Antithesis API enables programmatic access to the Antithesis autonomous testing environments. List runs, inspect run details and retrieve logs.\n\n### Authentication\n\nAll endpoints require an API key. Pass it in the `Authorization` header as `Authorization: Bearer <api_key>`. To obtain an API key, please contact support at support@antithesis.com.\n\n### Versioning\n\nPublic API endpoints are versioned via a path prefix:\n\n- `/api/v0/...` — **Preview.** APIs accessed from the `v0` route are in preview. They may change or be removed.\n- `/api/v1/...` — **Stable.** The first generally-available version with a compatibility commitment.\n\nIn the future only breaking changes trigger a new major version (e.g., `v2`). When that happens the previous version (`v1`) remains available, and preview APIs restart under `v0`.",
+    "description": "The Antithesis API enables programmatic access to the Antithesis autonomous testing environments. List runs, inspect run details, and retrieve logs.\n\n### Authentication\n\nPass the API key in the `Authorization` header as `Authorization: Bearer <api_key>`. To obtain an API key, please email us at [support@antithesis.com](mailto:support@antithesis.com) or talk to your forward deployed engineer.\n\n### Versioning\n\nAll endpoints are versioned via a path prefix:\n\n- `/api/v0/...` **Preview.** APIs accessed from the `v0` route are in preview. They may change or be removed.\n- `/api/v1/...` **Stable.** The first version with a compatibility commitment.\n\nIn the future only breaking changes trigger a new major version (e.g., `v2`). When that happens the previous version (`v1`) remains available, and preview APIs restart under `v0`.",
     "contact": {
       "name": "Antithesis Team",
       "url": "https://www.antithesis.com",
@@ -35,14 +35,19 @@
     {
       "name": "Launch",
       "description": "Launch a test run or debugging session."
+    },
+    {
+      "name": "Version",
+      "description": "API and release version information."
     }
   ],
   "paths": {
     "/api/v0/runs": {
+      "parameters": [],
       "get": {
         "operationId": "listRuns",
-        "summary": "List all runs",
-        "description": "Returns a paginated list of runs for your organization. Results are ordered by creation time, newest first.",
+        "summary": "List all test runs",
+        "description": "Returns a paginated list of test runs. Results are ordered by creation time, newest first.",
         "tags": ["Test runs"],
         "parameters": [
           {
@@ -69,7 +74,7 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Filter runs by status.",
+            "description": "Filter test runs by status.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/Run_Status"
@@ -78,7 +83,7 @@
           {
             "name": "created_after",
             "in": "query",
-            "description": "Only return runs created after this timestamp (ISO 8601).",
+            "description": "Only return test runs created after this timestamp (ISO 8601).",
             "required": false,
             "schema": {
               "type": "string",
@@ -88,7 +93,7 @@
           {
             "name": "created_before",
             "in": "query",
-            "description": "Only return runs created before this timestamp (ISO 8601).",
+            "description": "Only return test runs created before this timestamp (ISO 8601).",
             "required": false,
             "schema": {
               "type": "string",
@@ -98,7 +103,7 @@
           {
             "name": "launcher",
             "in": "query",
-            "description": "Filter by the launcher that kicked off the run.",
+            "description": "Filter by the launcher that kicked off the test run.",
             "required": false,
             "schema": {
               "type": "string"
@@ -107,7 +112,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A paginated list of runs.",
+            "description": "A paginated list of test runs.",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,23 +121,47 @@
                 "example": {
                   "data": [
                     {
-                      "run_id": "9325f006ffd3a399a8497bc888878b97-50-1",
+                      "run_id": "9043254f65c9c65d63fe043a0abfc7fc-53-1",
                       "status": "completed",
-                      "created_at": "2025-03-20T02:00:00Z",
-                      "started_at": "2025-03-20T02:01:12Z",
-                      "completed_at": "2025-03-20T02:31:45Z",
-                      "launcher": "Payments Nightly"
+                      "created_at": "2026-04-28T13:49:49Z",
+                      "launcher": "Research Nightly",
+                      "started_at": "2026-04-28T13:49:49Z",
+                      "completed_at": "2026-04-28T14:14:07Z",
+                      "creator": {
+                        "name": "abc.xyz",
+                        "type": "user"
+                      },
+                      "parameters": {
+                        "antithesis.description": "Placeholder description",
+                        "antithesis.integrations.type": "none",
+                        "antithesis.is_ephemeral": "false"
+                      },
+                      "links": {
+                        "triage_report": "https://antithesis-dev.antithesis.com/report/VQ81z_5My-BjOmj6uFNKqVPq/Pv_GDPOCDEer8yk3Tf90Twj-83iedGwTgf60FyOYtA8.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA0LTI4VDEzOjE0OjA1LjY3NTMyMTY1N1oiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiUHZfR0RQT0NERWVyOHlrM1RmOTBUd2otODNpZWRHd1RnZjYwRnlPWXRBOC5odG1sIiwicmVwb3J0X2lkIjoiVlE4MXpfNU15LUJqT21qNnVGTktxVlBxIn19fTuj6S2XLg2SC-7dhP7H4CNTV5WZME2xiXlmReHLchLERjHxLXaOVxnkkv2Li5VF_4MLtIxunbBl_4gOwNJE3gY&debug=true"
+                      }
                     },
                     {
-                      "run_id": "a1c4e7f2b5d8039c6e9f1a4b7d0e3f68-50-1",
+                      "run_id": "ced73597f5f6499a6041f4c7f2329cf1-53-1",
                       "status": "completed",
-                      "created_at": "2025-03-19T14:00:00Z",
-                      "started_at": "2025-03-19T14:00:32Z",
-                      "completed_at": "2025-03-19T14:45:10Z",
-                      "launcher": "Debug Runner"
+                      "created_at": "2026-04-28T13:49:49Z",
+                      "launcher": "Thesis",
+                      "started_at": "2026-04-28T13:49:49Z",
+                      "completed_at": "2026-04-28T14:07:36Z",
+                      "creator": {
+                        "name": "abc.xyz",
+                        "type": "user"
+                      },
+                      "parameters": {
+                        "antithesis.description": "Placeholder description",
+                        "antithesis.integrations.type": "none",
+                        "antithesis.is_ephemeral": "true"
+                      },
+                      "links": {
+                        "triage_report": "https://antithesis-dev.antithesis.com/report/upBLS-4SrdaVqSi7tv5IbF38/Fqt1GZOTLPd978JxmCxAY-fXoUWvnqDjaTOmRM2g_g4.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiRnF0MUdaT1RMUGQ5NzhKeG1DeEFZLWZYb1VXdm5xRGphVE9tUk0yZ19nNC5odG1sIiwicmVwb3J0X2lkIjoidXBCTFMtNFNyZGFWcVNpN3R2NUliRjM4In19LCJuYmYiOiIyMDI2LTA0LTI4VDEzOjA3OjI1LjcwMDgzODkwM1oifVZW5_voXDGIhlndVP0FXfpDpBhUyYPbm99Zl7DlSzO38NSGXVU4_hKliNLgMGz1SXP9VW4NJLwDcEGetW224gY&debug=true"
+                      }
                     }
                   ],
-                  "next_cursor": "eyJjcmVhdGVkX2F0IjoiMjAyNS0wMy0xOVQxNDowMDowMFoiLCJydW5faWQiOiJiN2YzYTFlOWQwNDg0N2ExYjJjM2Q0ZTVmNmE3YjhjOSJ9"
+                  "next_cursor": "MjAyNi0wNC0yOFQxMzo0OTo0NVosMDM2MDc0MjdmMDg0NmE0OGE3ZjY2ZTQyYTUxOTY3ODktNTMtMQ=="
                 }
               }
             }
@@ -167,14 +196,14 @@
     "/api/v0/runs/{run_id}": {
       "get": {
         "operationId": "getRun",
-        "summary": "Get run details",
-        "description": "Returns the full details of a single run, including results.",
+        "summary": "Get test run details",
+        "description": "Returns the full details of a single test run, including results.",
         "tags": ["Test runs"],
         "parameters": [
           {
             "name": "run_id",
             "in": "path",
-            "description": "Unique identifier of the run to retrieve.",
+            "description": "Unique identifier of the test run to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -183,27 +212,70 @@
         ],
         "responses": {
           "200": {
-            "description": "Full details of the requested run.",
+            "description": "Full details of the requested test run.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Run_Detail"
                 },
-                "examples": {
-                  "test_run": {
-                    "summary": "A completed test run",
-                    "value": {
-                      "run_id": "9325f006ffd3a399a8497bc888878b97-50-1",
-                      "status": "completed",
-                      "created_at": "2025-03-20T02:00:00Z",
-                      "started_at": "2025-03-20T02:01:12Z",
-                      "completed_at": "2025-03-20T02:31:45Z",
-                      "launcher": "Payments Nightly",
-                      "description": "basic_test on main",
-                      "links": {
-                        "triage_report": "https://demo.antithesis.com/report/dBDNYWsHWywLBl1mtobJjjuB/dw8bjBJES6HzQ9iw8PSlGUXNnraLuWpLlbavyABg_R0.html"
-                      },
-                      "results": {}
+                "example": {
+                  "run_id": "ff0192ee9607f8ffa39187731d359c43-54-0",
+                  "status": "completed",
+                  "created_at": "2026-05-14T03:01:27Z",
+                  "launcher": "basic_k8s_test",
+                  "started_at": "2026-05-14T03:01:27Z",
+                  "completed_at": "2026-05-14T03:29:04Z",
+                  "creator": {
+                    "name": "antithesis_pdev",
+                    "type": "antithesis_scheduler"
+                  },
+                  "parameters": {
+                    "antithesis.config_image": "etcd-config-k8s:latest",
+                    "antithesis.description": "Nightly: Basic K8s test (etcd)",
+                    "antithesis.duration": "15",
+                    "antithesis.integrations.type": "none",
+                    "antithesis.is_ephemeral": "false",
+                    "antithesis.report.recipients": "foo.bar@antithesis.com"
+                  },
+                  "links": {
+                    "triage_report": "https://antithesis-dev.antithesis.com/report/mj9kKGUQwD-NuB5MKdvoBbUs/hHB2tlELW0k2fysU3tEHMyluQqqzBhspg2JalbFl3tQ.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiaEhCMnRsRUxXMGsyZnlzVTN0RUhNeWx1UXFxekJoc3BnMkphbGJGbDN0US5odG1sIiwicmVwb3J0X2lkIjoibWo5a0tHVVF3RC1OdUI1TUtkdm9CYlVzIn19LCJuYmYiOiIyMDI2LTA1LTE0VDAyOjI5OjAyLjY1MTUxNzIyMloifetWU3K1qICy8CzM5VzyveqhPMgpKgej_FOogxKqyfG9r16HsGjbAEKoiXXIIl6pi6_hvgIduzAgroEoNigj3wo"
+                  },
+                  "results": {
+                    "environment": {
+                      "antithesis_version": "v54-0",
+                      "images": [
+                        {
+                          "name": "etcd-config-k8s",
+                          "image": "us-central1-docker.pkg.dev/molten-verve-216720/antithesis-pdev-repository/etcd-config-k8s@sha256:16f57a2ec79c0d61886c28774264ab1d027e51a9301e014941404a35dcf8c631",
+                          "tag": "latest"
+                        },
+                        {
+                          "name": "mirrored-coredns-coredns",
+                          "image": "docker.io/rancher/mirrored-coredns-coredns@sha256:4f7a57135719628cf2070c5e3cbde64b013e90d4c560c5ecbf14004181f91998"
+                        },
+                        {
+                          "name": "etcd",
+                          "image": "docker.io/bitnamilegacy/etcd@sha256:4abe38869d5919c9ec70b2008713c2eb90c1b26d9e6700e126875894681b5b99",
+                          "tag": "3.5"
+                        },
+                        {
+                          "name": "local-path-provisioner",
+                          "image": "docker.io/rancher/local-path-provisioner@sha256:5fb0394abf87407a27cc56db94334eb0c92d0b5de2636683a7ec51f38143dfc9"
+                        },
+                        {
+                          "name": "busybox",
+                          "image": "docker.io/library/busybox@sha256:e56bc0f7fc7d4452b17eb4ac0a9261ff4c9a469afa45d2b673e03650716d095d"
+                        },
+                        {
+                          "name": "mirrored-pause",
+                          "image": "docker.io/rancher/mirrored-pause@sha256:7c38f24774e3cbd906d2d33c38354ccf787635581c122965132c9bd309754d4a"
+                        },
+                        {
+                          "name": "etcd-client-k8s",
+                          "image": "us-central1-docker.pkg.dev/molten-verve-216720/antithesis-pdev-repository/etcd-client-k8s@sha256:112394d9bacd070df4a8d18db3b7575d6e314220ee2462a31dc24df2e98373cc",
+                          "tag": "latest"
+                        }
+                      ]
                     }
                   }
                 }
@@ -241,13 +313,13 @@
       "get": {
         "operationId": "getRunLogs",
         "summary": "Get logs for a specific moment",
-        "description": "Streams the logs for a moment in the run as newline-delimited JSON (NDJSON) in chronological order. Each line is a self-contained JSON object. The response is streamed — the connection remains open until all matching log lines have been sent.",
+        "description": "Streams the logs for a moment in the test run as newline-delimited JSON (NDJSON) in chronological order. Each line is a self-contained JSON object. The response is streamed and the connection remains open until all matching log lines have been sent.",
         "tags": ["Test runs"],
         "parameters": [
           {
             "name": "run_id",
             "in": "path",
-            "description": "Unique identifier of the run to retrieve logs for.",
+            "description": "Unique identifier of the test run to retrieve logs for.",
             "required": true,
             "schema": {
               "type": "string"
@@ -275,7 +347,7 @@
           {
             "name": "begin_vtime",
             "in": "query",
-            "description": "Start streaming logs from this virtual time instead of from the beginning of the run.",
+            "description": "Start streaming logs from this virtual time instead of from the beginning of the test run.",
             "required": false,
             "schema": {
               "type": "string",
@@ -305,15 +377,15 @@
                   "raft_vote_log": {
                     "summary": "A raft pre-vote request log line",
                     "value": {
+                      "moment": {
+                        "input_hash": "-3625518438076122494",
+                        "vtime": "398.4898056755774"
+                      },
                       "output_text": "{\"level\":\"info\",\"ts\":\"2026-03-26T01:42:55.628233Z\",\"logger\":\"raft\",\"caller\":\"v3@v3.6.0/raft.go:1064\",\"msg\":\"2c6c7b8d0d0933f7 [logterm: 78, index: 436] sent MsgPreVote request to dcb68c82481661be at term 79\"}",
                       "source": {
                         "container": "etcd0",
                         "name": "etcd0",
                         "stream": "error"
-                      },
-                      "moment": {
-                        "input_hash": "-3625518438076122494",
-                        "vtime": "398.4898056755774"
                       }
                     }
                   },
@@ -383,13 +455,13 @@
       "get": {
         "operationId": "getRunBuildLogs",
         "summary": "Stream build logs",
-        "description": "Streams the build logs for a run as newline-delimited JSON (NDJSON). Each line contains a timestamp, a stream indicator, and the log text. The response is streamed — the connection remains open until all matching log lines have been sent.",
+        "description": "Streams the build logs for a test run as newline-delimited JSON (NDJSON). Each line contains a timestamp, a stream indicator, and the log text. The response is streamed and the connection remains open until all matching log lines have been sent.\n\n**Known limitation:** Build logs are not available for test runs created before Antithesis version 54.5. Requests for such runs return `404 Not Found`.",
         "tags": ["Test runs"],
         "parameters": [
           {
             "name": "run_id",
             "in": "path",
-            "description": "Unique identifier of the run to retrieve build logs for.",
+            "description": "Unique identifier of the test run to retrieve build logs for.",
             "required": true,
             "schema": {
               "type": "string"
@@ -403,7 +475,8 @@
               "application/x-ndjson": {
                 "schema": {
                   "$ref": "#/components/schemas/Build_Log_Line"
-                }
+                },
+                "example": "{\"timestamp\":\"2026-05-14T03:03:23.481Z\",\"text\":\"\",\"stream\":\"stdout\"}\n{\"timestamp\":\"2026-05-14T03:03:24.668Z\",\"text\":\"About to wait for the flock. If the script is hanging here, somebody else is doing a build.\",\"stream\":\"stdout\"}"
               }
             }
           },
@@ -437,14 +510,14 @@
     "/api/v0/runs/{run_id}/properties": {
       "get": {
         "operationId": "listRunProperties",
-        "summary": "List run properties",
-        "description": "Returns a paginated list of property results for a run, including both passing and failing properties by default. Use the `status` parameter to filter by a specific status.",
+        "summary": "List test run properties",
+        "description": "Returns a paginated list of property results for a test run, including both passing and failing properties by default. Use the `status` parameter to filter by a specific status.\n\n**Known limitation:** Property results are not available for test runs created before Antithesis version 54.5. Requests for such runs return `404 Not Found`.",
         "tags": ["Test runs"],
         "parameters": [
           {
             "name": "run_id",
             "in": "path",
-            "description": "Unique identifier of the run to retrieve properties for.",
+            "description": "Unique identifier of the test run to retrieve properties for.",
             "required": true,
             "schema": {
               "type": "string"
@@ -488,6 +561,45 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Property_List_Response"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "name": "Sometimes: Root moments",
+                      "description": null,
+                      "status": "Passing",
+                      "is_event": true,
+                      "is_group": false,
+                      "example_count": 1,
+                      "counterexample_count": 0,
+                      "examples": [
+                        {
+                          "env_setup": "complete",
+                          "source": {
+                            "name": "env_root"
+                          },
+                          "moment": {
+                            "input_hash": "-363173456058459333",
+                            "vtime": "22.475549569819123"
+                          }
+                        }
+                      ],
+                      "counterexamples": []
+                    },
+                    {
+                        "name": "Input count",
+                        "description": null,
+                        "status": "Passing",
+                        "is_event": false,
+                        "is_group": false,
+                        "example_count": 1,
+                        "counterexample_count": 0,
+                        "examples": [
+                            318446
+                        ],
+                        "counterexamples": []
+                    }
+                  ]
                 }
               }
             }
@@ -523,13 +635,13 @@
       "get": {
         "operationId": "searchRunEvents",
         "summary": "Search run events",
-        "description": "Searches events in a run for the given query string. The search matches against output text, assertion messages, function names, and test composer commands. Results are streamed as newline-delimited JSON (NDJSON). Each line is a self-contained JSON object representing an event.",
+        "description": "Searches events in a test run for the given query string. The search matches against output text, assertion messages, function names, and test composer commands. Results are streamed as newline-delimited JSON (NDJSON). Each line is a self-contained JSON object representing an event.",
         "tags": ["Test runs"],
         "parameters": [
           {
             "name": "run_id",
             "in": "path",
-            "description": "Unique identifier of the run to search.",
+            "description": "Unique identifier of the test run to search.",
             "required": true,
             "schema": {
               "type": "string"
@@ -538,7 +650,7 @@
           {
             "name": "q",
             "in": "query",
-            "description": "The search term. Matches events where this string is contained in the output text, assertion message, function name, or test composer command.",
+            "description": "The search term. Matches events where this string is contained in the output text, assertion message, function name, or test command.",
             "required": true,
             "schema": {
               "type": "string"
@@ -552,7 +664,8 @@
               "application/x-ndjson": {
                 "schema": {
                   "$ref": "#/components/schemas/Event"
-                }
+                },
+                "example": "{\"moment\":{\"input_hash\":\"-2978388909754056022\",\"vtime\":22.66615231265314},\"IPT_bytes_out\":1073904,\"source\":{\"command_id\":\"BSPID1ERCnmoGEnk6WjwIZ4o3TM\",\"name\":\"setup\",\"stream\":\"info\"},\"output_text\":\"3:08:17AM:     ^ Pending: ContainerCreating\"}\n{\"moment\":{\"input_hash\":\"-2978388909754056022\",\"vtime\":22.6661523131188},\"IPT_bytes_out\":1074064,\"source\":{\"command_id\":\"BSPID1ERCnmoGEnk6WjwIZ4o3TM\",\"name\":\"setup\",\"stream\":\"info\"},\"output_text\":\"3:08:17AM:     ^ Pending: ContainerCreating\"}"
               }
             }
           },
@@ -612,12 +725,16 @@
           }
         },
         "responses": {
-          "200": {
+          "202": {
             "description": "Test successfully launched.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Launch_Response"
+                },
+                "example": {
+                  "statusCode": 202,
+                  "runId": "0e62aa320a60967967096401ce826bd5-54-1"
                 }
               }
             }
@@ -649,30 +766,84 @@
         }
       }
     },
+    "/api/version": {
+      "get": {
+        "tags": ["Version"],
+        "operationId": "getVersion",
+        "summary": "Get API and release version",
+        "description": "Returns the latest supported API version and the current Antithesis release version for the tenant.",
+        "responses": {
+          "200": {
+            "description": "Version information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Version_Response"
+                },
+                "example": {
+                  "latest_api_version": "v1",
+                  "release_version": "56.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/launch/debugging": {
+      "parameters": [],
       "post": {
         "operationId": "launchMvd",
         "summary": "Launch a debugging session",
-        "description": "Kicks off a multiverse debugging session that'll be available for six hours. Returns an HTTP status code indicating whether the debugging session request was successfully accepted and the session is getting ready.",
+        "description": "Kicks off a multiverse debugging session that'll be available for six hours. Returns an HTTP status code indicating whether the debugging session request was successfully accepted and the session is getting ready.\n\nThe target test run is identified by `antithesis.debugging.run_id`. For backwards compatibility, `antithesis.debugging.session_id` is also accepted — prefer `run_id` for new integrations.",
         "tags": ["Launch"],
-        "parameters": [],
+        "parameters": [
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Launch_MVD_Request"
+              },
+              "examples": {
+                "by_run_id": {
+                  "summary": "Identified by run ID (preferred)",
+                  "value": {
+                    "params": {
+                      "antithesis.debugging.run_id": "9043254f65c9c65d63fe043a0abfc7fc-56-1",
+                      "antithesis.debugging.input_hash": "-9067336385060865277",
+                      "antithesis.debugging.vtime": "45.334635781589895",
+                      "antithesis.report.recipients": "user1@example.com; user2@example.com"
+                    }
+                  }
+                },
+                "by_session_id": {
+                  "summary": "Identified by session ID",
+                  "value": {
+                    "params": {
+                      "antithesis.debugging.session_id": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1",
+                      "antithesis.debugging.input_hash": "-9067336385060865277",
+                      "antithesis.debugging.vtime": "45.334635781589895",
+                      "antithesis.report.recipients": "user1@example.com; user2@example.com"
+                    }
+                  }
+                }
               }
             }
           }
         },
         "responses": {
-          "200": {
+          "202": {
             "description": "Debugging session launcher successfully started.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Launch_Response"
+                  "$ref": "#/components/schemas/Launch_MVD_Response"
+                },
+                "example": {
+                  "statusCode": 202,
+                  "runId": "633c43d99162a42d8c6b784751802f30-54-1"
                 }
               }
             }
@@ -706,6 +877,20 @@
     }
   },
   "components": {
+    "parameters": {
+      "Version": {
+        "name": "version",
+        "in": "path",
+        "description": "API version identifier. Use `v0` for preview APIs (may change without notice) or `v1` for the stable, compatibility-committed version. See the [Versioning section](/docs/rest_api/#versioning) for the full policy.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "enum": ["v0", "v1"],
+          "default": "v1",
+          "example": "v1"
+        }
+      }
+    },
     "schemas": {
       "Error_Response": {
         "type": "object",
@@ -744,7 +929,7 @@
         "properties": {
           "run_id": {
             "type": "string",
-            "description": "Unique identifier for the run.",
+            "description": "Unique identifier for the test run.",
             "example": "9325f006ffd3a399a8497bc888878b97-50-1"
           },
           "status": {
@@ -753,24 +938,24 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "description": "Timestamp when the run was created (ISO 8601)."
+            "description": "Timestamp when the test run was created (ISO 8601)."
           },
           "started_at": {
             "type": "string",
             "format": "date-time",
             "nullable": true,
-            "description": "Timestamp when the run started executing. Null if the run has not yet started."
+            "description": "Timestamp when the test run started executing. Null if the run has not yet started."
           },
           "completed_at": {
             "type": "string",
             "format": "date-time",
             "nullable": true,
-            "description": "Timestamp when the run finished. Null if the run is still in progress or has not started."
+            "description": "Timestamp when the test run finished. Null if the run is still in progress or has not started."
           },
           "creator": {
             "type": "object",
             "nullable": true,
-            "description": "Information about who or what created this run. Null if the creator is unknown.",
+            "description": "Information about who or what created this test run. Null if the creator is unknown.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Creator_Info"
@@ -779,7 +964,7 @@
           },
           "launcher": {
             "type": "string",
-            "description": "The name of the launcher that kicked off this run.",
+            "description": "The name of the launcher that kicked off this test run.",
             "example": "Payments Nightly"
           },
           "description": {
@@ -791,7 +976,7 @@
           "parameters": {
             "type": "object",
             "nullable": true,
-            "description": "Run parameters. Null if no parameters were specified.",
+            "description": "Test run parameters. Null if no parameters were specified.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Params"
@@ -801,7 +986,7 @@
           "links": {
             "type": "object",
             "nullable": true,
-            "description": "Relevant links for this run. Null if no links are available yet.",
+            "description": "Relevant links for this test run. Null if no links are available yet.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Run_Links"
@@ -822,7 +1007,7 @@
               "results": {
                 "type": "object",
                 "additionalProperties": true,
-                "description": "Aggregate results for the run. Structure varies by run type. May be absent or partial for runs that have not yet completed."
+                "description": "Aggregate results for the test run. Structure varies by run type. May be absent or partial for runs that have not yet completed."
               },
               "failure_moment": {
                 "type": "object",
@@ -855,6 +1040,37 @@
           }
         },
         "additionalProperties": false
+      },
+      "Version_Response": {
+        "type": "object",
+        "description": "Version information returned by the version endpoint.",
+        "required": ["latest_api_version", "release_version"],
+        "properties": {
+          "latest_api_version": {
+            "type": "string",
+            "description": "The API version exposed by this server.",
+            "example": "v1"
+          },
+          "release_version": {
+            "type": "string",
+            "description": "The underlying Antithesis release version.",
+            "example": "56.0"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Launch_MVD_Response": {
+        "type": "object",
+        "description": "Response returned when a debugging session request is successfully accepted.",
+        "required": ["run_id"],
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "description": "Unique identifier for the launched debugging session.",
+            "example": "c8d2f4a6e0b3197d5f8a2c4e6b0d3f79-49-1"
+          }
+        },
+        "additionalProperties": true
       },
       "Launch_Request": {
         "type": "object",
@@ -935,40 +1151,81 @@
         }
       },
       "MVD_Params": {
-        "type": "object",
-        "description": "Key-value pairs of multiverse debugging session parameters. Used when launching a debugging session.",
-        "required": [
-          "antithesis.debugging.input_hash",
-          "antithesis.debugging.session_id",
-          "antithesis.debugging.vtime"
-        ],
-        "properties": {
-          "antithesis.debugging.session_id": {
-            "type": "string",
-            "description": "The session ID of the test run you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
-            "example": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1"
+        "description": "Key-value pairs of multiverse debugging session parameters. Used when launching a debugging session. The target test run must be identified by exactly one of `antithesis.debugging.run_id` (preferred) or `antithesis.debugging.session_id`.",
+        "oneOf": [
+          {
+            "title": "Identified by run ID",
+            "type": "object",
+            "required": [
+              "antithesis.debugging.input_hash",
+              "antithesis.debugging.run_id",
+              "antithesis.debugging.vtime"
+            ],
+            "properties": {
+              "antithesis.debugging.run_id": {
+                "type": "string",
+                "description": "The run ID of the test run you want to start debugging.",
+                "example": "9043254f65c9c65d63fe043a0abfc7fc-53-1"
+              },
+              "antithesis.debugging.input_hash": {
+                "type": "string",
+                "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "example": "-9067336385060865277"
+              },
+              "antithesis.debugging.vtime": {
+                "type": "string",
+                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "example": "45.334635781589895"
+              },
+              "antithesis.event_description": {
+                "type": "string",
+                "description": "A description of the debugging event or session.",
+                "example": "Investigate the failed assertion at this moment"
+              },
+              "antithesis.report.recipients": {
+                "type": "string",
+                "description": "A semicolon-delimited list of email addresses that receive the link to the debugging session when ready. If not specified, emails are sent to the default users configured for the endpoint.",
+                "example": "user1@example.com; user2@example.com"
+              }
+            }
           },
-          "antithesis.debugging.input_hash": {
-            "type": "string",
-            "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
-            "example": "-9067336385060865277"
-          },
-          "antithesis.debugging.vtime": {
-            "type": "string",
-            "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
-            "example": "45.334635781589895"
-          },
-          "antithesis.event_description": {
-            "type": "string",
-            "description": "A description of the debugging event or session.",
-            "example": "Investigate the failed assertion at this moment"
-          },
-          "antithesis.report.recipients": {
-            "type": "string",
-            "description": "A semicolon-delimited list of email addresses that receive the link to the debugging session when ready. If not specified, emails are sent to the default users configured for the endpoint.",
-            "example": "user1@example.com; user2@example.com"
+          {
+            "title": "Identified by session ID",
+            "type": "object",
+            "required": [
+              "antithesis.debugging.input_hash",
+              "antithesis.debugging.session_id",
+              "antithesis.debugging.vtime"
+            ],
+            "properties": {
+              "antithesis.debugging.session_id": {
+                "type": "string",
+                "description": "Identifies the test run you want to start debugging. Prefer `antithesis.debugging.run_id` for new integrations.",
+                "example": "d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1"
+              },
+              "antithesis.debugging.input_hash": {
+                "type": "string",
+                "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "example": "-9067336385060865277"
+              },
+              "antithesis.debugging.vtime": {
+                "type": "string",
+                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "example": "45.334635781589895"
+              },
+              "antithesis.event_description": {
+                "type": "string",
+                "description": "A description of the debugging event or session.",
+                "example": "Investigate the failed assertion at this moment"
+              },
+              "antithesis.report.recipients": {
+                "type": "string",
+                "description": "A semicolon-delimited list of email addresses that receive the link to the debugging session when ready. If not specified, emails are sent to the default users configured for the endpoint.",
+                "example": "user1@example.com; user2@example.com"
+              }
+            }
           }
-        }
+        ]
       },
       "Event": {
         "type": "object",
@@ -1052,6 +1309,7 @@
           },
           "description": {
             "type": "string",
+            "nullable": true,
             "description": "A human-readable description of the property."
           },
           "status": {
@@ -1059,7 +1317,7 @@
           },
           "is_event": {
             "type": "boolean",
-            "description": "Whether this property is event-based. When true, examples and counterexamples are Event objects; when false, they may have any shape."
+            "description": "Whether this property is an event-based property. When true, examples and counterexamples are Event objects; when false, they may have any shape. If `is_event` is false, it's evaluated at the level of a whole test rather than a specific branch of execution, e.g., 'Recent version of software was provided' is evaluated at a whole test level and is independent of a branch of execution."
           },
           "is_group": {
             "type": "boolean",
@@ -1072,11 +1330,13 @@
           "example_count": {
             "type": "integer",
             "format": "uint32",
+            "nullable": true,
             "description": "Total number of examples observed."
           },
           "counterexample_count": {
             "type": "integer",
             "format": "uint32",
+            "nullable": true,
             "description": "Total number of counterexamples observed."
           }
         },
@@ -1150,19 +1410,12 @@
       },
       "Run_Status": {
         "type": "string",
-        "enum": [
-          "starting",
-          "in_progress",
-          "completed",
-          "cancelled",
-          "incomplete",
-          "unknown"
-        ],
-        "description": "Current lifecycle status of a run. `starting` — the run is being set up. `in_progress` — the run is actively running. `completed` — the run finished successfully. `cancelled` — the run was cancelled before completion. `incomplete` — the run did not complete successfully. `unknown` — the status of the run is unknown."
+        "enum": ["starting", "in_progress", "completed", "cancelled", "incomplete", "unknown"],
+        "description": "Current lifecycle status of a test run. `starting`: the run is being set up. `in_progress`: the run is actively running. `completed`: the run finished successfully. `cancelled`: the run was cancelled before completion. `incomplete`: the run did not complete successfully. `unknown`: the status of the run is unknown."
       },
       "Creator_Info": {
         "type": "object",
-        "description": "Information about who or what created this run. Distinguishes between CI-triggered runs, manual user-initiated runs, and agent-driven runs.",
+        "description": "Information about who or what created this test run. Distinguishes between CI-triggered test runs, manual user-initiated test runs, and agent-driven test runs.",
         "properties": {
           "name": {
             "type": "string",
@@ -1179,12 +1432,12 @@
       },
       "Run_Links": {
         "type": "object",
-        "description": "Relevant links for this run, providing direct access to the triage report.",
+        "description": "Relevant links for this test run, providing direct access to the triage report.",
         "properties": {
           "triage_report": {
             "type": "string",
             "format": "uri",
-            "description": "URL to the triage report for this run."
+            "description": "URL to the triage report for this test run."
           }
         },
         "additionalProperties": false
@@ -1202,7 +1455,7 @@
               "message": "limit must be between 1 and 100"
             }
           }
-        }
+        }   
       },
       "Unauthorized": {
         "description": "Unauthorized — invalid or missing authentication credentials.",
@@ -1310,7 +1563,7 @@
       "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "API key provided by your Antithesis forward deployment engineer. Pass the key in the Authorization header as `Authorization: Bearer <api_key>`."
+        "description": "All endpoints require an API key. Pass it in the Authorization header as Authorization: Bearer <api_key>. To obtain an API key, please contact support at support@antithesis.com or talk to our forward deployed engineers."
       }
     }
   }

--- a/src/params.rs
+++ b/src/params.rs
@@ -86,6 +86,24 @@ impl Params {
         validate_against_def(&self.inner, "debuggingParams")
     }
 
+    /// Ensure the debugging target run is identified by exactly one of
+    /// `antithesis.debugging.run_id` (preferred) or
+    /// `antithesis.debugging.session_id`.
+    ///
+    /// The MVD launch API models its params as a `oneOf` over these two
+    /// identifiers, so supplying both — or neither — is an error. This is
+    /// checked here, after schema validation, so a missing `input_hash`/`vtime`
+    /// surfaces first and the identifier error gets a tailored message.
+    pub fn ensure_single_debug_target(&self) -> Result<()> {
+        let has_run_id = self.inner.contains_key("antithesis.debugging.run_id");
+        let has_session_id = self.inner.contains_key("antithesis.debugging.session_id");
+        match (has_run_id, has_session_id) {
+            (true, false) | (false, true) => Ok(()),
+            (true, true) => bail!("specify exactly one of --run-id / --session-id"),
+            (false, false) => bail!("specify --run-id or --session-id"),
+        }
+    }
+
     /// Check if the params are empty.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
@@ -332,6 +350,65 @@ mod tests {
         ];
         let params = Params::from_args(args).unwrap();
         assert!(params.validate_debugging_params().is_err());
+    }
+
+    #[test]
+    fn validate_debugging_params_run_id_success() {
+        let args = [
+            "--antithesis.debugging.input_hash",
+            "abc123",
+            "--antithesis.debugging.run_id",
+            "9043254f65c9c65d63fe043a0abfc7fc-53-1",
+            "--antithesis.debugging.vtime",
+            "1234567890",
+        ];
+        let params = Params::from_args(args).unwrap();
+        assert!(params.validate_debugging_params().is_ok());
+    }
+
+    #[test]
+    fn validate_debugging_params_does_not_require_an_identifier() {
+        // The exactly-one-of rule is enforced by ensure_single_debug_target, not
+        // the schema: schema validation only requires input_hash + vtime.
+        let args = [
+            "--antithesis.debugging.input_hash",
+            "abc123",
+            "--antithesis.debugging.vtime",
+            "1234567890",
+        ];
+        let params = Params::from_args(args).unwrap();
+        assert!(params.validate_debugging_params().is_ok());
+    }
+
+    #[test]
+    fn ensure_single_debug_target_accepts_run_id_only() {
+        let mut params = Params::new();
+        params.insert("antithesis.debugging.run_id", "run-1");
+        assert!(params.ensure_single_debug_target().is_ok());
+    }
+
+    #[test]
+    fn ensure_single_debug_target_accepts_session_id_only() {
+        let mut params = Params::new();
+        params.insert("antithesis.debugging.session_id", "sess-1");
+        assert!(params.ensure_single_debug_target().is_ok());
+    }
+
+    #[test]
+    fn ensure_single_debug_target_rejects_both() {
+        let mut params = Params::new();
+        params.insert("antithesis.debugging.run_id", "run-1");
+        params.insert("antithesis.debugging.session_id", "sess-1");
+        let err = params.ensure_single_debug_target().unwrap_err().to_string();
+        assert!(err.contains("specify exactly one of --run-id / --session-id"));
+    }
+
+    #[test]
+    fn ensure_single_debug_target_rejects_neither() {
+        let mut params = Params::new();
+        params.insert("antithesis.debugging.input_hash", "abc");
+        let err = params.ensure_single_debug_target().unwrap_err().to_string();
+        assert!(err.contains("specify --run-id or --session-id"));
     }
 
     #[test]

--- a/src/params_schema.json
+++ b/src/params_schema.json
@@ -80,9 +80,13 @@
           "type": "string",
           "description": "Input hash obtained from the copy moment button in the triage report"
         },
+        "antithesis.debugging.run_id": {
+          "type": "string",
+          "description": "Run ID of the test run to debug (preferred). Exactly one of run_id or session_id must be supplied."
+        },
         "antithesis.debugging.session_id": {
           "type": "string",
-          "description": "Session ID of the test run to debug, from the copy moment button in triage report"
+          "description": "Session ID of the test run to debug, from the copy moment button in triage report. Exactly one of run_id or session_id must be supplied."
         },
         "antithesis.debugging.vtime": {
           "type": "string",
@@ -95,7 +99,6 @@
       },
       "required": [
         "antithesis.debugging.input_hash",
-        "antithesis.debugging.session_id",
         "antithesis.debugging.vtime"
       ]
     },


### PR DESCRIPTION
## What & why

`snouty debug` now accepts `--run-id` in addition to `--session-id` to identify the moment to recreate. **Exactly one of the two is required.** This lets the antithesis-skills agents launch MVD sessions directly from a run id (which triage already hands off) instead of asking the user to look up a session id. `--session-id` stays supported for moments copied straight from a triage report.

The debugging API models this as a `oneOf` (run-id-identified vs session-id-identified) in the vendored OpenAPI spec, so the generated client exposes an `MvdParams` enum. `launch_mvd_request` builds the matching variant, and `Params::ensure_single_debug_target` enforces the exactly-one rule with a clear error (both → "specify exactly one…"; neither → "specify --run-id or --session-id").

Moment/stdin parsing is unchanged and stays field-agnostic: a `run_id` or `session_id` moment passes through as-is (the triage report can switch from `session_id` to `run_id` without a snouty change).

## Launch/debug response tolerance

The vendored spec documents the `launch` and `launchMvd` success responses as HTTP `202` with a `run_id` body, but the deployed API returns the Antithesis webhook envelope — HTTP `200` with `{"statusCode": 202, "runId": ...}`. Without handling, the generated client rejects the live `200` as `API error: 200 OK`, mis-reporting a successful launch.

`finish_launch` now treats **any 2xx** HTTP status as success and reads the run id from the body (tolerating `run_id`/`runId`). `snouty debug` emits the same `runId`/`statusCode` envelope as `snouty launch` for `--json`.

> `src/openapi.json` is the upstream-owned vendored spec (copied in, not edited here), so this is a client-side tolerance rather than a spec change.

## Also

- Version bump `0.5.0` → `0.6.0`.
- Merged latest `main`.

## Testing

Local `cargo test` (lib unit tests + `tests/cli_*.rs` + `tests/spec.rs`), `cargo clippy --all-targets`, and `cargo fmt --check` all pass. New coverage includes the run-id / session-id / both / neither paths, the HTTP-200 webhook envelope for both launch and debug, and `--run-id` / `--session-id` spec cases in `specs/debug.txt`.
