### PR TITLE
fix(doctor): clarify authentication around the API key, add --json

### DIFF
--- a/.claude/skills/satisfaction-review/SKILL.md
+++ b/.claude/skills/satisfaction-review/SKILL.md
@@ -64,8 +64,12 @@ Each `*.md` file has this shape:
 $ snouty <args>
 <captured output>
 ```
+Exit code: `<n>`
 _Automated check: PASS|FAIL — <detail>_
 ```
+
+(Help stories show an `Exit code:` line under each command block — the `--help`,
+the default output, and every variant.)
 
 Read every story file. For the **large** outputs (e.g. `runs-build-logs`,
 `runs-logs-incomplete` can be tens/hundreds of KB) do **not** read the whole
@@ -84,6 +88,13 @@ a human with this goal feel the question was actually answered? Is anything
 misleading, redundant, mis-sorted, or missing context that the goal implies?
 For error stories: is the message clear about *what went wrong* and ideally
 *what to do next*, not just technically non-crashing?
+
+Also check the **exit code** (the `Exit code:` line under each command block)
+makes sense given the output: a clean error or a "not found" should be non-zero;
+a healthy listing, report, or "all passed" should be zero; a warning-only state
+is a judgement call (e.g. `doctor` exits zero with warnings). Flag mismatches —
+an error printed but exit 0, or a success-looking result that exited non-zero —
+as a correctness problem even if the text reads fine.
 
 ### Axis B — Follow-up readiness
 Does the output give the user what they need to run the **obvious next

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -608,6 +608,29 @@ def doctor_check(
     return chk
 
 
+def doctor_json_check(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+    """Gate the `doctor --json` story: stdout must be a parseable report with a
+    boolean `ok` and a non-empty `checks` array of well-formed records (name,
+    status, message), it must include the api_key check, and a missing required
+    credential must drive `ok` false."""
+    try:
+        data = json.loads(sr.result.stdout)
+    except json.JSONDecodeError as e:
+        return (False, f"stdout is not valid JSON: {e}")
+    checks = data.get("checks")
+    if not isinstance(data.get("ok"), bool) or not isinstance(checks, list) or not checks:
+        return (False, f"missing ok/checks ({data!r:.80})")
+    well_formed = all(
+        isinstance(c.get("name"), str)
+        and c.get("status") in ("ok", "warn", "error")
+        and isinstance(c.get("message"), str)
+        for c in checks
+    )
+    names = {c.get("name") for c in checks}
+    passed = well_formed and "api_key" in names and data["ok"] is False
+    return (passed, f"ok={data['ok']}, {len(checks)} checks, well_formed={well_formed}")
+
+
 def verbose_api_calls(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     has_get = "> GET" in sr.result.stderr or "> GET" in sr.result.stdout
     has_table = "STATUS" in sr.result.combined or "RUN" in sr.result.combined.upper()
@@ -1070,8 +1093,8 @@ def build_stories(d: Discovery) -> list[Story]:
             "doctor-api-key",
             "Confirm my environment is ready with an API key",
             "I've configured snouty with an API key and want doctor to confirm I'm set up.",
-            "doctor recognises the API key as full access and reports it with a single green check; "
-            "it does not mention username/password at all.",
+            "doctor reports the API key as set with a single green check and does not mention "
+            "username/password at all.",
             ["doctor"],
             doctor_check(
                 contains=("ANTITHESIS_API_KEY is set",),
@@ -1081,6 +1104,21 @@ def build_stories(d: Discovery) -> list[Story]:
             env=_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
         ),
         Story(
+            "doctor-api-key-and-legacy",
+            "Both an API key and leftover username/password are set",
+            "I have an API key but also still have ANTITHESIS_USERNAME/PASSWORD exported; "
+            "I want to know which one snouty uses.",
+            "doctor reports only the API key (it takes precedence) and does not mention the "
+            "legacy username/password at all.",
+            ["doctor"],
+            doctor_check(
+                contains=("ANTITHESIS_API_KEY is set",),
+                absent=("ANTITHESIS_USERNAME", "ANTITHESIS_PASSWORD"),
+            ),
+            json_capable=False,
+            env=_doctor_env(api_key=True, username=True, password=True, tenant=True, repo=True),
+        ),
+        Story(
             "doctor-no-auth",
             "Fresh install — doctor tells me what to configure",
             "I just installed snouty and haven't set any credentials; I want doctor to tell me what I need.",
@@ -1088,7 +1126,11 @@ def build_stories(d: Discovery) -> list[Story]:
             "steer me toward username/password, which is legacy auth (issue #145).",
             ["doctor"],
             doctor_check(
-                contains=("ANTITHESIS_API_KEY is not set", "requires an API key"),
+                contains=(
+                    "ANTITHESIS_API_KEY is not set",
+                    "requires an API key",
+                    "ask Antithesis support",
+                ),
                 absent=("ANTITHESIS_USERNAME", "ANTITHESIS_PASSWORD"),
                 ok=False,
             ),
@@ -1111,10 +1153,26 @@ def build_stories(d: Discovery) -> list[Story]:
                     "ANTITHESIS_USERNAME",
                     "legacy",
                     "snouty launch",
+                    "ask Antithesis support",
                 ),
             ),
             json_capable=False,
             env=_doctor_env(api_key=False, username=True, password=True, tenant=True, repo=True),
+        ),
+        Story(
+            "doctor-json",
+            "Gate CI on a ready environment with --json",
+            "I want to check my environment in a script/CI step and parse the result, "
+            "not scrape human text.",
+            "`doctor --json` prints a structured report — a top-level `ok` boolean and a `checks` "
+            "array, each with name/status/message and any notes — and exits non-zero when a required "
+            "check fails, so CI can gate on it.",
+            ["doctor", "--json"],
+            doctor_json_check,
+            json_capable=False,
+            env=_doctor_env(
+                api_key=False, username=False, password=False, tenant=False, repo=False
+            ),
         ),
     ]
     return stories + build_help_stories(d)
