### PR TITLE
feat(doctor): report API and tenant version, validate connectivity

### DIFF
--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -1093,13 +1093,60 @@ def build_stories(d: Discovery) -> list[Story]:
             "doctor-api-key",
             "Confirm my environment is ready with an API key",
             "I've configured snouty with an API key and want doctor to confirm I'm set up.",
-            "doctor reports the API key as set with a single green check and does not mention "
-            "username/password at all.",
+            "doctor reports the API key as set without mentioning username/password, and also "
+            "contacts the API to confirm it's reachable and report the API and tenant versions.",
             ["doctor"],
             doctor_check(
-                contains=("ANTITHESIS_API_KEY is set",),
+                contains=("ANTITHESIS_API_KEY is set", "Antithesis API reachable"),
                 absent=("ANTITHESIS_USERNAME", "ANTITHESIS_PASSWORD"),
             ),
+            json_capable=False,
+            env=_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
+        ),
+        Story(
+            "doctor-offline",
+            "Check my setup without touching the network",
+            "I don't want snouty making any network calls; I just want to validate my local "
+            "tooling and environment variables.",
+            "doctor runs every local check but skips the API connectivity/version check entirely "
+            "— there is no 'Antithesis API' line — and still reports the rest.",
+            ["doctor", "--offline"],
+            doctor_check(
+                contains=("ANTITHESIS_API_KEY is set",),
+                absent=("Antithesis API",),
+            ),
+            json_capable=False,
+            env=_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
+        ),
+        Story(
+            "doctor-api-unreachable",
+            "The Antithesis API can't be reached",
+            "I run doctor but the API host is unreachable (wrong tenant, blocked network, or the "
+            "service is down); I want a clear failure fast, not a hang.",
+            "doctor reports the API as unreachable and fails (non-zero exit), and it returns "
+            "promptly — the connect timeout bounds a black-holed or unresolvable host rather than "
+            "letting doctor hang.",
+            ["doctor"],
+            doctor_check(contains=("Antithesis API unreachable",), ok=False),
+            json_capable=False,
+            # Point the client at a reserved, unroutable address (RFC 5737
+            # TEST-NET-1) so the connect attempt is black-holed.
+            env={
+                **_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
+                "ANTITHESIS_BASE_URL": "http://192.0.2.1",
+            },
+        ),
+        Story(
+            "doctor-verbose",
+            "See the API request doctor makes",
+            "I'm debugging connectivity and want to see the exact request doctor sends to the "
+            "Antithesis API.",
+            "doctor's report prints, and stderr shows the `> GET .../api/version` request (auth "
+            "token redacted) for the version check. This is a debugging flag: the full request "
+            "AND response is intended output, including bulky response headers and long lines — "
+            "do not treat header verbosity or line width here as a defect.",
+            ["doctor", "--verbose"],
+            doctor_check(contains=("> GET", "Antithesis API reachable")),
             json_capable=False,
             env=_doctor_env(api_key=True, username=False, password=False, tenant=True, repo=True),
         ),

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -34,3 +34,44 @@ env ANTITHESIS_PASSWORD=testpass
 stderr '.*ANTITHESIS_API_KEY is not set.*'
 stderr '.*legacy.*'
 stderr '.*snouty launch.*'
