### PR TITLE
fix(release): v0.6.0 release-blocker fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Python bytecode cache (e.g. from running scripts/gen-gallery.py)
 __pycache__/
 *.pyc
+
+# uv project virtualenv (created when running scripts via `uv run`)
+.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,11 @@ checks run against staging — any spec that would mutate state is gated
 
 ## Scripts
 
-The `scripts/` directory holds Python helpers run via `uv` (each has an inline
-`# /// script` dependency header). After changing `gen-gallery.py`, type-check it
-with pyright and confirm it reports 0 errors before considering the change done:
+The `scripts/` directory holds Python helpers run via `uv` (e.g.
+`uv run scripts/gen-gallery.py`). The Python version and dependencies are
+managed centrally in the top-level `pyproject.toml` rather than per-script.
+After changing `gen-gallery.py`, type-check it with pyright and confirm it
+reports 0 errors before considering the change done:
 
 ```
 uvx pyright scripts/gen-gallery.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,7 @@ dependencies = [
  "jsonschema",
  "libc",
  "log",
+ "openapiv3",
  "predicates",
  "prettyplease",
  "progenitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ name = "mock_api"
 path = "examples/mock_api.rs"
 
 [build-dependencies]
+# Same openapiv3 version progenitor resolves; build.rs preprocesses the spec
+# through this type before handing it to the generator.
+openapiv3 = "2"
 prettyplease = "0.2"
 progenitor = "0.14.0"
 quote = "1"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Antithesis supports two forms of authentication, supplied via environment variab
 export ANTITHESIS_API_KEY="your-api-key"
 ```
 
-Username/password authentication is only supported when launching runs (`snouty launch`, `snouty debug`, and `snouty api webhook`). All other commands that talk to the API — such as `snouty runs` — require an API key.
+Username/password authentication is only supported when launching runs (`snouty launch` and `snouty debug`). All other commands that talk to the API — such as `snouty runs` — require an API key.
 
 ```sh
 export ANTITHESIS_USERNAME="your-username"
@@ -140,8 +140,9 @@ Snouty provides the following subcommands. Invoke `snouty <command> --help` to f
 - `snouty debug`: start a debug session.
 - `snouty validate`: locally run and validate your docker-compose.yaml setup.
 - `snouty doctor`: check your environment is configured correctly.
-- `snouty docs`: fast, local search of the Antithesis documentation.
+- `snouty docs`: search the Antithesis documentation locally (auto-refreshes the local copy over the network; pass `--offline` to skip).
 - `snouty completions <shell>`: generate shell completion scripts.
+- `snouty version`: print version and build information.
 - `snouty update`: install the latest version.
 
 ## Shell Completions

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn main() {
         "cargo:rustc-env=SNOUTY_RUSTC_VERSION={}",
         rustc_version().unwrap()
     );
+    emit_version();
 
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     fs::create_dir_all(&out_dir).unwrap();
@@ -17,7 +18,29 @@ fn main() {
 
 fn generate_api_client(out_dir: &Path) {
     let file = std::fs::File::open("src/openapi.json").unwrap();
-    let spec = serde_json::from_reader(file).unwrap();
+    let mut spec_value: serde_json::Value = serde_json::from_reader(file).unwrap();
+
+    // A schema's `additionalProperties: false` makes progenitor/typify emit
+    // `#[serde(deny_unknown_fields)]`, which turns a forwards-compatible server
+    // change (a new field added to a response) into a hard deserialization
+    // error — e.g. `snouty doctor` would report a healthy API as "unreachable"
+    // the day `/api/version` grows a field. typify has no setting to disable
+    // this (the choice is hardwired from the schema value), so strip the
+    // constraint from the spec itself before generating, rather than patching
+    // the generated text afterwards. Removing the key is equivalent to the
+    // permissive default: no `deny_unknown_fields` is emitted, and no flattened
+    // `extra` map is added, so struct shapes are unchanged. Operating on the
+    // structured spec (not the formatted output) also handles the attribute
+    // wherever it would appear — including combined with other serde options on
+    // one line (`#[serde(rename = "…", deny_unknown_fields)]`) and on enums —
+    // which a line-text patch could silently miss.
+    let stripped = strip_additional_properties_false(&mut spec_value);
+    assert!(
+        stripped > 0,
+        "expected the openapi spec to mark some schema `\"additionalProperties\": false`; \
+         none found — the lenient-client transform is now a no-op and can be removed"
+    );
+    let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_interface(progenitor::InterfaceStyle::Builder);
@@ -29,6 +52,31 @@ fn generate_api_client(out_dir: &Path) {
     let content = patch_lenient_booleans(content);
 
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
+}
+
+/// Recursively remove every `"additionalProperties": false` from the spec so
+/// the generated client is lenient about unknown response fields (see the call
+/// site for why). Returns the number of occurrences removed.
+fn strip_additional_properties_false(value: &mut serde_json::Value) -> usize {
+    let mut count = 0;
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
+                map.remove("additionalProperties");
+                count += 1;
+            }
+            for v in map.values_mut() {
+                count += strip_additional_properties_false(v);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items.iter_mut() {
+                count += strip_additional_properties_false(v);
+            }
+        }
+        _ => {}
+    }
+    count
 }
 
 // The API represents booleans as the strings "true"/"false", but some
@@ -60,6 +108,59 @@ fn patch_lenient_booleans(content: String) -> String {
         content = content.replace(from, to);
     }
     content