@@ -1353,32 +1411,40 @@ def build_help_stories(d: Discovery) -> list[Story]:
 HELP_SAMPLE_MAX_LINES = 18
 
 
-def _capped_block(args: list[str], text: str) -> str:
-    """A ```shell block showing `$ snouty <args>` and its output, truncated to
-    `HELP_SAMPLE_MAX_LINES` with a marker so help stories stay focused."""
+def _shell_block(args: list[str], text: str, returncode: int, cap: int | None = None) -> str:
+    """A ```shell block showing `$ snouty <args>`, its output, and the exit code
+    on the line below — so a reviewer can judge whether the return code makes
+    sense given the output (e.g. a clean error should be non-zero; a healthy
+    listing should be zero). When `cap` is set the output is truncated to that
+    many lines with a marker (help-story samples cap; full goal output does not)."""
     lines = text.rstrip("\n").split("\n")
-    if len(lines) > HELP_SAMPLE_MAX_LINES:
-        hidden = len(lines) - HELP_SAMPLE_MAX_LINES
-        lines = lines[:HELP_SAMPLE_MAX_LINES] + [f"… ({hidden} more lines)"]
+    if cap is not None and len(lines) > cap:
+        hidden = len(lines) - cap
+        lines = lines[:cap] + [f"… ({hidden} more lines)"]
     body = "\n".join(lines)
-    return f"```shell\n$ snouty {' '.join(args)}\n{body}\n```"
+    return f"```shell\n$ snouty {' '.join(args)}\n{body}\n```\nExit code: `{returncode}`"
 
 
 def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
     help_text = (sr.help_result.combined if sr.help_result else "").rstrip("\n")
+    help_rc = sr.help_result.returncode if sr.help_result else 0
     parts = [
         f"# {story.title}",
         f"**User goal:** {story.goal}",
         f"**Judge satisfaction by:** {story.judge}",
         "## Help text",
-        f"```shell\n$ snouty {' '.join(story.help_cmd or [])} --help\n{help_text}\n```",
+        _shell_block([*(story.help_cmd or []), "--help"], help_text, help_rc),
     ]
     if story.args:
         parts.append("## Default output")
-        parts.append(_capped_block(story.args, sr.result.combined))
+        parts.append(
+            _shell_block(
+                story.args, sr.result.combined, sr.result.returncode, cap=HELP_SAMPLE_MAX_LINES
+            )
+        )
         for label, res in sr.sample_results or []:
             parts.append(f"### Variant: {label}")
-            parts.append(_capped_block(res.args, res.combined))
+            parts.append(_shell_block(res.args, res.combined, res.returncode, cap=HELP_SAMPLE_MAX_LINES))
     parts.append(f"_Automated check: {verdict} — {detail}_")
     (out_dir / f"{story.slug}.md").write_text("\n\n".join(parts) + "\n")
 
@@ -1388,12 +1454,11 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
     if story.help_cmd is not None:
         _write_help_story(out_dir, story, sr, verdict, detail)
         return
-    body = sr.result.combined.rstrip("\n")
     md = (
         f"# {story.title}\n\n"
         f"**User goal:** {story.goal}\n\n"
         f"**Judge satisfaction by:** {story.judge}\n\n"
-        f"```shell\n$ snouty {' '.join(story.args)}\n{body}\n```\n\n"
+        f"{_shell_block(story.args, sr.result.combined, sr.result.returncode)}\n\n"
         f"_Automated check: {verdict} — {detail}_\n"
     )
     (out_dir / f"{story.slug}.md").write_text(md)

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -113,12 +113,23 @@ class Snouty:
     def cleanup(self) -> None:
         shutil.rmtree(self._shim, ignore_errors=True)
 
-    def run(self, args: list[str]) -> Result:
+    def run(self, args: list[str], env: dict[str, str | None] | None = None) -> Result:
+        # `env` overrides individual vars for this call only: a string sets the
+        # var, None unsets it (so a story can model an environment missing some
+        # credential). Everything else inherits the live ANTITHESIS_* env.
+        run_env = self._env
+        if env is not None:
+            run_env = dict(self._env)
+            for key, value in env.items():
+                if value is None:
+                    run_env.pop(key, None)
+                else:
+                    run_env[key] = value
         proc = subprocess.run(
             [str(self.binary), *args],
             capture_output=True,
             text=True,
-            env=self._env,
+            env=run_env,
         )
         return Result(args, proc.stdout, proc.stderr, proc.returncode)
 
@@ -465,6 +476,10 @@ class Story:
     # commands; set False for a command that legitimately exits non-zero while
     # still printing representative output (e.g. `doctor` when a check fails).
     expect_ok: bool = True
+    # Per-story ANTITHESIS_* env overrides for the default-output command: a
+    # string sets a var, None unsets it. Used by the doctor stories to model a
+    # specific credential setup regardless of the operator's real environment.
+    env: dict[str, str | None] | None = None
 
 
 @dataclass
@@ -559,6 +574,36 @@ def contains_all(*needles: str):
         text = sr.result.combined
         missing = [n for n in needles if n not in text]
         return (not missing, "all present" if not missing else f"missing {missing!r}")