+
+# --- API connectivity + version check (issue #146) ---
+# Cases that inject a status via mock-server are [!staging]-gated: under
+# SNOUTY_STAGING, mock-server passes through to the real API where fabricated
+# responses don't hold. The --offline and unreachable cases use a controlled
+# local setup and run in both modes. The mock + --offline cases assume a
+# container runtime (CI provisions one); the unreachable case is robust either way.
+
+# 2xx: doctor reports the live API and tenant release versions. The check runs
+# only with an API key (the endpoint rejects basic auth), so set one on top of
+# the basic creds mock-server configures.
+[!staging] mock-server 200 '{"latest_api_version":"v1","release_version":"56.0"}'
+[!staging] env ANTITHESIS_API_KEY=testkey
+[!staging] snouty doctor
+[!staging] stderr '.*Antithesis API reachable.*'
+[!staging] stderr '.*latest API version: v1.*'
+[!staging] stderr '.*tenant release version: 56.0.*'
+
+# 404: an older tenant predating the version endpoint — still reachable and
+# authenticated, so doctor stays green and warns the tenant release is old.
+[!staging] mock-server 404 '{}'
+[!staging] env ANTITHESIS_API_KEY=testkey
+[!staging] snouty doctor
+[!staging] stderr '.*Antithesis API reachable.*'
+[!staging] stderr '.*older than v56.*'
+[!staging] stderr '.*upgrade recommended.*'
+
+# --offline skips the network check entirely: no version line, no API contact.
+env ANTITHESIS_API_KEY=testkey
+env ANTITHESIS_TENANT=testtenant
+snouty doctor --offline
+! stderr '.*Antithesis API.*'
+
+# Connection failure: the check fails (non-zero) with a host-named note (the raw
+# error detail follows it; its exact text is reqwest's and unit-tested instead).
+env ANTITHESIS_API_KEY=testkey
+env ANTITHESIS_TENANT=testtenant
+env ANTITHESIS_BASE_URL=http://127.0.0.1:1
+! snouty doctor
+stderr '.*Antithesis API unreachable.*'
+stderr '.*could not connect to 127.0.0.1.*'

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,6 +28,23 @@ pub use generated::types::{
 };
 pub use progenitor_client::ByteStream;
 
+/// API and tenant release version, from `GET /api/version`.
+#[derive(Debug, Clone)]
+pub struct ApiVersion {
+    pub latest_api_version: String,
+    pub release_version: String,
+}
+
+/// Why a `/api/version` probe failed, classified for `snouty doctor`.
+#[derive(Debug)]
+pub enum VersionError {
+    /// The server replied with a non-success HTTP status (e.g. 404 when the
+    /// endpoint is missing on an older backend, or 401/403 when auth is rejected).
+    Http(u16),
+    /// The API could not be reached at all (DNS, connection, TLS, timeout).
+    Unreachable(String),
+}
+
 fn params_test_name(params: Option<&RunParams>) -> Option<&str> {
     params.and_then(|p| p.extra.get("antithesis.test_name").map(String::as_str))
 }
@@ -116,6 +133,12 @@ fn normalize_property(property: Property) -> Result<Property> {
 }
 
 const CLIENT_TIMEOUT_SECS: u64 = 60;