+}
+
+// Compose the display version string as `SNOUTY_VERSION`, used by both `snouty
+// version` and clap's `--version`. It is the crate version, plus the short git
+// commit hash the build came from when available — with a `-dirty` suffix when
+// tracked files differ from HEAD (the standard `git describe --dirty`
+// convention) — e.g. `0.6.0 (a1b2c3d)` or `0.6.0 (a1b2c3d-dirty)`. When git or
+// the repository is unavailable (e.g. building from a published source
+// tarball), it falls back to the bare crate version, `0.6.0`.
+fn emit_version() {
+    // Rebuild when the checked-out commit or staged state changes, so the stamp
+    // stays current. (Purely unstaged edits don't retrigger on their own; the
+    // next rebuild for any reason picks them up — the same caveat vergen and
+    // similar build-stamp tools carry.)
+    for path in [".git/HEAD", ".git/index"] {
+        if Path::new(path).exists() {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+    // CARGO_PKG_VERSION is provided to build scripts by cargo.
+    let pkg = std::env::var("CARGO_PKG_VERSION").unwrap();
+    let version = match git_sha() {
+        Some(sha) => format!("{pkg} ({sha})"),
+        None => pkg,
+    };
+    println!("cargo:rustc-env=SNOUTY_VERSION={version}");
+}
+
+fn git_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+    if sha.is_empty() {
+        return None;
+    }
+
+    // `git status --porcelain` refreshes the index as a side effect (avoiding
+    // stat-only false positives) and, with untracked files excluded, reports
+    // only tracked modifications — matching `git describe --dirty` semantics.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    Some(if dirty { format!("{sha}-dirty") } else { sha })
 }
 
 fn rustc_version() -> Result<String, Box<dyn std::error::Error>> {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+# Central configuration for the Python helper scripts in `scripts/`.
+#
+# These scripts are run with `uv` (e.g. `uv run scripts/gen-gallery.py`), which
+# uses this file to pin a consistent Python version and to manage dependencies
+# in one place rather than per-script inline metadata. No third-party
+# dependencies are needed today; add them to `dependencies` below as required.
+[project]
+name = "snouty-scripts"
+version = "0.0.0"
+description = "Python helper scripts for snouty, run via uv."
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.uv]
+# Scripts only — there is no installable package to build here.
+package = false

--- a/scripts/build-validate-samples.sh
+++ b/scripts/build-validate-samples.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build the container images for the live `snouty validate` sample projects.
+#
+# The live samples bake their Antithesis test commands into an image (rather
+# than bind-mounting them from the host), so the images must already exist
+# locally before `snouty validate` runs — validate never builds and never
+# pulls. The gallery generator (scripts/gen-gallery.py) runs this before its
+# live validate stories; run it by hand the same way:
+#
+#   scripts/build-validate-samples.sh
+#
+# Any sample with a Dockerfile is built (its compose `image:` tag). The
+# `missing-image` sample intentionally has no Dockerfile — it references an
+# image that doesn't exist, to exercise validate's "image not available"
+# path — so it is skipped here.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+samples_dir="$repo_root/tests/fixtures/validate"
+base_image="debian:bookworm-slim"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found on PATH" >&2
+  exit 1
+fi
+# Use the standalone `docker-compose` binary (Compose v2), matching what snouty
+# itself invokes — not the `docker compose` plugin subcommand.
+if ! command -v docker-compose >/dev/null 2>&1; then
+  echo "error: docker-compose not found on PATH" >&2
+  exit 1
+fi
+
+# Pull the glibc base once. validate's `--pull=never` means the samples that
+# use the base directly (timeout, stranded's app service) need it present, and
+# the built images FROM it.
+echo "Pulling base image ${base_image}…"
+docker pull -q "$base_image" >/dev/null
+
+built=0
+for compose in "$samples_dir"/*/docker-compose.yaml; do
+  dir="$(dirname "$compose")"
+  [ -f "$dir/Dockerfile" ] || continue
+  echo "Building image(s) for sample '$(basename "$dir")'…"
+  docker-compose -f "$compose" build
+  built=$((built + 1))
+done
+
+echo "Built ${built} sample image(s); base ${base_image} present."

--- a/scripts/build_docs_fixture.py
+++ b/scripts/build_docs_fixture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
 """Build a docs.db fixture from a folder of sample markdown files."""
 
 from __future__ import annotations

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env -S uv run --script
-# /// script
-# requires-python = ">=3.11"
-# dependencies = []
-# ///
+#!/usr/bin/env -S uv run
 """Regenerate the snouty "gallery" against fresh, live run IDs.
 
 The gallery is a set of Markdown files, one per "story". Each story models a
@@ -58,6 +54,16 @@ UNKNOWN_RUN = "ffffffffffffffffffffffffffffffff-54-5"
 # Stories are captured concurrently (each is one or two snouty subprocesses that
 # can each block on snouty's 60s timeout); checks are then evaluated serially.
 CAPTURE_WORKERS = 6
+
+# Committed `snouty validate` sample projects (their goal is documented in the
+# comment atop each docker-compose.yaml). The validate stories run `snouty
+# validate` against these.
+SAMPLES_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "validate"
+
+# The live samples bake their test commands into images; `snouty validate`
+# never builds or pulls, so the images must exist first. This script builds
+# them (and pulls the glibc base) and is run before the live validate stories.
+BUILD_SAMPLES_SCRIPT = Path(__file__).resolve().parent / "build-validate-samples.sh"
 
 # Keywords probed (in order) to sample a real event from a run. --match is
 # required, so a truly unfiltered call isn't possible; ordering broadest-first
@@ -223,10 +229,31 @@ def _sample_event(sn: Snouty, run: str) -> dict | None:
     return None
 
 
-def _pick_event_completed_run(sn: Snouty, scan: int) -> tuple[str, dict]:
+@dataclass
+class CompletedPick:
+    """A completed run that can drive *every* completed-run story, plus the
+    per-story selections derived from it (so discovery doesn't re-derive them)."""
+
+    run: str
+    event: dict
+    fail_prop: str
+    pass_prop: str
+    nonevent_prop: str
+    name_filter: str
+
+
+def _pick_completed_run(sn: Snouty, scan: int) -> CompletedPick:
+    """Pick a completed run that can drive *all* the completed-run stories, not
+    just the event/logs ones. Earlier this committed to the first run with
+    sampleable events, then `discover` separately demanded that same run also
+    render failing/passing/non-event property moments — so a run with events but
+    no failing-property moments (the first completed run on a tenant routinely is
+    one) sank the whole gallery. Instead, scan recent completed runs and take the
+    first that satisfies every requirement at once."""
     runs = sn.json_lines(["runs", "list", "--status", "completed", "-n", str(scan)])
     if not runs:
         raise GalleryError("no completed runs found on this tenant")
+    last_reason = "none had sampleable events"
     for r in runs:
         run = r["run_id"]
         try:
@@ -234,17 +261,34 @@ def _pick_event_completed_run(sn: Snouty, scan: int) -> tuple[str, dict]:
         except GalleryError:
             print(f"  skip {run}: events endpoint unreachable", file=sys.stderr)
             continue
-        if event is not None:
-            print(
-                f"  completed run : {run} (events matched '{event['_keyword']}')",
-                file=sys.stderr,
-            )
-            return run, event
-        print(f"  skip {run}: no sampleable events", file=sys.stderr)
+        if event is None:
+            print(f"  skip {run}: no sampleable events", file=sys.stderr)
+            continue
+        # Has events; now require it to drive the property stories too. Each
+        # picker raises GalleryError if this run can't satisfy its story — catch
+        # it and move on rather than committing to a run that fails downstream.
+        props = sn.json_lines(["runs", "properties", run])
+        try:
+            fail_prop = _pick_property_with_moments(sn, run, props, "Failing")
+            pass_prop = _pick_property_with_moments(sn, run, props, "Passing")
+            nonevent_prop = _pick_nonevent_property(sn, run, props)
+            name_filter = _pick_name_filter([p["name"] for p in props])
+        except GalleryError as e:
+            print(f"  skip {run}: {e}", file=sys.stderr)
+            last_reason = str(e)
+            continue
+        print(
+            f"  completed run : {run} (events matched '{event['_keyword']}')",
+            file=sys.stderr,
+        )
+        return CompletedPick(
+            run, event, fail_prop, pass_prop, nonevent_prop, name_filter
+        )
     raise GalleryError(
-        f"none of the {len(runs)} most recent completed runs returned events "
-        "(all unreachable or empty) — refusing to write a gallery with the "
-        "event/logs stories skipped"
+        f"none of the {len(runs)} most recent completed runs can drive every "
+        f"completed-run story (need sampleable events plus failing/passing/"
+        f"non-event property moments and a unique name filter); last reason: "
+        f"{last_reason}"
     )
 
 
@@ -448,7 +492,8 @@ def _pick_name_filter(prop_names: list[str]) -> str:
 def discover(sn: Snouty, scan: int) -> Discovery:
     print("discovering runs via the live API…", file=sys.stderr)
 
-    success, event = _pick_event_completed_run(sn, scan)
+    pick = _pick_completed_run(sn, scan)
+    success, event = pick.run, pick.event
 
     fail, fail_moment, fail_event_kw = _pick_incomplete_run(sn, scan)
     cancelled = _first_run(sn, "--status", "cancelled")
@@ -473,9 +518,6 @@ def discover(sn: Snouty, scan: int) -> Discovery:
     keyword = event["_keyword"]
     moment = event["moment"]
 
-    props = sn.json_lines(["runs", "properties", success])
-    prop_names = [p["name"] for p in props]
-
     disc = Discovery(
         success=success,
         fail=fail,
@@ -488,10 +530,12 @@ def discover(sn: Snouty, scan: int) -> Discovery:
         event_kw2=event["_second_needle"],
         event_hash=moment["input_hash"],
         event_vtime=float(moment["vtime"]),
-        fail_prop=_pick_property_with_moments(sn, success, props, "Failing"),
-        pass_event_prop=_pick_property_with_moments(sn, success, props, "Passing"),
-        nonevent_prop=_pick_nonevent_property(sn, success, props),
-        name_filter=_pick_name_filter(prop_names),
+        # Property-story selections were derived against `success` during the
+        # holistic run pick, so reuse them rather than re-probing the API.
+        fail_prop=pick.fail_prop,
+        pass_event_prop=pick.pass_prop,
+        nonevent_prop=pick.nonevent_prop,
+        name_filter=pick.name_filter,
         # _pick_incomplete_run guarantees a real (non-0/0) failure moment.
         fail_hash=str(fail_moment["input_hash"]),
         fail_vtime=str(fail_moment["vtime"]),
@@ -538,6 +582,11 @@ class Story:
     # string sets a var, None unsets it. Used by the doctor stories to model a
     # specific credential setup regardless of the operator's real environment.
     env: dict[str, str | None] | None = None
+    # The story starts real containers (a live `snouty validate` sample), as
+    # opposed to the static checks that fail before any container starts. All
+    # validate stories require a container runtime (see `ensure_validate_runtime`);
+    # this flag just documents which ones spin up live containers.
+    needs_docker: bool = False
 
 
 @dataclass
@@ -732,13 +781,29 @@ def property_non_event_result(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     return (ok, f"result={has_result}, no moments={no_moments}")
 
 
-def succeeds_with(*needles: str):
+def _exit_with(*needles: str, want_ok: bool):
+    """Story check: the command must exit with the expected success/failure AND
+    every needle must appear in its output. Requiring the exit polarity stops a
+    command that merely prints a needle (while exiting the other way) from
+    passing as the wrong kind of story."""
+
     def chk(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
         text = sr.result.combined
         missing = [n for n in needles if n not in text]
-        return (sr.result.ok and not missing, f"exit ok, missing={missing!r}")
+        ok = (sr.result.ok == want_ok) and not missing
+        return (ok, f"exit={sr.result.returncode}, missing={missing!r}")
 
     return chk
+
+
+def succeeds_with(*needles: str):
+    """A clean-success story: exit zero AND every needle appears in the output."""
+    return _exit_with(*needles, want_ok=True)
+
+
+def fails_with(*needles: str):
+    """A clean-error story: exit non-zero AND every needle appears in the output."""
+    return _exit_with(*needles, want_ok=False)
 
 
 def logs_non_empty(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
@@ -1507,6 +1572,199 @@ def build_help_stories(d: Discovery) -> list[Story]:
     ]
 
 
+def ensure_validate_runtime() -> None:
+    """Verify a container runtime is ready for the validate stories and build the
+    sample images, raising GalleryError if anything is missing.
+
+    gen-gallery is a developer tool, so a container runtime is required — not
+    optional. `snouty validate` resolves docker/podman before it even inspects a
+    config, so *every* validate story (including the static misconfiguration
+    checks) needs the runtime, and the live samples additionally need a running
+    daemon to start containers. The live samples bake their test commands into
+    images and `snouty validate` never builds or pulls, so the images must exist
+    first — built here via scripts/build-validate-samples.sh."""
+    try:
+        if subprocess.run(["docker", "info"], capture_output=True).returncode != 0:
+            raise GalleryError(
+                "Docker daemon not reachable (`docker info` failed). gen-gallery "
+                "is a developer tool and requires a running container runtime — "
+                "start Docker and retry."
+            )
+        ver = subprocess.run(["docker-compose", "version"], capture_output=True, text=True)
+        if ver.returncode != 0 or "docker compose" not in ver.stdout.lower():
+            raise GalleryError(
+                "docker-compose (Compose v2) not available (`docker-compose version` "
+                "failed or is not v2). Install the docker-compose v2 binary and retry."
+            )
+    except FileNotFoundError as e:
+        raise GalleryError(
+            f"container runtime not found ({e.filename}): gen-gallery requires "
+            "docker and the docker-compose v2 binary on PATH."
+        ) from e
+    print("building validate sample images…", file=sys.stderr)
+    build = subprocess.run(
+        ["bash", str(BUILD_SAMPLES_SCRIPT)], capture_output=True, text=True
+    )
+    if build.returncode != 0:
+        tail = (build.stderr or build.stdout).strip()
+        raise GalleryError(f"validate sample image build failed:\n{tail}")
+
+
+def build_validate_stories(ephemeral: Path | None) -> list[Story]:
+    """`snouty validate` stories, run against the committed sample projects under
+    tests/fixtures/validate (each sample has its own README). The static
+    misconfiguration samples fail fast (but still need the runtime resolved); the
+    live ones (`needs_docker`) start real containers. All require a container
+    runtime — `ensure_validate_runtime` enforces that before these run.
+
+    Two degenerate inputs can't be committed — a non-existent directory and an
+    empty `manifests/` dir (git can't track an empty directory) — so they're
+    synthesized under `ephemeral` at run time. In `--list` mode `ephemeral` is
+    None and they fall back to placeholder paths (their args are never run)."""
+    s = SAMPLES_DIR
+    missing_dir = s / "does-not-exist"  # deliberately never created
+    if ephemeral is not None:
+        empty_manifests = ephemeral / "empty-manifests"
+        (empty_manifests / "manifests").mkdir(parents=True, exist_ok=True)
+    else:
+        empty_manifests = s / "empty-manifests"  # placeholder; not run for --list
+
+    def v(slug, title, goal, judge, sample_args, check, *, needs_docker=False):
+        return Story(
+            slug=slug,
+            title=title,
+            goal=goal,
+            judge=judge,
+            args=["validate", *sample_args],
+            check=check,
+            json_capable=False,  # validate isn't a list/stream command
+            needs_docker=needs_docker,
+        )
+
+    return [
+        # -- static misconfigurations (detected before any container starts) --
+        v(
+            "validate-not-a-config",
+            "Validate a directory that isn't a config",
+            "I point validate at a directory with no compose file or manifests/.",
+            "The error says no docker-compose.yaml or manifests/ was found, so I know what's missing.",
+            [str(s / "neither")],
+            fails_with("does not contain a docker-compose.yaml file or a manifests/ subdirectory"),
+        ),
+        v(
+            "validate-missing-dir",
+            "Validate a path that doesn't exist",
+            "I mistype the path to my config directory.",
+            "The error says the path is not a directory, rather than something cryptic.",
+            [str(missing_dir)],
+            fails_with("is not a directory"),
+        ),
+        v(
+            "validate-wrong-extension",
+            "Validate a .yml compose file",
+            "My compose file is named docker-compose.yml instead of .yaml.",
+            "The error names the wrong filename and suggests the exact rename.",
+            [str(s / "wrong-extension")],
+            fails_with("not the required docker-compose.yaml", "rename it to docker-compose.yaml"),
+        ),
+        v(
+            "validate-ambiguous",
+            "Validate a dir with both compose and manifests",
+            "My directory has both a docker-compose.yaml and a manifests/ subdirectory.",
+            "The error explains the ambiguity and says to provide one or the other.",
+            [str(s / "ambiguous")],
+            fails_with("contains both docker-compose.yaml and a manifests/ subdirectory"),
+        ),
+        v(
+            "validate-empty-manifests",
+            "Validate an empty manifests/ directory",
+            "My manifests/ directory is empty.",
+            "The error says the manifests/ dir is empty, not something obscure further along.",
+            [str(empty_manifests)],
+            fails_with("empty manifests/ subdirectory"),
+        ),
+        v(
+            "validate-malformed-compose",
+            "Validate a broken compose file",
+            "My docker-compose.yaml has a YAML syntax error.",
+            "The error shows docker-compose config failed and includes the parser's message.",
+            [str(s / "malformed-compose")],
+            fails_with("'docker-compose config' failed"),
+        ),
+        v(
+            "validate-no-services",
+            "Validate a compose file with no services",
+            "My compose file declares no services.",
+            "The error states plainly that no services were found.",
+            [str(s / "no-services")],
+            fails_with("no services found in docker-compose.yaml"),
+        ),
+        v(
+            "validate-external-network",
+            "Validate a compose file with an external network",
+            "My compose file references an external network.",
+            "The error explains an external network can't work on Antithesis.",
+            [str(s / "external-network")],
+            fails_with("declared as external"),
+        ),
+        v(
+            "validate-missing-image",
+            "Validate when a service image is missing locally",
+            "A service references an image I haven't built or pulled.",
+            "The error lists the missing image and reminds me snouty never pulls.",
+            [str(s / "missing-image")],
+            fails_with("some images are not available locally"),
+            needs_docker=True,
+        ),
+        # -- live container runs (require a Docker daemon) --------------------
+        v(
+            "validate-valid",
+            "Validate a correct harness",
+            "I validate a well-formed harness before launching it.",
+            "Setup-complete is detected and the discovered test commands are summarized; exit is clean.",
+            [str(s / "valid")],
+            succeeds_with("Setup-complete event detected", "Setup validation successful"),
+            needs_docker=True,
+        ),
+        v(
+            "validate-timeout",
+            "Validate a harness that never signals setup-complete",
+            "My harness never emits the setup-complete event.",
+            "snouty waits up to --timeout and then fails with a clear timeout message.",
+            [str(s / "timeout"), "--timeout", "5"],
+            fails_with("timed out waiting for setup-complete event"),
+            needs_docker=True,
+        ),
+        v(
+            "validate-unrecognized-command",
+            "Validate a harness with an unknown test command",
+            "One of my test commands has a name with no recognized prefix.",
+            "Discovery fails and the offending command is named.",
+            [str(s / "unrecognized-command")],
+            fails_with("test command discovery failed", "Unrecognized command names"),
+            needs_docker=True,
+        ),
+        v(
+            "validate-non-executable-command",
+            "Validate a harness with a non-executable test command",
+            "One of my test commands is missing its executable bit.",
+            "Discovery fails and the non-executable command is named.",
+            [str(s / "non-executable-command")],
+            fails_with("test command discovery failed", "are not executable"),
+            needs_docker=True,
+        ),
+        v(
+            "validate-stranded",
+            "Validate a harness whose init container exits",
+            "A one-shot container holds test commands but exits during startup.",
+            "snouty warns those commands are stranded but still validates successfully.",
+            [str(s / "stranded")],
+            succeeds_with("their containers exited", "Setup validation successful"),
+            needs_docker=True,
+        ),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Rendering + main
 # ---------------------------------------------------------------------------
@@ -1617,6 +1875,8 @@ def main() -> int:
         # only reads a few fields, and event_vtime defaults to a real float).
         for s in build_stories(Discovery()):
             print(s.slug)
+        for s in build_validate_stories(None):
+            print(s.slug)
         return 0
 
     snouty_bin = args.snouty
@@ -1636,11 +1896,31 @@ def main() -> int:
     out_dir = args.out or Path(tempfile.mkdtemp(prefix="snouty-gallery."))
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    # The uncommittable validate fixtures (a non-existent dir, an empty
+    # manifests/ dir) are synthesized here for this run only.
+    fixtures_dir = Path(tempfile.mkdtemp(prefix="snouty-gallery-fixtures."))
+
     sn = Snouty(snouty_bin)
     failures: list[tuple[str, str]] = []
     try:
         disc = discover(sn, args.runs_to_scan)
         stories = build_stories(disc)
+
+        # Validate stories run against the committed sample projects, all of
+        # which require a container runtime (`snouty validate` resolves
+        # docker/podman before inspecting any config). gen-gallery is a developer
+        # tool, so the runtime is mandatory: build the sample images and hard-fail
+        # if it isn't available, rather than silently dropping stories.
+        ensure_validate_runtime()
+        validate_stories = build_validate_stories(fixtures_dir)
+        n_live = sum(s.needs_docker for s in validate_stories)
+        print(
+            f"including all {len(validate_stories)} validate stories "
+            f"({n_live} start live containers)",
+            file=sys.stderr,
+        )
+        stories += validate_stories
+
         if args.only:
             wanted = set(args.only)
             stories = [s for s in stories if s.slug in wanted]
@@ -1678,6 +1958,7 @@ def main() -> int:
         return 1
     finally:
         sn.cleanup()
+        shutil.rmtree(fixtures_dir, ignore_errors=True)
 
     print(file=sys.stderr)
     if failures:

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -52,14 +52,15 @@ stderr '.*snouty launch.*'
 [!staging] stderr '.*latest API version: v1.*'
 [!staging] stderr '.*tenant release version: 56.0.*'
 
-# 404: an older tenant predating the version endpoint — still reachable and
-# authenticated, so doctor stays green and warns the tenant release is old.
+# 404: typically an older tenant predating the version endpoint, but possibly a
+# proxy/route intercepting the request — either way it's still reachable and
+# authenticated, so doctor stays green and warns without blaming the tenant.
 [!staging] mock-server 404 '{}'
 [!staging] env ANTITHESIS_API_KEY=testkey
 [!staging] snouty doctor
 [!staging] stderr '.*Antithesis API reachable.*'
-[!staging] stderr '.*older than v56.*'
-[!staging] stderr '.*upgrade recommended.*'
+[!staging] stderr '.*returned 404.*'
+[!staging] stderr '.*proxy.*'
 
 # --offline skips the network check entirely: no version line, no API contact.
 env ANTITHESIS_API_KEY=testkey

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -80,13 +80,13 @@ stderr '"antithesis.is_ephemeral": "true"'
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30
 stderr '"antithesis.is_ephemeral": "true"'
-stderr 'Starting ephemeral run, Findings will not be available \(provide --source\)'
+stderr 'Starting an ephemeral run; its findings will not be retained.*'
 
 # 6c2. With --source, is_ephemeral is not set unless --ephemeral is passed.
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --source ci-pipeline
 ! stderr 'is_ephemeral.*'
-! stderr 'Starting ephemeral run.*'
+! stderr 'Starting an ephemeral run.*'
 
 # 6d. --param flag passes custom properties.
 mock-server 200 '{"runId":"run-123","statusCode":202}'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -290,6 +290,17 @@ mock-runs-server
 stderr '.*run not found: no-such-run.*'
 ! stderr '.*API error.*'
 
+# A successful but empty build-logs stream prints an explicit note in human
+# mode, so the user isn't left wondering whether anything happened.
+mock-runs-server
+snouty runs build-logs run-empty
+stderr 'No build logs for this run\.'
+
+# In --json mode an empty stream is the correct machine answer, so no note.
+mock-runs-server
+snouty --json runs build-logs run-empty
+! stderr 'No build logs for this run\.'
+
 mock-runs-server
 ! snouty runs events no-such-run --match anything
 stderr '.*run not found: no-such-run.*'
@@ -371,6 +382,11 @@ stdout 'No events matched "nomatch"\.'
 mock-runs-server
 ! snouty runs events run-1
 stderr '.*no search term given.*'
+
+# `snouty runs events` rejects an empty needle rather than matching every line.
+mock-runs-server
+! snouty runs events run-1 --match ''
+stderr '.*empty search term.*'
 
 # `snouty runs events` also accepts a backward-compatible positional query
 # whose terms are treated as additional needles.

--- a/specs/settings_tenant.txt
+++ b/specs/settings_tenant.txt
@@ -1,0 +1,16 @@
+# Tenant host validation
+#
+# A derived base URL interpolates the tenant into the request host
+# (https://{tenant}.antithesis.com), and snouty attaches the API key to that
+# host. A tenant carrying URL-significant characters (a path separator, '#',
+# whitespace, ...) would silently redirect those credentialed requests to an
+# unintended endpoint, so it is rejected up front when the base URL is derived.
+# An explicit ANTITHESIS_BASE_URL bypasses the tenant and this check (covered by
+# the validate_tenant_host unit tests).
+
+# A tenant with a path separator would mangle the derived host; reject it.
+! snouty doctor
+stderr '.*invalid tenant.*'
+
+-- .snouty.toml --
+tenant = "evil.com/x"

--- a/src/api.rs
+++ b/src/api.rs
@@ -216,8 +216,7 @@ impl Auth {
             err = err.note(
                 "ANTITHESIS_USERNAME/ANTITHESIS_PASSWORD are set, but this command only \
                  accepts API key authentication; username/password authentication is only \
-                 supported when launching runs (`snouty launch`, `snouty debug`, \
-                 `snouty api webhook`)",
+                 supported when launching runs (`snouty launch`, `snouty debug`)",
             );
         }
         Err(err.suggestion(
@@ -363,10 +362,12 @@ impl AntithesisApi {
     }
 
     /// Probe `GET /api/version` for the API and tenant release versions. The
-    /// endpoint is unauthenticated, so a success doubles as proof the API is
-    /// reachable; `snouty doctor` uses it as a connectivity check. Errors are
-    /// classified (HTTP status vs unreachable) rather than rendered, so the
-    /// caller can decide how to present each case.
+    /// endpoint authenticates like every endpoint other than launch, so the
+    /// probe runs only when an API key is configured; receiving any HTTP
+    /// response (success or error) doubles as proof the API is reachable, and
+    /// `snouty doctor` uses it as a connectivity check. Errors are classified
+    /// (HTTP status vs unreachable) rather than rendered, so the caller can
+    /// decide how to present each case.
     pub async fn get_version(&self) -> std::result::Result<ApiVersion, VersionError> {
         // The client's connect timeout (CONNECT_TIMEOUT) keeps a black-holed or
         // unresolvable host from hanging this probe.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,9 @@ fn parse_run_status(value: &str) -> Result<RunStatus, String> {
 #[derive(Parser)]
 #[command(name = "snouty")]
 #[command(about = "CLI for the Antithesis API", long_about = None)]
-#[command(version)]
+// SNOUTY_VERSION (from build.rs) is the crate version plus the build's git sha
+// when known, so `--version` and the `version` subcommand print the same string.
+#[command(version = env!("SNOUTY_VERSION"))]
 pub struct Cli {
     /// Output JSON where supported (NDJSON for list/stream commands, pretty JSON otherwise)
     // High display_order so the two global flags sort to the bottom of every

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashSet};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use color_eyre::{
@@ -12,6 +14,78 @@ use tokio::process::Child;
 
 use crate::config::ComposeConfig;
 use crate::settings::Settings;
+
+/// Wall-clock budget for each synchronous docker/podman call made while
+/// discovering test commands (`ps`, `exec test -d`, `cp`). Discovery runs on
+/// the current-thread runtime between the two `validate` timeout windows, so a
+/// wedged daemon or a flapping container could otherwise block it — and the
+/// whole CLI — forever, with neither `--timeout` nor ctrl+c able to interrupt a
+/// blocking `Command`. These calls are normally sub-second; the generous bound
+/// only exists to convert an indefinite hang into a clear error.
+const DISCOVERY_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Run a command to completion with a wall-clock timeout, killing it (and
+/// returning an error) if it overruns. Reader threads drain stdout/stderr so a
+/// chatty child can't deadlock on a full pipe while we wait. Used for the
+/// synchronous discovery commands, which would otherwise be uninterruptible.
+///
+/// Deliberately kills only the leader process — not the process group — so it
+/// needs no `libc::kill(-pid, …)` `unsafe`, unlike [`ProcessGroupChild`]. That
+/// wrapper exists for the long-running `docker-compose up`/`logs` commands,
+/// which fork and manage a tree of children that must all die on timeout. The
+/// callers here are one-shot docker/podman *client* invocations (`cp`,
+/// `exec test -d`, `ps`) whose only child is the client itself: killing it
+/// closes the pipes (so the reader threads finish) and the work we were waiting
+/// on ends. The daemon-side operation is intentionally not ours to kill.
+fn output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().wrap_err("failed to spawn command")?;
+
+    // Drain both pipes on their own threads; otherwise a child that fills a pipe
+    // buffer would block on write while we block on wait — a deadlock.
+    let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child.try_wait().wrap_err("failed to wait for command")? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            // The killed leader's pipe write-ends are now closed, so the reader
+            // threads hit EOF and finish; join them rather than detaching them.
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(eyre!(
+                "command timed out after {}s (the container runtime may be unresponsive)",
+                timeout.as_secs()
+            ));
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
 
 /// RAII wrapper around a [`Child`] spawned with `process_group(0)`.
 ///
@@ -335,9 +409,9 @@ pub trait ContainerRuntime: Send + Sync {
 
         let runtime = self.name();
         let src_arg = format!("{container_id}:{TEST_TEMPLATES_PATH}");
-        let output = Command::new(runtime)
-            .args(["cp", &src_arg, &dst.display().to_string()])
-            .output()
+        let mut cp_cmd = Command::new(runtime);
+        cp_cmd.args(["cp", &src_arg, &dst.display().to_string()]);
+        let output = output_with_timeout(cp_cmd, DISCOVERY_COMMAND_TIMEOUT)
             .wrap_err_with(|| format!("failed to run '{runtime} cp'"))?;
 
         if !output.status.success() {
@@ -358,9 +432,9 @@ pub trait ContainerRuntime: Send + Sync {
     /// OtherOrUnknown so callers fall back to cp.
     fn container_path_kind(&self, container_id: &str, path: &str) -> Result<PathKind> {
         let runtime = self.name();
-        let output = Command::new(runtime)
-            .args(["exec", container_id, "test", "-d", path])
-            .output()
+        let mut exec_cmd = Command::new(runtime);
+        exec_cmd.args(["exec", container_id, "test", "-d", path]);
+        let output = output_with_timeout(exec_cmd, DISCOVERY_COMMAND_TIMEOUT)
             .wrap_err_with(|| format!("failed to run '{runtime} exec'"))?;
         match output.status.code() {
             Some(0) => Ok(PathKind::Directory),
@@ -382,7 +456,7 @@ pub enum PathKind {
 }
 
 /// Standard path inside a container where Antithesis test templates live.
-const TEST_TEMPLATES_PATH: &str = "/opt/antithesis/test/v1";
+pub const TEST_TEMPLATES_PATH: &str = "/opt/antithesis/test/v1";
 
 /// Result of [`ContainerRuntime::extract_test_templates`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -575,7 +649,8 @@ impl DockerCompose<'_> {
         cmd.args(compose_file_args(overlay));
         cmd.args(["ps", "-a", "--format", "json"]);
 
-        let output = cmd.output().wrap_err("failed to run 'docker-compose ps'")?;
+        let output = output_with_timeout(cmd, DISCOVERY_COMMAND_TIMEOUT)
+            .wrap_err("failed to run 'docker-compose ps'")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2888,6 +2963,27 @@ services:
                 "-f".to_string(),
                 "/tmp/override.yaml".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn output_with_timeout_returns_quick_command_output() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf hi; printf oops 1>&2; exit 3"]);
+        let out = output_with_timeout(cmd, Duration::from_secs(10)).unwrap();
+        assert_eq!(out.status.code(), Some(3));
+        assert_eq!(out.stdout, b"hi");
+        assert_eq!(out.stderr, b"oops");
+    }
+
+    #[test]
+    fn output_with_timeout_kills_and_errors_on_overrun() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30"]);
+        let err = output_with_timeout(cmd, Duration::from_millis(150)).unwrap_err();
+        assert!(
+            format!("{err}").contains("timed out"),
+            "expected a timeout error, got: {err}"
         );
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -315,19 +315,26 @@ fn version_check(host: &str, result: std::result::Result<ApiVersion, VersionErro
                 format!("tenant release version: {}", v.release_version),
             ),
         // 404: the version endpoint was added in release 56, so an older tenant
-        // 404s — but the request was served, so auth and connectivity are fine
-        // and the API is the stable v1.
+        // 404s — but the request was served, so auth and connectivity are fine.
+        // A 404 can also come from a proxy/route in front of the tenant, so we
+        // name that possibility rather than asserting the tenant is old.
         Err(VersionError::Http(404)) => Check::ok("api", "Antithesis API reachable").note(
             Level::Warning,
-            "tenant release version: older than v56; upgrade recommended",
+            "GET /api/version returned 404 — your tenant likely predates version \
+             reporting (added in release 56); if you expect a current tenant, a \
+             proxy or route may be intercepting the request",
         ),
-        // 401/403: the request was rejected — authentication is broken.
-        // Connectivity is only probably ok (a proxy can reject before the
-        // request reaches the API), so we don't claim it.
+        // 401/403: the request was rejected. Most often the API key is wrong,
+        // but a proxy can also reject before the request reaches the API, so we
+        // name both rather than blaming the key outright.
         Err(VersionError::Http(status @ (401 | 403))) => {
             Check::fail("api", "Antithesis API rejected authentication")
                 .note(Level::Error, format!("the API returned HTTP {status}"))
-                .note(Level::Note, "check ANTITHESIS_API_KEY")
+                .note(
+                    Level::Note,
+                    "verify ANTITHESIS_API_KEY is valid; if it is, a proxy may be \
+                     rejecting the request before it reaches Antithesis",
+                )
         }
         // 5xx: we reached something, but it's erroring — connectivity is broken
         // by a server error and auth status is unknown.
@@ -591,16 +598,19 @@ mod tests {
     }
 
     #[test]
-    fn version_404_is_reachable_but_warns_an_old_tenant() {
+    fn version_404_is_reachable_but_warns() {
         let check = version_check("tenant.antithesis.com", Err(VersionError::Http(404)));
         assert_eq!(check.status, Status::Ok);
         assert!(check.message.contains("reachable"));
-        assert!(
-            check
-                .notes
-                .iter()
-                .any(|n| n.level == Level::Warning && n.text.contains("older than v56"))
-        );
+        // The warning explains the 404 without definitively blaming an old
+        // tenant — it names both the old-tenant and proxy possibilities.
+        let warning = check
+            .notes
+            .iter()
+            .find(|n| n.level == Level::Warning)
+            .expect("a 404 should attach a warning note");
+        assert!(warning.text.contains("404"));
+        assert!(warning.text.contains("proxy"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,10 @@ async fn run(cli: Cli) -> Result<()> {
     let result = match command {
         Commands::Completions { shell } => cmd_completions(shell),
         Commands::Version => {
-            println!("snouty {}", env!("CARGO_PKG_VERSION"));
+            // SNOUTY_VERSION (set by build.rs) is the crate version plus the
+            // build's git sha when known — the same string clap's --version
+            // prints, so the two stay consistent.
+            println!("snouty {}", env!("SNOUTY_VERSION"));
             Ok(())
         }
         Commands::Update(args) => cmd_update(args),
@@ -238,7 +241,10 @@ async fn cmd_launch(
 
     if !has_source {
         params.insert("antithesis.is_ephemeral", "true");
-        eprintln!("Starting ephemeral run, Findings will not be available (provide --source)");
+        eprintln!(
+            "Starting an ephemeral run; its findings will not be retained as historic \
+             results. Pass --source to record property history across runs."
+        );
     }
 
     params.validate_test_params()?;

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1214,6 +1214,17 @@ struct LogOutputOptions {
     raw: bool,
 }
 
+/// After streaming a log/event stream in human mode, print `empty_note` when the
+/// stream completed successfully but produced no lines, so the user isn't left
+/// wondering whether anything happened. In `--json` mode an empty stream is the
+/// correct machine answer, so stay quiet. Shared by `cmd_runs_logs` and
+/// `cmd_runs_build_logs`, which track `wrote_any` the same way.
+fn note_if_empty(result: &Result<()>, json: bool, wrote_any: bool, empty_note: &str) {
+    if result.is_ok() && !json && !wrote_any {
+        eprintln!("{empty_note}");
+    }
+}
+
 async fn cmd_runs_build_logs(
     run_id: &str,
     settings: &Settings,
@@ -1229,14 +1240,17 @@ async fn cmd_runs_build_logs(
     };
     let mut stdout = BufWriter::new(std::io::stdout().lock());
 
+    let mut wrote_any = false;
     let result = if json {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+            wrote_any = true;
             writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
     } else {
         stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+            wrote_any = true;
             if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
                 let ts = format_local_str(entry["timestamp"].as_str().unwrap_or(""));
                 let stream = entry["stream"].as_str().unwrap_or("out");
@@ -1251,6 +1265,7 @@ async fn cmd_runs_build_logs(
     };
 
     stdout.flush()?;
+    note_if_empty(&result, json, wrote_any, "No build logs for this run.");
     result
 }
 
@@ -1319,6 +1334,13 @@ async fn cmd_runs_events(
         return Err(user_error("no search term given")
             .suggestion("pass at least one needle via `-m/--match` or as a positional argument"));
     }
+    // An empty needle matches every line (`contains("")` is always true), which
+    // would silently disable filtering, so reject it rather than dump the whole
+    // stream as if no filter were given.
+    if matches.iter().any(|m| m.is_empty()) {
+        return Err(user_error("empty search term")
+            .suggestion("each `-m/--match` needle must be a non-empty substring"));
+    }
 
     // The server endpoint takes a single `q` substring and streams only a capped
     // subset of matching events. Send the LONGEST needle (a crude selectivity
@@ -1329,6 +1351,18 @@ async fn cmd_runs_events(
         .max_by_key(|m| m.chars().count())
         .cloned()
         .unwrap_or_default();
+
+    // With more than one needle only `server_query` is filtered server-side, and
+    // the server caps how many events it returns; the remaining needles filter
+    // that capped subset locally. A true match the cap evicted would otherwise
+    // vanish silently, so make the limitation visible.
+    if matches.len() > 1 {
+        eprintln!(
+            "Note: only \"{server_query}\" is matched on the server (which returns a capped \
+             subset of events); the other terms filter that subset locally, so some matching \
+             events may not appear. Search a single, more specific term to be exhaustive."
+        );
+    }
 
     let api = AntithesisApi::new_requiring_api_key(settings, verbose)?;
     let stream = match api.search_run_events(run_id, &server_query).await {
@@ -1471,11 +1505,8 @@ async fn cmd_runs_logs(
     };
     stdout.flush()?;
     // A moment with no logs (e.g. a manually-supplied 0/0 placeholder) yields an
-    // empty stream; say so in human mode rather than printing nothing. In --json
-    // mode an empty stream is the correct machine answer, so stay quiet.
-    if result.is_ok() && !json && !wrote_any {
-        eprintln!("No log lines at this moment.");
-    }
+    // empty stream; say so in human mode rather than printing nothing.
+    note_if_empty(&result, json, wrote_any, "No log lines at this moment.");
     result
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,7 @@ use color_eyre::eyre::{Result, eyre};
 use toml::Table;
 
 use crate::env;
+use crate::error::user_error;
 
 pub const ANTITHESIS_PROFILE_ENV_VAR_NAME: &str = "ANTITHESIS_PROFILE";
 pub const SNOUTY_SETTINGS_PATH_VAR_NAME: &str = "SNOUTY_SETTINGS_PATH";
@@ -139,6 +140,17 @@ impl Settings {
         let base_url = resolve("base_url", ANTITHESIS_BASE_URL_VAR_NAME)?;
         let container_engine = resolve("container_engine", CONTAINER_ENGINE_VAR_NAME)?;
 
+        // A derived base URL interpolates the tenant into the request host
+        // (`https://{tenant}.antithesis.com`) and we attach the API key to that
+        // host, so a malformed tenant would silently send credentials to an
+        // unintended endpoint. Validate it as a hostname before deriving. An
+        // explicit base_url bypasses the tenant, so only check when we'd derive.
+        if base_url.is_none()
+            && let Some(tenant) = &tenant
+        {
+            validate_tenant_host(tenant)?;
+        }
+
         Ok(Self::assemble(
             profile,
             tenant,
@@ -226,6 +238,37 @@ impl Settings {
     pub(crate) fn for_test_base_url(base_url: String) -> Self {
         Self::for_test(None, None, None, Some(&base_url), None)
     }
+}
+
+/// Validate that `tenant` is safe to interpolate into the derived base URL
+/// `https://{tenant}.antithesis.com`. The tenant becomes the request host, so
+/// it must be a valid DNS hostname — one or more labels of ASCII letters,
+/// digits, and hyphens (hyphens not leading/trailing). This rejects values
+/// carrying URL-significant characters (`/`, `#`, `?`, `@`, `:`, whitespace,
+/// …) that would otherwise redirect requests — with the API key attached — to
+/// an unintended host. Dots are allowed so a multi-label tenant still works;
+/// set `ANTITHESIS_BASE_URL` directly for any URL this rejects.
+fn validate_tenant_host(tenant: &str) -> Result<()> {
+    fn is_valid_label(label: &str) -> bool {
+        !label.is_empty()
+            && label.len() <= 63
+            && label
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+    }
+
+    let valid = !tenant.is_empty() && tenant.len() <= 253 && tenant.split('.').all(is_valid_label);
+    if !valid {
+        return Err(user_error(format!(
+            "invalid tenant `{tenant}`: a tenant must be a valid hostname \
+             (letters, digits, and hyphens) because it becomes the host in \
+             `https://{tenant}.antithesis.com`. Set ANTITHESIS_BASE_URL directly \
+             if you need a custom API URL."
+        )));
+    }
+    Ok(())
 }
 
 /// Turn a missing required setting into snouty's standard "run doctor" error.
@@ -590,5 +633,57 @@ mod tests {
     fn container_engine_resolves_when_set() {
         let settings = Settings::for_test(None, None, None, None, Some("podman"));
         assert_eq!(settings.container_engine(), Some("podman"));
+    }
+
+    // ---- validate_tenant_host -----------------------------------------
+
+    #[test]
+    fn valid_tenants_pass_host_validation() {
+        for tenant in ["orbitinghail", "acme", "my-tenant", "t123", "foo.bar"] {
+            assert!(
+                validate_tenant_host(tenant).is_ok(),
+                "expected `{tenant}` to be a valid tenant host"
+            );
+        }
+    }
+
+    #[test]
+    fn url_significant_tenants_are_rejected() {
+        // Each of these would otherwise redirect requests (with the API key) to
+        // an unintended host or mangle the URL.
+        for tenant in [
+            "evil.com#",
+            "evil.com/x",
+            "a b",
+            "acme#",
+            "foo/../bar",
+            "host:8080",
+            "tenant?x=1",
+            "user@host",
+            "",
+            "-leadinghyphen",
+            "trailinghyphen-",
+        ] {
+            assert!(
+                validate_tenant_host(tenant).is_err(),
+                "expected `{tenant}` to be rejected as a tenant host"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_base_url_bypasses_tenant_host_validation() {
+        // An explicit base_url bypasses tenant-host validation (the tenant isn't
+        // interpolated into the host), so an otherwise-invalid tenant still
+        // constructs. The derive-path validation itself is covered by
+        // validate_tenant_host's unit tests and specs/settings_tenant.txt.
+        let s = Settings::for_test(
+            None,
+            Some("evil.com#"),
+            None,
+            Some("https://ok.example"),
+            None,
+        );
+        assert_eq!(s.base_url(), Some("https://ok.example"));
     }
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -562,6 +562,11 @@ fn mock_route_get_run(run_id: &str) -> (u16, String) {
 }
 
 fn mock_route_get_run_build_logs(run_id: &str) -> (u16, String) {
+    // `run-empty` models a completed run with no build logs: a successful but
+    // empty stream, which exercises the "No build logs for this run." note.
+    if run_id == "run-empty" {
+        return (200, String::new());
+    }
     if !mock_run_known(run_id) {
         return mock_run_not_found(run_id);
     }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -514,31 +514,39 @@ fn discover_scripts(
         return Err(err);
     }
 
-    if !unrecognized.is_empty() || !not_executable.is_empty() || !stopped_with_scripts.is_empty() {
-        return Err(combined_discovery_error(
-            unrecognized,
-            not_executable,
-            stopped_with_scripts,
-        ));
+    // A service carrying test commands whose container has exited is, for this
+    // release, only a warning: a one-shot setup/init container that exits 0 is a
+    // legitimate compose pattern (e.g. `depends_on: service_completed_successfully`),
+    // and an unexpected non-zero exit surfaces as a property failure during the
+    // run itself. We can promote this to a hard error later if it proves noisy.
+    if !stopped_with_scripts.is_empty() {
+        eprintln!("{}", stranded_scripts_warning(&stopped_with_scripts));
+    }
+
+    // Genuine misconfigurations — unknown command prefixes or non-executable
+    // commands — remain hard errors: those scripts can never run.
+    if !unrecognized.is_empty() || !not_executable.is_empty() {
+        return Err(combined_discovery_error(unrecognized, not_executable));
     }
 
     Ok(all_scripts)
 }
 
-/// Build a single error report covering every category of discovery problem
-/// found across all containers. Sections are sorted by service name for
-/// deterministic output.
+/// Build a single error report covering every hard discovery failure found
+/// across all containers — unknown command prefixes and non-executable test
+/// commands. Sections are sorted by service name for deterministic output.
+/// (A test-bearing container that merely exited is handled separately as a
+/// warning; see [`stranded_scripts_warning`].)
 fn combined_discovery_error(
     unrecognized: BTreeMap<String, BTreeSet<String>>,
     not_executable: BTreeMap<String, BTreeSet<String>>,
-    stopped_with_scripts: BTreeSet<String>,
 ) -> color_eyre::Report {
     let mut err = user_error("test command discovery failed");
 
     for (service, commands) in &unrecognized {
         let listing = commands
             .iter()
-            .map(|c| format!("  {c}"))
+            .map(|c| format!("  {}/{c}", container::TEST_TEMPLATES_PATH))
             .collect::<Vec<_>>()
             .join("\n");
         err = err.with_section(|| {
@@ -551,7 +559,7 @@ fn combined_discovery_error(
     for (service, commands) in &not_executable {
         let listing = commands
             .iter()
-            .map(|c| format!("  {c}"))
+            .map(|c| format!("  {}/{c}", container::TEST_TEMPLATES_PATH))
             .collect::<Vec<_>>()
             .join("\n");
         err = err.with_section(|| {
@@ -561,24 +569,27 @@ fn combined_discovery_error(
         });
     }
 
-    if !stopped_with_scripts.is_empty() {
-        let listing = stopped_with_scripts
-            .iter()
-            .map(|s| format!("  {s}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        err = err.with_section(|| {
-            listing.header(
-                "Services contain Antithesis test commands but their containers exited. \
-                 Antithesis cannot run test commands in stopped containers:",
-            )
-        });
-        err = err.with_suggestion(|| {
-            "set the service's command/entrypoint to a long-running process (for example `sleep infinity`, or `tail -f /dev/null`) so the container stays alive for the duration of the test"
-        });
-    }
-
     err
+}
+
+/// Advisory warning that services carrying Antithesis test commands have exited.
+/// This is intentionally not an error: a one-shot setup/init container that
+/// exits 0 is a legitimate compose pattern. Antithesis still cannot run test
+/// commands in a stopped container, so we surface it; an unexpected non-zero
+/// exit is caught as a property failure during the run itself.
+fn stranded_scripts_warning(stopped_with_scripts: &BTreeSet<String>) -> String {
+    let listing = stopped_with_scripts
+        .iter()
+        .map(|s| format!("  {s}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Warning: these services contain Antithesis test commands but their containers \
+         exited; Antithesis cannot run test commands in a stopped container:\n{listing}\n\
+         If a container should stay up for the test, set its command/entrypoint to a \
+         long-running process (for example `sleep infinity` or `tail -f /dev/null`). A \
+         one-shot setup/init container that exits 0 can be left as-is."
+    )
 }
 
 /// Validate the structure of discovered test commands without executing them.
@@ -1070,5 +1081,33 @@ services:
             format!("{err}").contains("not a directory"),
             "expected 'not a directory' error, got: {err}"
         );
+    }
+
+    #[test]
+    fn stranded_scripts_warning_lists_services_and_stays_advisory() {
+        let mut stopped = BTreeSet::new();
+        stopped.insert("init".to_string());
+        stopped.insert("migrate".to_string());
+        let msg = stranded_scripts_warning(&stopped);
+        // Advisory, not a failure: it warns and names every affected service,
+        // and explicitly blesses a one-shot container that exits 0.
+        assert!(msg.starts_with("Warning:"));
+        assert!(msg.contains("  init"));
+        assert!(msg.contains("  migrate"));
+        assert!(msg.contains("exits 0"));
+    }
+
+    #[test]
+    fn combined_discovery_error_covers_only_hard_failures() {
+        let mut unrecognized = BTreeMap::new();
+        unrecognized.insert("app".to_string(), BTreeSet::from(["bogus_cmd".to_string()]));
+        let not_executable = BTreeMap::new();
+        let err = combined_discovery_error(unrecognized, not_executable);
+        let rendered = format!("{err:?}");
+        assert!(rendered.contains("test command discovery failed"));
+        // Test commands are referenced by their full in-container path.
+        assert!(rendered.contains("/opt/antithesis/test/v1/bogus_cmd"));
+        // The stranded-container case is no longer part of the hard error.
+        assert!(!rendered.contains("containers exited"));
     }
 }

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -146,7 +146,7 @@ fn launch_without_source_sets_ephemeral() {
             r#""antithesis.is_ephemeral": "true""#,
         ))
         .stderr(predicate::str::contains(
-            "Starting ephemeral run, Findings will not be available (provide --source)",
+            "Starting an ephemeral run; its findings will not be retained",
         ));
 }
 
@@ -167,7 +167,7 @@ fn launch_with_source_omits_ephemeral() {
         .assert()
         .success()
         .stderr(predicate::str::contains("is_ephemeral").not())
-        .stderr(predicate::str::contains("Starting ephemeral run").not());
+        .stderr(predicate::str::contains("Starting an ephemeral run").not());
 }
 
 #[test]

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -5,7 +5,7 @@
 Rebuild it with:
 
 ```sh
-./tests/fixtures/build_docs_fixture.py
+uv run scripts/build_docs_fixture.py
 ```
 
 The generator creates the minimal schema expected by `snouty docs`:

--- a/tests/fixtures/validate/README.md
+++ b/tests/fixtures/validate/README.md
@@ -1,0 +1,78 @@
+# validate sample projects
+
+Small Antithesis config directories used to exercise `snouty validate` (and, by
+hand, `snouty launch`) across the situations it has to handle. The gallery
+generator (`scripts/gen-gallery.py`) runs `snouty validate` against each of
+these to produce the `validate-*` gallery stories.
+
+**The goal of each sample is documented in the comment at the top of its
+`docker-compose.yaml`** — read that to understand what the sample is and what
+outcome to expect. (The `neither/` sample has no compose file, so its
+explanation lives in `neither/README.md` instead.)
+
+**A container runtime is required for all of these.** `snouty validate` resolves
+docker/podman (and shells out to `docker-compose`) before it inspects a config,
+so even the static checks need the runtime binaries installed.
+
+At a glance:
+
+**Static misconfigurations** (fail before any container starts; need the
+docker/podman + docker-compose binaries, but not a running daemon):
+`neither/`, `wrong-extension/`, `ambiguous/`, `malformed-compose/`,
+`no-services/`, `external-network/`.
+
+**Need a running Docker daemon:**
+- `missing-image/` — queries the local image store to report the missing image.
+- Live runs that start real containers: `valid/`, `timeout/`,
+  `unrecognized-command/`, `non-executable-command/`, `stranded/`.
+
+All service images use the glibc-based `debian:bookworm-slim` — Antithesis does
+not support non-glibc (e.g. musl/Alpine) images. The live samples **bake their
+test commands into an image** (via a `Dockerfile` + compose `build:`) rather
+than bind-mounting them, so the same image works for `validate` and `launch`.
+
+## Build the sample images first
+
+`snouty validate` never builds or pulls, so the live samples' images must exist
+locally beforehand. Build them all:
+
+```sh
+scripts/build-validate-samples.sh
+```
+
+`missing-image/` deliberately has no Dockerfile — it references an image that
+doesn't exist, to exercise validate's "image not available locally" path — so
+it is skipped by the build script.
+
+## Validate
+
+```sh
+snouty validate tests/fixtures/validate/valid
+```
+
+The `timeout/` sample never emits the setup-complete event, so give it a short
+deadline instead of waiting the full default:
+
+```sh
+snouty validate tests/fixtures/validate/timeout --timeout 5
+```
+
+## Launch
+
+`validate` runs a config locally; `launch` submits it to Antithesis. `--config`
+points at the directory, which snouty builds and pushes as the config image —
+the compose service images must already exist locally (snouty never pulls).
+Set your tenant, repository, and credentials first (see `snouty launch --help`).
+
+```sh
+ANTITHESIS_TENANT=your-tenant \
+ANTITHESIS_REPOSITORY=us-central1-docker.pkg.dev/your-proj/your-repo \
+ANTITHESIS_API_KEY=… \
+  snouty launch \
+    --webhook basic_test \
+    --config tests/fixtures/validate/valid \
+    --test-name "snouty-valid-sample" \
+    --description "snouty valid sample harness" \
+    --duration 15 \
+    --ephemeral
+```

--- a/tests/fixtures/validate/ambiguous/docker-compose.yaml
+++ b/tests/fixtures/validate/ambiguous/docker-compose.yaml
@@ -1,0 +1,6 @@
+# This directory holds BOTH a docker-compose.yaml and a manifests/ subdirectory,
+# so snouty can't tell whether it's a Compose or a Kubernetes config.
+services:
+  app:
+    image: debian:bookworm-slim
+    command: ["tail", "-f", "/dev/null"]

--- a/tests/fixtures/validate/ambiguous/manifests/namespace.yaml
+++ b/tests/fixtures/validate/ambiguous/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: antithesis-demo

--- a/tests/fixtures/validate/external-network/docker-compose.yaml
+++ b/tests/fixtures/validate/external-network/docker-compose.yaml
@@ -1,0 +1,16 @@
+# Declares an external network, which snouty rejects. The concrete reason is
+# `validate`-specific: validate wraps every network in a generated isolation
+# override (internal: true), and docker-compose won't allow a network that is
+# both external and internal — so snouty errors early with a clear message
+# instead of surfacing docker-compose's confusing one. (An external network
+# would also have nothing to attach to in Antithesis' fresh, air-gapped
+# environment, which is built from your config alone.)
+services:
+  app:
+    image: debian:bookworm-slim
+    command: ["tail", "-f", "/dev/null"]
+    networks:
+      - corp
+networks:
+  corp:
+    external: true

--- a/tests/fixtures/validate/malformed-compose/docker-compose.yaml
+++ b/tests/fixtures/validate/malformed-compose/docker-compose.yaml
@@ -1,0 +1,8 @@
+# Intentionally malformed YAML (an unterminated flow sequence) so that
+# `docker-compose config` — which snouty shells out to — fails to parse it.
+services:
+  app:
+    image: debian:bookworm-slim
+    command: ["tail", "-f", "/dev/null"
+    ports:
+      - "8080:8080

--- a/tests/fixtures/validate/missing-image/docker-compose.yaml
+++ b/tests/fixtures/validate/missing-image/docker-compose.yaml
@@ -1,0 +1,7 @@
+# References an image that does not exist in the local image store. snouty
+# never pulls (it tests exactly what is present locally), so validation stops
+# before starting anything and tells you which image is missing.
+services:
+  app:
+    image: snouty-gallery-nonexistent:latest
+    command: ["tail", "-f", "/dev/null"]

--- a/tests/fixtures/validate/neither/README.md
+++ b/tests/fixtures/validate/neither/README.md
@@ -1,0 +1,16 @@
+# neither — not a config directory
+
+This directory contains neither a `docker-compose.yaml` nor a `manifests/`
+subdirectory, so `snouty validate` can't classify it as a Compose or Kubernetes
+config. (This README is also what keeps the otherwise-empty directory tracked
+by git.)
+
+```sh
+snouty validate tests/fixtures/validate/neither
+```
+
+Expected: exit 1 with
+
+```
+directory '…/neither' does not contain a docker-compose.yaml file or a manifests/ subdirectory
+```

--- a/tests/fixtures/validate/no-services/docker-compose.yaml
+++ b/tests/fixtures/validate/no-services/docker-compose.yaml
@@ -1,0 +1,3 @@
+# A syntactically valid compose file that declares no services at all.
+# snouty has nothing to instrument and refuses it.
+services: {}

--- a/tests/fixtures/validate/non-executable-command/Dockerfile
+++ b/tests/fixtures/validate/non-executable-command/Dockerfile
@@ -1,0 +1,5 @@
+# Bake the Antithesis test commands into the image at the conventional path, so
+# they travel with the image — no host bind mount. The test command keeps the
+# non-executable mode it has in the build context.
+FROM debian:bookworm-slim
+COPY test/ /opt/antithesis/test/v1/

--- a/tests/fixtures/validate/non-executable-command/docker-compose.yaml
+++ b/tests/fixtures/validate/non-executable-command/docker-compose.yaml
@@ -1,0 +1,13 @@
+# Bakes a recognized test command (test/quickstart/first_setup) that is missing
+# its executable bit into the image. Antithesis could never run it, so snouty
+# fails discovery during `validate` and names the offending command. Like the
+# unrecognized-command sample, this fails during discovery, so the service only
+# needs to stay up.
+#
+# Run scripts/build-validate-samples.sh to build the image — `snouty validate`
+# never builds or pulls.
+services:
+  app:
+    image: snouty-sample-non-executable-command:latest
+    build: .
+    command: ["tail", "-f", "/dev/null"]

--- a/tests/fixtures/validate/non-executable-command/test/quickstart/first_setup
+++ b/tests/fixtures/validate/non-executable-command/test/quickstart/first_setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/stranded/Dockerfile
+++ b/tests/fixtures/validate/stranded/Dockerfile
@@ -1,0 +1,4 @@
+# Bake the Antithesis test commands into the init image at the conventional
+# path, so they travel with the image — no host bind mount.
+FROM debian:bookworm-slim
+COPY test/ /opt/antithesis/test/v1/

--- a/tests/fixtures/validate/stranded/docker-compose.yaml
+++ b/tests/fixtures/validate/stranded/docker-compose.yaml
@@ -1,0 +1,29 @@
+# Demonstrates the "stranded test commands" warning on an otherwise successful
+# validation.
+#
+# `init` bakes Antithesis test commands into its image (see Dockerfile) but
+# exits immediately — a common setup/migration pattern. Antithesis can't run
+# test commands in a stopped container, so snouty warns about it; this is
+# advisory, not fatal. `app` is the long-running service that emits the
+# setup-complete event, so validation still succeeds overall (exit 0).
+#
+# depends_on/service_completed_successfully makes `up` wait for init to exit
+# before app starts, so init is reliably stopped (and flagged) by the time
+# snouty discovers test commands.
+#
+# Run scripts/build-validate-samples.sh to build the init image — `snouty
+# validate` never builds or pulls; `app` uses the stock glibc base.
+services:
+  init:
+    image: snouty-sample-stranded-init:latest
+    build: .
+    command: ["true"]
+  app:
+    image: debian:bookworm-slim
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    command:
+      - sh
+      - -c
+      - "echo '{\"antithesis_setup\": {\"status\": \"complete\"}}' >> \"$$ANTITHESIS_OUTPUT_DIR/sdk.jsonl\"; exec tail -f /dev/null"

--- a/tests/fixtures/validate/stranded/test/lifecycle/first_bootstrap
+++ b/tests/fixtures/validate/stranded/test/lifecycle/first_bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/timeout/docker-compose.yaml
+++ b/tests/fixtures/validate/timeout/docker-compose.yaml
@@ -1,0 +1,8 @@
+# The service comes up and stays up but never emits the setup-complete event
+# (no Antithesis SDK is wired in). snouty waits for the event until --timeout
+# elapses and then fails. The gallery runs this with a deliberately short
+# --timeout so it doesn't stall.
+services:
+  app:
+    image: debian:bookworm-slim
+    command: ["tail", "-f", "/dev/null"]

--- a/tests/fixtures/validate/unrecognized-command/Dockerfile
+++ b/tests/fixtures/validate/unrecognized-command/Dockerfile
@@ -1,0 +1,4 @@
+# Bake the Antithesis test commands into the image at the conventional path, so
+# they travel with the image — no host bind mount.
+FROM debian:bookworm-slim
+COPY test/ /opt/antithesis/test/v1/

--- a/tests/fixtures/validate/unrecognized-command/docker-compose.yaml
+++ b/tests/fixtures/validate/unrecognized-command/docker-compose.yaml
@@ -1,0 +1,14 @@
+# Bakes a test command (test/quickstart/run_workload) whose name has no
+# recognized Antithesis prefix (first_, parallel_driver_, serial_driver_,
+# singleton_driver_, anytime_, eventually_, finally_, or helper_) into the
+# image. snouty discovers it during `validate`, can't classify it, and fails —
+# caught during discovery, before the setup-complete wait, so the service only
+# needs to stay up. Expected: validation fails naming the unrecognized command.
+#
+# Run scripts/build-validate-samples.sh to build the image — `snouty validate`
+# never builds or pulls.
+services:
+  app:
+    image: snouty-sample-unrecognized-command:latest
+    build: .
+    command: ["tail", "-f", "/dev/null"]

--- a/tests/fixtures/validate/unrecognized-command/test/quickstart/run_workload
+++ b/tests/fixtures/validate/unrecognized-command/test/quickstart/run_workload
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/valid/Dockerfile
+++ b/tests/fixtures/validate/valid/Dockerfile
@@ -1,0 +1,5 @@
+# Bake the Antithesis test commands into the image at the conventional path, so
+# they travel with the image — no host bind mount. The same image works for
+# `snouty validate` locally and for a real `snouty launch`.
+FROM debian:bookworm-slim
+COPY test/ /opt/antithesis/test/v1/

--- a/tests/fixtures/validate/valid/docker-compose.yaml
+++ b/tests/fixtures/validate/valid/docker-compose.yaml
@@ -1,0 +1,24 @@
+# The happy path: a correct harness with no issues.
+#
+# The test commands are baked into the image (see Dockerfile) at the
+# conventional /opt/antithesis/test/v1 path, so they travel with the image — no
+# host bind mount. The service emits the Antithesis setup-complete event to
+# $ANTITHESIS_OUTPUT_DIR/sdk.jsonl — the SDK output path that both `validate`
+# and the real Antithesis platform read — then stays up; snouty discovers the
+# test commands, checks their structure, and never runs them. Expected:
+# validation succeeds (exit 0).
+#
+# `image:` + `build:` means `snouty launch` can build and push this image, while
+# `snouty validate` uses the pre-built image — it never builds or pulls, so run
+# scripts/build-validate-samples.sh first.
+#
+# `$$` escapes the dollar sign so docker-compose passes $ANTITHESIS_OUTPUT_DIR
+# through to the container shell instead of interpolating it at config time.
+services:
+  app:
+    image: snouty-sample-valid:latest
+    build: .
+    command:
+      - sh
+      - -c
+      - "echo '{\"antithesis_setup\": {\"status\": \"complete\"}}' >> \"$$ANTITHESIS_OUTPUT_DIR/sdk.jsonl\"; exec tail -f /dev/null"

--- a/tests/fixtures/validate/valid/test/quickstart/anytime_probe
+++ b/tests/fixtures/validate/valid/test/quickstart/anytime_probe
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/valid/test/quickstart/first_setup
+++ b/tests/fixtures/validate/valid/test/quickstart/first_setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/valid/test/quickstart/helper_shared_lib
+++ b/tests/fixtures/validate/valid/test/quickstart/helper_shared_lib
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/valid/test/quickstart/singleton_driver_check
+++ b/tests/fixtures/validate/valid/test/quickstart/singleton_driver_check
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Antithesis discovers this command by name; validate never executes it.
+exit 0

--- a/tests/fixtures/validate/wrong-extension/docker-compose.yml
+++ b/tests/fixtures/validate/wrong-extension/docker-compose.yml
@@ -1,0 +1,6 @@
+# Intentionally named docker-compose.yml (.yml) instead of the required
+# docker-compose.yaml, so `snouty validate` emits its rename hint.
+services:
+  app:
+    image: debian:bookworm-slim
+    command: ["tail", "-f", "/dev/null"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "snouty-scripts"
+version = "0.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
Address documentation and correctness issues found while reviewing main ahead of the v0.6.0 release, plus the test tooling added to exercise snouty's human-facing output and `snouty validate` while doing so.

- Remove the dead `snouty api webhook` references from the README and the missing-API-key note; the command was removed this cycle and the note misdirected users mid-auth-debug.
- Stop strict-parsing API responses: strip `additionalProperties: false` from the OpenAPI spec before generating the client, so progenitor never emits `deny_unknown_fields` and a new field in a response can't make commands (e.g. `snouty doctor` reporting a healthy API as "unreachable") hard-fail. Transforming the spec rather than the generated text also covers the attribute wherever it would appear (combined serde options, enums).
- validate: downgrade the stranded-test-command check to a warning so a one-shot init/migration container that exits 0 no longer blocks validation; unrecognized/non-executable commands stay hard errors.
- validate: bound the test-command discovery docker calls (`ps`/`exec`/`cp`) with a wall-clock timeout so a wedged daemon can't hang the CLI forever. The timeout kills only the one-shot client process, so it needs no process group (and no extra unsafe).
- validate: refer to discovered test commands by their full in-container path (`/opt/antithesis/test/v1/...`) in discovery errors, not just the `{test}/{command}` suffix.
- doctor: soften the /api/version 404 and 401/403 messages to name the proxy/route possibility instead of blaming an old tenant or the API key.
- settings: validate the tenant as a hostname before deriving the base URL, so a malformed tenant can't send credentialed requests to an unintended host.
- runs events: reject an empty `-m` needle and warn when multiple needles are given (only one is filtered server-side, with a cap), so matches are not dropped silently.
- runs build-logs: print an explicit empty-state, matching `runs logs`.
- version: embed the build's git sha in `snouty version` and `--version` (e.g. `0.6.0 (a1b2c3d)`, with a `-dirty` suffix when the tree has uncommitted changes); computed in build.rs and omitted for tarball builds.
- docs/help: document the `snouty docs` network refresh; reword the ephemeral-launch message; fix a stale `api.rs` doc comment.
- test: add `snouty validate` sample projects under `tests/fixtures/validate/` for the static misconfigurations (missing config, wrong filename, ambiguous, malformed/empty compose, external network, missing image) and the live cases (valid harness, setup-complete timeout, unrecognized/non-executable commands, stranded init container). Live samples bake their test commands into a glibc image rather than bind-mounting them, so they validate and launch identically; `scripts/build-validate-samples.sh` builds the images.
- gen-gallery: add `validate-*` stories that run `snouty validate` against the samples, and make completed-run discovery holistic so it selects a run that can drive every story instead of bailing on the first one missing a property. gen-gallery is a developer tool, so it now requires a container runtime and hard-fails if one isn't available rather than silently skipping stories.
- tooling: move `build_docs_fixture.py` under `scripts/` and add a uv/PEP 723 project (`pyproject.toml`, `uv.lock`) for the Python scripts.

https://claude.ai/code/session_017emtFTc6VbRvi12kMS7DL7