+
+    return chk
+
+
+def doctor_check(
+    *,
+    contains: tuple[str, ...],
+    absent: tuple[str, ...] = (),
+    ok: bool | None = None,
+):
+    """Gate a doctor story: every `contains` needle must appear, no `absent`
+    needle may, and (when `ok` is given) the exit status must match. `ok` is left
+    None for the api-key/legacy stories because their overall pass/fail also
+    depends on the machine's container runtime — only the auth lines, which this
+    asserts on, are deterministic."""
+
+    def chk(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+        text = sr.result.combined
+        missing = [n for n in contains if n not in text]
+        unexpected = [n for n in absent if n in text]
+        exit_matches = ok is None or sr.result.ok == ok
+        passed = not missing and not unexpected and exit_matches
+        bits = []
+        if missing:
+            bits.append(f"missing={missing!r}")
+        if unexpected:
+            bits.append(f"unexpected={unexpected!r}")
+        if not exit_matches:
+            bits.append(f"exit_ok={sr.result.ok} (want {ok})")
+        return (passed, "; ".join(bits) or "auth output as expected")
 
     return chk
 
@@ -673,6 +718,31 @@ def help_story_check(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
 # ---------------------------------------------------------------------------
 # Story definitions
 # ---------------------------------------------------------------------------
+
+
+# `doctor` never calls the API, so each doctor story drives one specific output
+# with a controlled ANTITHESIS_* env, independent of the operator's shell. Each
+# flag says whether that var should be *set* for the story: a set var inherits
+# the operator's real value when present (so the stories reflect the real
+# environment) and falls back to a placeholder otherwise, so the state still
+# holds on a machine missing that credential. doctor only checks presence, never
+# the value, so an inherited secret is never printed and a placeholder is purely
+# a stand-in.
+def _doctor_env(
+    *, api_key: bool, username: bool, password: bool, tenant: bool, repo: bool
+) -> dict[str, str | None]:
+    def want(name: str, set_it: bool, placeholder: str) -> str | None:
+        return (os.environ.get(name) or placeholder) if set_it else None
+
+    return {
+        "ANTITHESIS_API_KEY": want("ANTITHESIS_API_KEY", api_key, "demo-api-key"),
+        "ANTITHESIS_USERNAME": want("ANTITHESIS_USERNAME", username, "demo-user"),
+        "ANTITHESIS_PASSWORD": want("ANTITHESIS_PASSWORD", password, "demo-pass"),
+        "ANTITHESIS_TENANT": want("ANTITHESIS_TENANT", tenant, "demo-tenant"),
+        "ANTITHESIS_REPOSITORY": want(
+            "ANTITHESIS_REPOSITORY", repo, "registry.example.com/acme/demo"
+        ),
+    }
 
 
 def build_stories(d: Discovery) -> list[Story]:
@@ -995,6 +1065,57 @@ def build_stories(d: Discovery) -> list[Story]:
             expect_message("error", "not found", "no ", "invalid"),
             json_capable=False,
         ),
+        # -- doctor (one story per distinct auth output) --------------------
+        Story(
+            "doctor-api-key",
+            "Confirm my environment is ready with an API key",
+            "I've configured snouty with an API key and want doctor to confirm I'm set up.",
+            "doctor recognises the API key as full access and reports it with a single green check; "
+            "it does not mention username/password at all.",
+            ["doctor"],
+            doctor_check(
+                contains=("ANTITHESIS_API_KEY is set",),
+                absent=("ANTITHESIS_USERNAME", "ANTITHESIS_PASSWORD"),
+            ),
+            json_capable=False,
+            env=_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
+        ),
+        Story(
+            "doctor-no-auth",
+            "Fresh install — doctor tells me what to configure",
+            "I just installed snouty and haven't set any credentials; I want doctor to tell me what I need.",
+            "doctor states an API key is required and points ONLY at ANTITHESIS_API_KEY — it must not "
+            "steer me toward username/password, which is legacy auth (issue #145).",
+            ["doctor"],
+            doctor_check(
+                contains=("ANTITHESIS_API_KEY is not set", "requires an API key"),
+                absent=("ANTITHESIS_USERNAME", "ANTITHESIS_PASSWORD"),
+                ok=False,
+            ),
+            json_capable=False,
+            env=_doctor_env(
+                api_key=False, username=False, password=False, tenant=False, repo=False
+            ),
+        ),
+        Story(
+            "doctor-legacy-auth",
+            "I only have a legacy username and password",
+            "I authenticate with a username/password and no API key; I want doctor to tell me whether that's enough.",
+            "doctor warns the API key is missing (so `snouty runs` and other API commands won't work), "
+            "flags username/password as legacy auth limited to `snouty launch`/`snouty debug`, and steers "
+            "me toward setting an API key.",
+            ["doctor"],
+            doctor_check(
+                contains=(
+                    "ANTITHESIS_API_KEY is not set",
+                    "ANTITHESIS_USERNAME",
+                    "legacy",
+                    "snouty launch",
+                ),
+            ),
+            json_capable=False,
+            env=_doctor_env(api_key=False, username=True, password=True, tenant=True, repo=True),
+        ),
     ]
     return stories + build_help_stories(d)
 
@@ -1280,7 +1401,7 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
 
 def run_story(sn: Snouty, story: Story) -> StoryRun:
     # Help-only stories pass no `args`; don't invoke a bare `snouty`.
-    result = sn.run(story.args) if story.args else Result([], "", "", 0)
+    result = sn.run(story.args, story.env) if story.args else Result([], "", "", 0)
     rows = None
     if story.json_capable and story.args:
         try:

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -7,3 +7,19 @@ snouty doctor --help
 stdout '.*Check environment configuration.*'
 stdout '.*container runtime.*'
 stdout '.*environment variables.*'
+
+# With nothing configured, doctor must steer the user to an API key only — it
+# must not suggest username/password, which is legacy auth (issue #145).
+! snouty doctor
+stderr '.*ANTITHESIS_API_KEY is not set.*'
+stderr '.*requires an API key.*'
+! stderr '.*ANTITHESIS_USERNAME.*'
+
+# With only username/password set, the missing API key downgrades to a warning
+# and the legacy creds are flagged as launch/debug-only.
+env ANTITHESIS_USERNAME=testuser
+env ANTITHESIS_PASSWORD=testpass
+! snouty doctor
+stderr '.*ANTITHESIS_API_KEY is not set.*'
+stderr '.*legacy.*'
+stderr '.*snouty launch.*'

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -7,13 +7,24 @@ snouty doctor --help
 stdout '.*Check environment configuration.*'
 stdout '.*container runtime.*'
 stdout '.*environment variables.*'
+stdout '.*--json.*'
 