+
+/// Aggressive connect-phase cap (DNS + TCP + TLS). The `/api/version` probe in
+/// `snouty doctor` is expected to be fast, and no command should hang on a
+/// black-holed or unresolvable host; this bounds connection setup without
+/// limiting long streaming responses (governed by the total timeout above).
+const CONNECT_TIMEOUT_SECS: u64 = 5;
 
 fn required_env(name: &'static str) -> Result<String> {
     env::var(name).map_err(|e| match e {
@@ -308,6 +331,15 @@ impl AntithesisApi {
         &self.base_url
     }
 
+    /// The host of the configured base URL (no scheme, port, or path), for
+    /// user-facing messages. Falls back to the full base URL if it won't parse.
+    pub fn host(&self) -> String {
+        reqwest::Url::parse(&self.base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_string))
+            .unwrap_or_else(|| self.base_url.clone())
+    }
+
     pub async fn launch_test(&self, launcher: &str, params: &Params) -> Result<LaunchResponse> {
         let body = launch_request(params)?;
         let result = self
@@ -385,6 +417,29 @@ impl AntithesisApi {
         match self.client.get_run().run_id(run_id).send().await {
             Ok(response) => Ok(response.into_inner()),
             Err(err) => Err(format_api_client_error(err).await),
+        }
+    }
+
+    /// Probe `GET /api/version` for the API and tenant release versions. The
+    /// endpoint is unauthenticated, so a success doubles as proof the API is
+    /// reachable; `snouty doctor` uses it as a connectivity check. Errors are
+    /// classified (HTTP status vs unreachable) rather than rendered, so the
+    /// caller can decide how to present each case.
+    pub async fn get_version(&self) -> std::result::Result<ApiVersion, VersionError> {
+        // The connect-phase timeout on the client (CONNECT_TIMEOUT_SECS) keeps a
+        // black-holed or unresolvable host from hanging this probe.
+        match self.client.get_version().send().await {
+            Ok(response) => {
+                let v = response.into_inner();
+                Ok(ApiVersion {
+                    latest_api_version: v.latest_api_version,
+                    release_version: v.release_version,
+                })
+            }
+            Err(err) => Err(match err.status() {
+                Some(code) => VersionError::Http(code.as_u16()),
+                None => VersionError::Unreachable(err.to_string()),
+            }),
         }
     }
 
@@ -749,6 +804,7 @@ fn build_http_client(default_headers: reqwest::header::HeaderMap) -> Result<Clie
     Client::builder()
         .default_headers(default_headers)
         .timeout(Duration::from_secs(CLIENT_TIMEOUT_SECS))
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
         .build()
         .wrap_err("failed to build API client")
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -163,13 +163,18 @@ Checks container runtime availability and required environment variables.
 snouty prefers an API key (full API access); a username and password is legacy
 auth, accepted only by `snouty launch` and `snouty debug`.
 
+When credentials are configured, doctor also contacts the Antithesis API to
+report the API and tenant versions and confirm connectivity. Pass --offline to
+skip that network call.
+
 Exits non-zero if any required check fails. Pass --json for a machine-readable
 report (e.g. to gate CI).
 
 Example:
   snouty doctor
-  snouty doctor --json"#)]
-    Doctor,
+  snouty doctor --json
+  snouty doctor --offline"#)]
+    Doctor(DoctorArgs),
 
     /// Print version information
     Version,
@@ -296,6 +301,13 @@ pub struct ValidateArgs {
     /// Leave containers running after validation for manual inspection
     #[arg(long)]
     pub keep_running: bool,
+}
+
+#[derive(Args)]
+pub struct DoctorArgs {
+    /// Skip the network check (don't contact the Antithesis API for versions)
+    #[arg(long)]
+    pub offline: bool,
 }
 
 #[derive(Args)]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -3,6 +3,7 @@ use std::env;
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
+use crate::api::{AntithesisApi, ApiVersion, VersionError};
 use crate::container;
 
 /// Outcome of a single check. Only `Error` fails doctor; `Warn` is surfaced but
@@ -236,8 +237,69 @@ fn collect_checks() -> Vec<Check> {
     checks
 }
 
-pub fn cmd_doctor(json: bool) -> Result<()> {
-    let checks = collect_checks();
+/// Map a `GET /api/version` probe into a check. Reaching the endpoint at all —
+/// even a 404 on an older backend that lacks it — proves connectivity, so only
+/// rejected auth, an API error, or a failure to reach the API is a problem.
+/// Pure over the result so it can be unit-tested without the network.
+fn version_check(host: &str, result: std::result::Result<ApiVersion, VersionError>) -> Check {
+    match result {
+        Ok(v) => Check::ok("api", "Antithesis API reachable")
+            .note(
+                Level::Note,
+                format!("latest API version: {}", v.latest_api_version),
+            )
+            .note(
+                Level::Note,
+                format!("tenant release version: {}", v.release_version),
+            ),
+        // 404: the version endpoint was added in release 56, so an older tenant
+        // 404s — but the request was served, so auth and connectivity are fine
+        // and the API is the stable v1.
+        Err(VersionError::Http(404)) => Check::ok("api", "Antithesis API reachable").note(
+            Level::Warning,
+            "tenant release version: older than v56; upgrade recommended",
+        ),
+        // 401/403: the request was rejected — authentication is broken.
+        // Connectivity is only probably ok (a proxy can reject before the
+        // request reaches the API), so we don't claim it.
+        Err(VersionError::Http(status @ (401 | 403))) => {
+            Check::fail("api", "Antithesis API rejected authentication")
+                .note(Level::Error, format!("the API returned HTTP {status}"))
+                .note(Level::Note, "check ANTITHESIS_API_KEY")
+        }
+        // 5xx: we reached something, but it's erroring — connectivity is broken
+        // by a server error and auth status is unknown.
+        Err(VersionError::Http(status)) if (500..=599).contains(&status) => {
+            Check::fail("api", "Antithesis API unavailable").note(
+                Level::Error,
+                format!("the API returned HTTP {status} (server error)"),
+            )
+        }
+        // Any other unexpected status.
+        Err(VersionError::Http(status)) => Check::fail("api", "Antithesis API error").note(
+            Level::Error,
+            format!("the API returned an unexpected HTTP {status}"),
+        ),
+        // Couldn't connect at all — connectivity is broken.
+        Err(VersionError::Unreachable(err)) => Check::fail("api", "Antithesis API unreachable")
+            .note(Level::Error, format!("could not connect to {host}"))
+            .note(Level::Error, err),
+    }
+}
+
+pub async fn cmd_doctor(json: bool, verbose: bool, offline: bool) -> Result<()> {
+    let mut checks = collect_checks();
+
+    // Connectivity + version check (network). Skipped with --offline. Only runs
+    // with an API key: /api/version, like every endpoint but launch, rejects
+    // basic auth, so probing it under username/password would only yield a
+    // misleading 403 — and the auth checks above already tell legacy and
+    // unauthenticated users to set a key. `verbose` logs the request/response.
+    if !offline && let Ok(api) = AntithesisApi::from_env_requiring_api_key(verbose) {
+        let host = api.host();
+        checks.push(version_check(&host, api.get_version().await));
+    }
+
     let errors = checks.iter().filter(|c| c.status == Status::Error).count();
     let warnings = checks.iter().filter(|c| c.status == Status::Warn).count();
 
@@ -385,6 +447,99 @@ mod tests {
         let check = repository_check(false);
         assert_eq!(check.status, Status::Warn);
         assert!(check.notes.iter().any(|n| n.text.contains("--config")));
+    }
+
+    #[test]
+    fn version_ok_reports_both_versions() {
+        let check = version_check(
+            "tenant.antithesis.com",
+            Ok(ApiVersion {
+                latest_api_version: "v1".into(),
+                release_version: "56.0".into(),
+            }),
+        );
+        assert_eq!(check.status, Status::Ok);
+        let notes = check
+            .notes
+            .iter()
+            .map(|n| n.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(notes.contains("v1"));
+        assert!(notes.contains("56.0"));
+    }
+
+    #[test]
+    fn version_404_is_reachable_but_warns_an_old_tenant() {
+        // 404 means an older tenant that predates the endpoint, but the request
+        // was served — so connectivity and auth are fine; doctor stays green and
+        // warns that the tenant release is old.
+        let check = version_check("tenant.antithesis.com", Err(VersionError::Http(404)));
+        assert_eq!(check.status, Status::Ok);
+        assert!(check.message.contains("reachable"));
+        assert!(
+            check
+                .notes
+                .iter()
+                .any(|n| n.level == Level::Warning && n.text.contains("older than v56"))
+        );
+    }
+
+    #[test]
+    fn version_auth_rejection_reports_the_status_code() {
+        for status in [401, 403] {
+            let check = version_check("tenant.antithesis.com", Err(VersionError::Http(status)));
+            assert_eq!(check.status, Status::Error);
+            assert!(
+                check
+                    .notes
+                    .iter()
+                    .any(|n| n.text.contains(&status.to_string()))
+            );
+            assert!(
+                check
+                    .notes
+                    .iter()
+                    .any(|n| n.text.contains("ANTITHESIS_API_KEY"))
+            );
+        }
+    }
+
+    #[test]
+    fn version_unreachable_names_the_host_and_includes_the_error() {
+        let check = version_check(
+            "tenant.antithesis.com",
+            Err(VersionError::Unreachable("connection refused".into())),
+        );
+        assert_eq!(check.status, Status::Error);
+        assert!(check.message.contains("unreachable"));
+        // A clean host-named note, plus the raw error for debugging.
+        assert!(check.notes.iter().any(|n| {
+            n.text
+                .contains("could not connect to tenant.antithesis.com")
+        }));
+        assert!(
+            check
+                .notes
+                .iter()
+                .any(|n| n.text.contains("connection refused"))
+        );
+    }
+
+    #[test]
+    fn version_5xx_is_unavailable_with_status() {
+        // 5xx is connectivity broken by a server error (auth unknown).
+        let check = version_check("tenant.antithesis.com", Err(VersionError::Http(503)));
+        assert_eq!(check.status, Status::Error);
+        assert!(check.message.contains("unavailable"));
+        assert!(check.notes.iter().any(|n| n.text.contains("503")));
+    }
+
+    #[test]
+    fn version_unexpected_status_is_an_error_with_status() {
+        let check = version_check("tenant.antithesis.com", Err(VersionError::Http(429)));
+        assert_eq!(check.status, Status::Error);
+        assert!(check.notes.iter().any(|n| n.text.contains("429")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn run(cli: Cli) -> Result<()> {
             cmd_debug(args, json, verbose).await
         }
         Commands::Validate(args) => validate::cmd_validate(args).await,
-        Commands::Doctor => snouty::doctor::cmd_doctor(json),
+        Commands::Doctor(args) => snouty::doctor::cmd_doctor(json, verbose, args.offline).await,
         Commands::Completions { shell } => cmd_completions(shell),
         Commands::Version => {
             println!("snouty {}", env!("CARGO_PKG_VERSION"));
@@ -142,7 +142,7 @@ fn json_unaware_command_name(command: &Commands) -> Option<&'static str> {
         | Commands::Runs { .. }
         | Commands::Docs { .. }
         | Commands::Debug { .. }
-        | Commands::Doctor => None,
+        | Commands::Doctor(_) => None,
         Commands::Validate(_) => Some("validate"),
         Commands::Completions { .. } => Some("completions"),
         Commands::Version => Some("version"),


### PR DESCRIPTION
`snouty doctor` now contacts `GET /api/version` when an API key is configured, reporting the latest API version and the tenant's release version — which doubles as a connectivity and authentication check.

The result is classified by what the response actually tells us:

- **2xx** — reports the API and tenant release versions; auth and connectivity confirmed.
- **404** — the version endpoint was added in release 56, so an older tenant 404s; the request was still served, so doctor stays green and warns that the tenant release is old.
- **401/403** — authentication rejected. Connectivity isn't claimed, since a proxy can reject before the request reaches the API.
- **5xx** — the API is unavailable (server error); connectivity is broken and auth is unknown.
- **connection failure** — unreachable, naming the host (the raw error follows for debugging).

The check runs only with an API key — every endpoint but launch rejects basic auth, so probing it under username/password would only yield a misleading 403, and the existing auth checks already steer legacy/unauthenticated users toward a key. `--offline` skips the network call entirely.

To keep a black-holed or unresolvable host from hanging the command, the API client now sets an aggressive `connect_timeout` (bounding DNS + TCP + TLS without limiting long streaming responses). This applies to every command, not just doctor. `--verbose` logs the version request/response, and the versions ride in the check's notes so `--json` reports them too.

The gallery (`scripts/gen-gallery.py`) gains stories for the offline, unreachable, and verbose cases, and `doctor-api-key` now shows the version line.

fixes #146