-# With nothing configured, doctor must steer the user to an API key only — it
-# must not suggest username/password, which is legacy auth (issue #145).
+# With nothing configured, doctor steers the user to an API key only — it must
+# not suggest username/password, which is legacy auth (issue #145). The headline
+# states the bare problem; notes explain it and say where to get a key.
 ! snouty doctor
 stderr '.*ANTITHESIS_API_KEY is not set.*'
 stderr '.*requires an API key.*'
+stderr '.*ask Antithesis support.*'
 ! stderr '.*ANTITHESIS_USERNAME.*'
+
+# --json emits a structured report on stdout and still exits non-zero when a
+# required credential is missing (so CI can gate on it).
+! snouty doctor --json
+stdout '.*"ok": false.*'
+stdout '.*"name": "api_key".*'
+stdout '.*"status": "error".*'
+stdout '.*"level": "error".*'
 
 # With only username/password set, the missing API key downgrades to a warning
 # and the legacy creds are flagged as launch/debug-only.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,8 +160,15 @@ Example:
 Verifies that your environment is properly configured for Antithesis testing.
 Checks container runtime availability and required environment variables.
 
+snouty prefers an API key (full API access); a username and password is legacy
+auth, accepted only by `snouty launch` and `snouty debug`.
+
+Exits non-zero if any required check fails. Pass --json for a machine-readable
+report (e.g. to gate CI).
+
 Example:
-  snouty doctor"#)]
+  snouty doctor
+  snouty doctor --json"#)]
     Doctor,
 
     /// Print version information

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,49 +1,89 @@
 use std::env;
 
 use color_eyre::eyre::Result;
+use serde::Serialize;
 
 use crate::container;
-use crate::error::user_error;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// Outcome of a single check. Only `Error` fails doctor; `Warn` is surfaced but
+/// the run still passes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
 enum Status {
-    Ok,    // green ✓
-    Warn,  // yellow ⚠ — surfaced, but does not fail doctor
-    Error, // red ✗ — fails doctor
+    Ok,
+    Warn,
+    Error,
 }
 
-/// A single line in the doctor report: a status icon, a headline, and any
-/// number of indented detail lines (e.g. `ERROR: ...`, `NOTE: ...`).
+/// Severity of an explanatory line printed under a check. Independent of the
+/// check's `Status`: an `Ok` check can still carry `Note`s (what a var does),
+/// and a failing check pairs its `Error`/`Warning` line with `Note` how-tos.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Level {
+    Note,
+    Warning,
+    Error,
+}
+
+impl Level {
+    fn label(self) -> &'static str {
+        match self {
+            Level::Note => "NOTE",
+            Level::Warning => "WARNING",
+            Level::Error => "ERROR",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Note {
+    level: Level,
+    text: String,
+}
+
+/// One line in the doctor report. The headline `message` states the bare fact
+/// ("ANTITHESIS_API_KEY is not set"); the `notes` carry every explanation of
+/// what the variable does, what it's required for, and what to do about it. The
+/// `name` is a stable machine key for `--json` consumers.
+#[derive(Serialize)]
 struct Check {
+    name: &'static str,
     status: Status,
-    headline: String,
-    notes: Vec<String>,
+    message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    notes: Vec<Note>,
 }
 
 impl Check {
-    fn new(status: Status, headline: impl Into<String>) -> Self {
+    fn new(name: &'static str, status: Status, message: impl Into<String>) -> Self {
         Self {
+            name,
             status,
-            headline: headline.into(),
+            message: message.into(),
             notes: Vec::new(),
         }
     }
 
-    fn ok(headline: impl Into<String>) -> Self {
-        Self::new(Status::Ok, headline)
+    fn ok(name: &'static str, message: impl Into<String>) -> Self {
+        Self::new(name, Status::Ok, message)
     }
 
-    fn warn(headline: impl Into<String>) -> Self {
-        Self::new(Status::Warn, headline)
+    fn warn(name: &'static str, message: impl Into<String>) -> Self {
+        Self::new(name, Status::Warn, message)
     }
 
-    fn error(headline: impl Into<String>) -> Self {
-        Self::new(Status::Error, headline)
+    fn fail(name: &'static str, message: impl Into<String>) -> Self {
+        Self::new(name, Status::Error, message)
     }
 
-    /// Attach an indented detail line, returning `self` for chaining.
-    fn note(mut self, note: impl Into<String>) -> Self {
-        self.notes.push(note.into());
+    /// Attach an explanatory line, returning `self` for chaining. Prefer several
+    /// short, independent notes over one bundled sentence.
+    fn note(mut self, level: Level, text: impl Into<String>) -> Self {
+        self.notes.push(Note {
+            level,
+            text: text.into(),
+        });
         self
     }
 
@@ -53,105 +93,189 @@ impl Check {
             Status::Warn => console::style("⚠").yellow(),
             Status::Error => console::style("✗").red(),
         };
-        eprintln!("  {} {}", icon, self.headline);
+        eprintln!("  {} {}", icon, self.message);
         for note in &self.notes {
-            eprintln!("      {note}");
+            let label = match note.level {
+                Level::Note => console::style(note.level.label()).dim(),
+                Level::Warning => console::style(note.level.label()).yellow(),
+                Level::Error => console::style(note.level.label()).red(),
+            };
+            eprintln!("      {}: {}", label, note.text);
         }
     }
+}
+
+/// The full doctor report, as emitted by `--json`.
+#[derive(Serialize)]
+struct Report<'a> {
+    ok: bool,
+    checks: &'a [Check],
 }
 
 fn env_set(name: &str) -> bool {
     env::var(name).is_ok_and(|v| !v.is_empty())
 }
 
-/// A plain "is set / is not set" check for a single required env var.
-fn env_check(name: &str) -> Check {
-    if env_set(name) {
-        Check::ok(format!("{name} is set"))
+fn presence(var: &str, set: bool) -> String {
+    format!("{var} {}", if set { "is set" } else { "is not set" })
+}
+
+/// `ANTITHESIS_TENANT` is required by every command, so a missing one is a hard
+/// failure.
+fn tenant_check(set: bool) -> Check {
+    let message = presence("ANTITHESIS_TENANT", set);
+    if set {
+        Check::ok("tenant", message)
     } else {
-        Check::error(format!("{name} is not set"))
+        Check::fail("tenant", message).note(
+            Level::Note,
+            "your Antithesis tenant, required by every command",
+        )
+    }
+}
+
+/// `ANTITHESIS_REPOSITORY` is only needed to build and push a config image
+/// (`snouty launch --config`), so a missing one is a warning, not a failure —
+/// read-only use (`snouty runs`, `snouty debug`) doesn't need it.
+fn repository_check(set: bool) -> Check {
+    let message = presence("ANTITHESIS_REPOSITORY", set);
+    if set {
+        Check::ok("repository", message)
+    } else {
+        Check::warn("repository", message)
+            .note(Level::Note, "container registry for pushing images")
+            .note(Level::Note, "only required to launch with --config")
     }
 }
 
 /// Authentication checks. snouty authenticates with an API key, which grants
-/// access to the full Antithesis API. Username/password is a legacy fallback
-/// that only works for `snouty launch` and `snouty debug`, so it never stands
-/// in for a missing API key — it only softens the missing-key error into a
-/// warning.
+/// the full Antithesis API. Username/password is legacy auth accepted only by
+/// `snouty launch` and `snouty debug`, so it never stands in for a missing API
+/// key — it only softens the missing-key failure into a warning.
 ///
 /// Pure over the three booleans so it can be unit-tested without touching the
-/// process environment.
+/// environment.
 fn auth_checks(api_key: bool, username: bool, password: bool) -> Vec<Check> {
     if api_key {
-        return vec![Check::ok("ANTITHESIS_API_KEY is set")];
+        return vec![Check::ok("api_key", presence("ANTITHESIS_API_KEY", true))];
     }
 
     // Legacy auth needs BOTH halves; a lone username or password is not usable.
     if username && password {
         return vec![
-            Check::warn("ANTITHESIS_API_KEY is not set")
-                .note("WARNING: `snouty runs` and other API commands require ANTITHESIS_API_KEY"),
-            Check::ok("ANTITHESIS_USERNAME & ANTITHESIS_PASSWORD are set")
+            Check::warn("api_key", presence("ANTITHESIS_API_KEY", false))
                 .note(
-                    "NOTE: username/password is legacy auth — only `snouty launch` and \
-                     `snouty debug` accept it",
+                    Level::Warning,
+                    "`snouty runs` and other API commands require an API key",
                 )
-                .note("NOTE: set ANTITHESIS_API_KEY for full API access"),
+                .note(
+                    Level::Note,
+                    "ask Antithesis support for an API key if you don't have one",
+                ),
+            Check::ok(
+                "basic_auth",
+                "ANTITHESIS_USERNAME & ANTITHESIS_PASSWORD are set",
+            )
+            .note(
+                Level::Warning,
+                "legacy authentication method, set ANTITHESIS_API_KEY for full API access",
+            )
+            .note(
+                Level::Note,
+                "only `snouty launch` and `snouty debug` accept it",
+            ),
         ];
     }
 
     vec![
-        Check::error("ANTITHESIS_API_KEY is not set")
-            .note("ERROR: snouty requires an API key to authenticate with Antithesis"),
+        Check::fail("api_key", presence("ANTITHESIS_API_KEY", false))
+            .note(
+                Level::Error,
+                "snouty requires an API key to authenticate with Antithesis",
+            )
+            .note(
+                Level::Note,
+                "ask Antithesis support for an API key if you don't have one",
+            ),
     ]
 }
 
-pub fn cmd_doctor() -> Result<()> {
+fn collect_checks() -> Vec<Check> {
     let mut checks: Vec<Check> = Vec::new();
 
     // Container runtime (for building/pushing images)
     match container::runtime() {
-        Ok(rt) => checks.push(Check::ok(format!(
-            "Container runtime: {} detected",
-            rt.name()
-        ))),
-        Err(e) => checks.push(Check::error(format!("Container runtime: {e}"))),
+        Ok(rt) => checks.push(Check::ok(
+            "container_runtime",
+            format!("Container runtime: {} detected", rt.name()),
+        )),
+        Err(e) => checks.push(
+            Check::fail("container_runtime", "Container runtime not detected")
+                .note(Level::Error, e.to_string()),
+        ),
     }
 
     // Docker Compose v2 (required for compose configs)
     match container::docker_compose_version() {
-        Ok(version) => checks.push(Check::ok(format!("docker-compose: {version}"))),
-        Err(e) => checks.push(Check::error(format!("docker-compose: {e}"))),
+        Ok(version) => checks.push(Check::ok("docker_compose", version)),
+        Err(e) => checks.push(
+            Check::fail("docker_compose", "docker-compose not available")
+                .note(Level::Error, e.to_string()),
+        ),
     }
 
-    // Required environment
-    checks.push(env_check("ANTITHESIS_TENANT"));
-    checks.push(env_check("ANTITHESIS_REPOSITORY"));
-
-    // Authentication
+    // Required environment + authentication
+    checks.push(tenant_check(env_set("ANTITHESIS_TENANT")));
+    checks.push(repository_check(env_set("ANTITHESIS_REPOSITORY")));
     checks.extend(auth_checks(
         env_set("ANTITHESIS_API_KEY"),
         env_set("ANTITHESIS_USERNAME"),
         env_set("ANTITHESIS_PASSWORD"),
     ));
 
-    // Print all checks and check for failures
-    for check in &checks {
-        check.print();
-    }
+    checks
+}
 
-    eprintln!();
-    if checks.iter().any(|c| c.status == Status::Error) {
-        return Err(user_error("doctor found problems"));
-    }
+pub fn cmd_doctor(json: bool) -> Result<()> {
+    let checks = collect_checks();
+    let errors = checks.iter().filter(|c| c.status == Status::Error).count();
     let warnings = checks.iter().filter(|c| c.status == Status::Warn).count();
-    if warnings > 0 {
-        let plural = if warnings == 1 { "" } else { "s" };
-        eprintln!("All required checks passed ({warnings} warning{plural})");
+
+    if json {
+        let report = Report {
+            ok: errors == 0,
+            checks: &checks,
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
-        eprintln!("All checks passed");
+        for check in &checks {
+            check.print();
+        }
+        eprintln!();
+        let wp = if warnings == 1 { "" } else { "s" };
+        if errors > 0 {
+            let ep = if errors == 1 { "" } else { "s" };
+            if warnings > 0 {
+                eprintln!(
+                    "doctor found {errors} problem{ep} and {warnings} warning{wp} — \
+                     see the ✗ and ⚠ checks above"
+                );
+            } else {
+                eprintln!("doctor found {errors} problem{ep} — see the ✗ check{ep} above");
+            }
+        } else if warnings > 0 {
+            eprintln!("doctor passed with {warnings} warning{wp}");
+        } else {
+            eprintln!("All checks passed");
+        }
     }
 
+    // Exit non-zero on failure without re-rendering an error report: the checks
+    // above already say exactly what's wrong, so a generic "Error: doctor found
+    // problems" footer would be redundant noise.
+    if errors > 0 {
+        std::process::exit(1);
+    }
     Ok(())
 }
 
@@ -160,20 +284,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn auth_api_key_set_is_single_ok_check() {
+    fn auth_api_key_set_is_a_single_bare_ok_check() {
         let checks = auth_checks(true, false, false);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, Status::Ok);
-        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is set"));
+        assert!(checks[0].message.contains("ANTITHESIS_API_KEY is set"));
+        // A configured key needs no explanation — keep the happy path quiet.
+        assert!(checks[0].notes.is_empty());
     }
 
     #[test]
     fn auth_api_key_wins_and_ignores_basic_creds() {
-        // An API key takes precedence; username/password is not even mentioned.
         let checks = auth_checks(true, true, true);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, Status::Ok);
-        assert!(!checks[0].headline.contains("USERNAME"));
+        assert!(!checks[0].message.contains("USERNAME"));
     }
 
     #[test]
@@ -181,17 +306,31 @@ mod tests {
         let checks = auth_checks(false, true, true);
         assert_eq!(checks.len(), 2);
 
-        // Missing API key is a warning, not a failure: launch/debug still work.
+        // Missing API key is a warning, with a how-to-get-one note (issue #2).
         assert_eq!(checks[0].status, Status::Warn);
-        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
+        assert!(checks[0].message.contains("ANTITHESIS_API_KEY is not set"));
+        assert!(checks[0].notes.iter().any(|n| n.level == Level::Warning));
+        assert!(
+            checks[0]
+                .notes
+                .iter()
+                .any(|n| n.text.contains("ask Antithesis support"))
+        );
 
-        // The legacy creds get their own passing check with explanatory notes
-        // that steer the user back toward an API key.
+        // The legacy creds get their own passing check: a WARNING that flags the
+        // legacy method and points at the API key, plus a NOTE on its scope.
         assert_eq!(checks[1].status, Status::Ok);
-        let notes = checks[1].notes.join(" ");
-        assert!(notes.contains("legacy"));
+        assert_eq!(checks[1].notes.len(), 2);
+        assert!(checks[1].notes.iter().any(|n| n.level == Level::Warning
+            && n.text.contains("legacy authentication method")
+            && n.text.contains("ANTITHESIS_API_KEY")));
+        let notes = checks[1]
+            .notes
+            .iter()
+            .map(|n| n.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(notes.contains("snouty launch"));
-        assert!(notes.contains("ANTITHESIS_API_KEY"));
     }
 
     #[test]
@@ -199,14 +338,28 @@ mod tests {
         let checks = auth_checks(false, false, false);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, Status::Error);
-        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
-
-        let notes = checks[0].notes.join(" ");
-        assert!(notes.contains("requires an API key"));
+        assert!(checks[0].message.contains("ANTITHESIS_API_KEY is not set"));
+        assert!(checks[0].notes.iter().any(|n| n.level == Level::Error));
+        // Issue #2: tell the user where to get a key.
+        assert!(
+            checks[0]
+                .notes
+                .iter()
+                .any(|n| n.text.contains("ask Antithesis support"))
+        );
         // Nothing-set must steer to the API key only — no username/password noise.
-        assert!(!checks[0].headline.contains("USERNAME"));
-        assert!(!notes.contains("USERNAME"));
-        assert!(!notes.contains("PASSWORD"));
+        let all = format!(
+            "{} {}",
+            checks[0].message,
+            checks[0]
+                .notes
+                .iter()
+                .map(|n| n.text.as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        assert!(!all.contains("USERNAME"));
+        assert!(!all.contains("PASSWORD"));
     }
 
     #[test]
@@ -215,7 +368,53 @@ mod tests {
             let checks = auth_checks(false, username, password);
             assert_eq!(checks.len(), 1);
             assert_eq!(checks[0].status, Status::Error);
-            assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
         }
+    }
+
+    #[test]
+    fn tenant_missing_is_an_error_with_a_note() {
+        let check = tenant_check(false);
+        assert_eq!(check.status, Status::Error);
+        assert!(!check.notes.is_empty());
+        assert!(check.notes.iter().any(|n| n.text.contains("required")));
+    }
+
+    #[test]
+    fn repository_missing_is_only_a_warning() {
+        // Issue #3: REPOSITORY is launch-only, so a missing one must not fail doctor.
+        let check = repository_check(false);
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.notes.iter().any(|n| n.text.contains("--config")));
+    }
+
+    #[test]
+    fn json_report_carries_structured_status_levels_and_notes() {
+        let checks = auth_checks(false, false, false);
+        let report = Report {
+            ok: false,
+            checks: &checks,
+        };
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["checks"][0]["name"], "api_key");
+        assert_eq!(value["checks"][0]["status"], "error");
+        assert_eq!(
+            value["checks"][0]["message"],
+            "ANTITHESIS_API_KEY is not set"
+        );
+        assert_eq!(value["checks"][0]["notes"][0]["level"], "error");
+        assert!(
+            value["checks"][0]["notes"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("requires an API key")
+        );
+    }
+
+    #[test]
+    fn json_omits_notes_when_empty() {
+        let check = Check::ok("docker_compose", "docker-compose: v2.0.0");
+        let value = serde_json::to_value(&check).unwrap();
+        assert!(value.get("notes").is_none());
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,30 +5,105 @@ use color_eyre::eyre::Result;
 use crate::container;
 use crate::error::user_error;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Status {
+    Ok,    // green ✓
+    Warn,  // yellow ⚠ — surfaced, but does not fail doctor
+    Error, // red ✗ — fails doctor
+}
+
+/// A single line in the doctor report: a status icon, a headline, and any
+/// number of indented detail lines (e.g. `ERROR: ...`, `NOTE: ...`).
 struct Check {
-    name: &'static str,
-    passed: bool,
-    message: String,
+    status: Status,
+    headline: String,
+    notes: Vec<String>,
 }
 
 impl Check {
-    fn env(name: &'static str) -> Self {
-        let set = env::var(name).is_ok_and(|v| !v.is_empty());
+    fn new(status: Status, headline: impl Into<String>) -> Self {
         Self {
-            name,
-            passed: set,
-            message: if set { "is set" } else { "is not set" }.into(),
+            status,
+            headline: headline.into(),
+            notes: Vec::new(),
         }
     }
 
-    fn print(&self) {
-        let icon = if self.passed {
-            console::style("✓").green()
-        } else {
-            console::style("✗").red()
-        };
-        eprintln!("  {} {} {}", icon, self.name, self.message);
+    fn ok(headline: impl Into<String>) -> Self {
+        Self::new(Status::Ok, headline)
     }
+
+    fn warn(headline: impl Into<String>) -> Self {
+        Self::new(Status::Warn, headline)
+    }
+
+    fn error(headline: impl Into<String>) -> Self {
+        Self::new(Status::Error, headline)
+    }
+
+    /// Attach an indented detail line, returning `self` for chaining.
+    fn note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+
+    fn print(&self) {
+        let icon = match self.status {
+            Status::Ok => console::style("✓").green(),
+            Status::Warn => console::style("⚠").yellow(),
+            Status::Error => console::style("✗").red(),
+        };
+        eprintln!("  {} {}", icon, self.headline);
+        for note in &self.notes {
+            eprintln!("      {note}");
+        }
+    }
+}
+
+fn env_set(name: &str) -> bool {
+    env::var(name).is_ok_and(|v| !v.is_empty())
+}
+
+/// A plain "is set / is not set" check for a single required env var.
+fn env_check(name: &str) -> Check {
+    if env_set(name) {
+        Check::ok(format!("{name} is set"))
+    } else {
+        Check::error(format!("{name} is not set"))
+    }
+}
+
+/// Authentication checks. snouty authenticates with an API key, which grants
+/// access to the full Antithesis API. Username/password is a legacy fallback
+/// that only works for `snouty launch` and `snouty debug`, so it never stands
+/// in for a missing API key — it only softens the missing-key error into a
+/// warning.
+///
+/// Pure over the three booleans so it can be unit-tested without touching the
+/// process environment.
+fn auth_checks(api_key: bool, username: bool, password: bool) -> Vec<Check> {
+    if api_key {
+        return vec![Check::ok("ANTITHESIS_API_KEY is set")];
+    }
+
+    // Legacy auth needs BOTH halves; a lone username or password is not usable.
+    if username && password {
+        return vec![
+            Check::warn("ANTITHESIS_API_KEY is not set")
+                .note("WARNING: `snouty runs` and other API commands require ANTITHESIS_API_KEY"),
+            Check::ok("ANTITHESIS_USERNAME & ANTITHESIS_PASSWORD are set")
+                .note(
+                    "NOTE: username/password is legacy auth — only `snouty launch` and \
+                     `snouty debug` accept it",
+                )
+                .note("NOTE: set ANTITHESIS_API_KEY for full API access"),
+        ];
+    }
+
+    vec![
+        Check::error("ANTITHESIS_API_KEY is not set")
+            .note("ERROR: snouty requires an API key to authenticate with Antithesis"),
+    ]
 }
 
 pub fn cmd_doctor() -> Result<()> {
@@ -36,44 +111,29 @@ pub fn cmd_doctor() -> Result<()> {
 
     // Container runtime (for building/pushing images)
     match container::runtime() {
-        Ok(rt) => checks.push(Check {
-            name: "Container runtime",
-            passed: true,
-            message: format!("{} detected", rt.name()),
-        }),
-        Err(e) => checks.push(Check {
-            name: "Container runtime",
-            passed: false,
-            message: e.to_string(),
-        }),
+        Ok(rt) => checks.push(Check::ok(format!(
+            "Container runtime: {} detected",
+            rt.name()
+        ))),
+        Err(e) => checks.push(Check::error(format!("Container runtime: {e}"))),
     }
 
     // Docker Compose v2 (required for compose configs)
     match container::docker_compose_version() {
-        Ok(version) => checks.push(Check {
-            name: "docker-compose",
-            passed: true,
-            message: version,
-        }),
-        Err(e) => checks.push(Check {
-            name: "docker-compose",
-            passed: false,
-            message: e.to_string(),
-        }),
+        Ok(version) => checks.push(Check::ok(format!("docker-compose: {version}"))),
+        Err(e) => checks.push(Check::error(format!("docker-compose: {e}"))),
     }
 
-    // Environment variables
-    checks.push(Check::env("ANTITHESIS_TENANT"));
-    checks.push(Check::env("ANTITHESIS_REPOSITORY"));
+    // Required environment
+    checks.push(env_check("ANTITHESIS_TENANT"));
+    checks.push(env_check("ANTITHESIS_REPOSITORY"));
 
-    // Auth: api key OR both username and password
-    let api_key = Check::env("ANTITHESIS_API_KEY");
-    if api_key.passed {
-        checks.push(api_key);
-    } else {
-        checks.push(Check::env("ANTITHESIS_USERNAME"));
-        checks.push(Check::env("ANTITHESIS_PASSWORD"));
-    }
+    // Authentication
+    checks.extend(auth_checks(
+        env_set("ANTITHESIS_API_KEY"),
+        env_set("ANTITHESIS_USERNAME"),
+        env_set("ANTITHESIS_PASSWORD"),
+    ));
 
     // Print all checks and check for failures
     for check in &checks {
@@ -81,10 +141,81 @@ pub fn cmd_doctor() -> Result<()> {
     }
 
     eprintln!();
-    if checks.iter().any(|c| !c.passed) {
+    if checks.iter().any(|c| c.status == Status::Error) {
         return Err(user_error("doctor found problems"));
     }
-    eprintln!("All checks passed");
+    let warnings = checks.iter().filter(|c| c.status == Status::Warn).count();
+    if warnings > 0 {
+        let plural = if warnings == 1 { "" } else { "s" };
+        eprintln!("All required checks passed ({warnings} warning{plural})");
+    } else {
+        eprintln!("All checks passed");
+    }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_api_key_set_is_single_ok_check() {
+        let checks = auth_checks(true, false, false);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, Status::Ok);
+        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is set"));
+    }
+
+    #[test]
+    fn auth_api_key_wins_and_ignores_basic_creds() {
+        // An API key takes precedence; username/password is not even mentioned.
+        let checks = auth_checks(true, true, true);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, Status::Ok);
+        assert!(!checks[0].headline.contains("USERNAME"));
+    }
+
+    #[test]
+    fn auth_legacy_basic_warns_on_key_and_notes_legacy() {
+        let checks = auth_checks(false, true, true);
+        assert_eq!(checks.len(), 2);
+
+        // Missing API key is a warning, not a failure: launch/debug still work.
+        assert_eq!(checks[0].status, Status::Warn);
+        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
+
+        // The legacy creds get their own passing check with explanatory notes
+        // that steer the user back toward an API key.
+        assert_eq!(checks[1].status, Status::Ok);
+        let notes = checks[1].notes.join(" ");
+        assert!(notes.contains("legacy"));
+        assert!(notes.contains("snouty launch"));
+        assert!(notes.contains("ANTITHESIS_API_KEY"));
+    }
+
+    #[test]
+    fn auth_nothing_set_errors_and_only_mentions_api_key() {
+        let checks = auth_checks(false, false, false);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, Status::Error);
+        assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
+
+        let notes = checks[0].notes.join(" ");
+        assert!(notes.contains("requires an API key"));
+        // Nothing-set must steer to the API key only — no username/password noise.
+        assert!(!checks[0].headline.contains("USERNAME"));
+        assert!(!notes.contains("USERNAME"));
+        assert!(!notes.contains("PASSWORD"));
+    }
+
+    #[test]
+    fn auth_partial_basic_errors_like_nothing_set() {
+        for (username, password) in [(true, false), (false, true)] {
+            let checks = auth_checks(false, username, password);
+            assert_eq!(checks.len(), 1);
+            assert_eq!(checks[0].status, Status::Error);
+            assert!(checks[0].headline.contains("ANTITHESIS_API_KEY is not set"));
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn run(cli: Cli) -> Result<()> {
             cmd_debug(args, json, verbose).await
         }
         Commands::Validate(args) => validate::cmd_validate(args).await,
-        Commands::Doctor => snouty::doctor::cmd_doctor(),
+        Commands::Doctor => snouty::doctor::cmd_doctor(json),
         Commands::Completions { shell } => cmd_completions(shell),
         Commands::Version => {
             println!("snouty {}", env!("CARGO_PKG_VERSION"));
@@ -141,9 +141,9 @@ fn json_unaware_command_name(command: &Commands) -> Option<&'static str> {
         | Commands::Run(_)
         | Commands::Runs { .. }
         | Commands::Docs { .. }
-        | Commands::Debug { .. } => None,
+        | Commands::Debug { .. }
+        | Commands::Doctor => None,
         Commands::Validate(_) => Some("validate"),
-        Commands::Doctor => Some("doctor"),
         Commands::Completions { .. } => Some("completions"),
         Commands::Version => Some("version"),
         Commands::Update(_) => Some("update"),


### PR DESCRIPTION
`snouty doctor` previously optimized its auth check for username/password: when no credentials were set it reported only the missing `ANTITHESIS_USERNAME`/`ANTITHESIS_PASSWORD` and never mentioned the API key — even though snouty prefers an API key, which unlocks the full Antithesis API, while username/password only authenticates `launch` and `debug`. This reframes the doctor authentication report around the API key.

Each check now states the bare fact on its headline and explains itself in indented NOTE/WARNING/ERROR lines:

- With nothing configured, doctor points only at `ANTITHESIS_API_KEY` (an error) and tells you to ask Antithesis support for one — it no longer steers toward the legacy credentials.
- A username/password pair is accepted but flagged as a legacy method scoped to `snouty launch`/`snouty debug`, with a warning to set an API key for full access.
- `ANTITHESIS_TENANT` and `ANTITHESIS_REPOSITORY` get explanatory notes, and `REPOSITORY` is a warning rather than an error since it's only needed to launch with `--config`, so a read-only setup passes.
- On failure doctor prints a plain summary that counts problems and warnings and exits non-zero, instead of the generic eyre `Error:` footer.

`snouty doctor --json` now emits a structured report (an `ok` boolean plus a `checks` array of name/status/message/notes) so a CI step can gate on it.

The gallery (`scripts/gen-gallery.py`) gains a story per distinct doctor output — API key, API key alongside leftover legacy creds, fresh install, legacy-only, and `--json` — through a per-story env-override mechanism, and every generated command block now records its exit code so a reviewer can sanity-check the return code against the output.

fixes #145