### PR TITLE
fix(launch): clear --duration errors and accept h/m durations

### DIFF
--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -14,10 +14,21 @@
 ! snouty launch --duration 30
 stderr '--webhook.*'
 
-# Parameters are validated against the testParams schema before making
-#    any API call.
+# An invalid --duration fails at flag-parse time with a message attributed to
+#    the flag, not an opaque schema regex.
 ! snouty launch -w basic_test --duration abc
+stderr 'invalid value .abc. for .--duration'
+stderr 'number of minutes.*'
+
+# Parameters are validated against the testParams schema before making
+#    any API call. A bad antithesis.* value (here via the raw --param escape
+#    hatch) reports only the real error, attributed to the offending field,
+#    not a misleading "unevaluated properties" cascade that names its valid
+#    siblings.
+! snouty launch -w basic_test --param antithesis.duration=asdf --param antithesis.source=ci
 stderr 'validation failed.*'
+stderr 'antithesis\.duration: .*'
+! stderr 'Unevaluated properties.*'
 
 # `launch` does not accept --stdin.
 ! snouty launch -w basic_test --stdin --duration 30
@@ -87,6 +98,12 @@ mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --source ci-pipeline
 ! stderr 'is_ephemeral.*'
 ! stderr 'Starting an ephemeral run.*'
+
+# 6c3. --duration accepts h/m unit suffixes, normalized to bare minutes for the
+#    API (1h30m -> 90).
+mock-server 200 '{"runId":"run-123","statusCode":202}'
+snouty launch -w basic_test --duration 1h30m --source ci-pipeline
+stderr '"antithesis.duration": "90"'
 
 # 6d. --param flag passes custom properties.
 mock-server 200 '{"runId":"run-123","statusCode":202}'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -72,12 +72,19 @@ snouty --json runs list --status completed
 [!staging] stdout '"run_id":"run-.*'
 env_from_json 0 run_id
 
-# `snouty runs show` displays run details in key-value format.
+# `snouty runs show` displays run details in key-value format. The requested
+# Duration (from antithesis.duration) and the wall-clock Elapsed (derived from
+# the start/complete timestamps) sit beside each other — they legitimately
+# differ, since Elapsed also spans provisioning/setup/teardown — and Source
+# reports where the run was launched from.
 mock-runs-server
 snouty runs show $R_run_id
 stdout 'Run ID.*$R_run_id'
 [!staging] stdout 'Status.*completed'
+[!staging] stdout 'Duration.*30m'
+[!staging] stdout 'Elapsed.*30m33s'
 [!staging] stdout 'Launcher.*nightly'
+[!staging] stdout 'Source.*demo-harness'
 
 # `snouty runs show` doesn't print the raw report URL — `snouty runs show --web`
 # is the way to follow that link. The hint is shown only when a report link

--- a/src/api.rs
+++ b/src/api.rs
@@ -82,6 +82,18 @@ impl RunDetail {
             .or_else(|| params_test_description(self.parameters.as_ref()))
     }
 
+    /// The requested run duration as launched (`antithesis.duration`, a count of
+    /// minutes), if the run recorded one. This is the configured workload length,
+    /// distinct from the wall-clock time derived from the run's timestamps.
+    pub(crate) fn requested_duration(&self) -> Option<&str> {
+        self.parameters.as_ref()?.antithesis_duration.as_deref()
+    }
+
+    /// The source the run was launched from (`antithesis.source`), if recorded.
+    pub(crate) fn source(&self) -> Option<&str> {
+        self.parameters.as_ref()?.antithesis_source.as_deref()
+    }
+
     /// The failure moment if it pins a real point in the run, otherwise `None`.
     ///
     /// A timed-out or killed run has no moment-pinned failure, so the API reports

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 
 use crate::api::RunStatus;
+use crate::time::ReportDuration;
 
 /// clap value parser for `--status` that keeps a friendly, enumerated error
 /// message (the generated `RunStatus::from_str` only says "invalid value").
@@ -352,11 +353,11 @@ pub struct LaunchArgs {
     #[arg(long)]
     pub description: Option<String>,
 
-    /// Test duration, in minutes
-    // A string (not a number) lets callers pass fractional minutes; the numeric
-    // format is enforced by the params schema.
+    /// Test duration in minutes, or h/m units (e.g. 90m, 2h, 1h30m)
+    // `ReportDuration: FromStr` gives clap the parser; we send it to the API as
+    // `.minutes().to_string()`, the (possibly fractional) minute count it wants.
     #[arg(long)]
-    pub duration: Option<String>,
+    pub duration: Option<ReportDuration>,
 
     /// Mark the test run as ephemeral. Ephemeral runs will not appear in future reports as a historic result.
     #[arg(long)]
@@ -588,6 +589,36 @@ mod tests {
 
     fn parse(args: &[&str]) -> Cli {
         Cli::try_parse_from(args).expect("args should parse")
+    }
+
+    #[test]
+    fn duration_flag_parses_into_report_duration() {
+        // Parsing/validation lives in `crate::time`; here we just confirm clap
+        // wires `--duration` through `ReportDuration: FromStr`.
+        let cli = parse(&[
+            "snouty",
+            "launch",
+            "-w",
+            "basic_test",
+            "--duration",
+            "1h30m",
+        ]);
+        let Commands::Launch(args) = cli.command else {
+            panic!("expected launch command");
+        };
+        assert_eq!(args.duration.unwrap().minutes(), 90.0);
+    }
+
+    #[test]
+    fn duration_flag_rejects_invalid_value() {
+        // `.err()` avoids requiring `Cli: Debug` (which `unwrap_err` would).
+        let err =
+            Cli::try_parse_from(["snouty", "launch", "-w", "basic_test", "--duration", "1.5h"])
+                .err()
+                .expect("invalid duration should fail to parse")
+                .to_string();
+        assert!(err.contains("--duration"), "got: {err}");
+        assert!(err.contains("number of minutes"), "got: {err}");
     }
 
     // The positional `input_hash`/`vtime` and the `--begin-*` flags must all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod scripts;
 pub mod settings;
 #[doc(hidden)]
 pub mod testutils;
+pub mod time;
 pub mod validate;
 
 /// User-Agent string sent with every HTTP request snouty makes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,8 @@ async fn cmd_launch(
         params.insert("antithesis.description", description);
     }
     if let Some(duration) = args.duration {
-        params.insert("antithesis.duration", duration);
+        // The API wants a bare minute count, not the human `1h30m` Display form.
+        params.insert("antithesis.duration", duration.minutes().to_string());
     }
     let has_source = if let Some(source) = args.source {
         params.insert("antithesis.source", source);
@@ -239,14 +240,6 @@ async fn cmd_launch(
         return Err(user_error("invalid arguments: no parameters provided"));
     }
 
-    if !has_source {
-        params.insert("antithesis.is_ephemeral", "true");
-        eprintln!(
-            "Starting an ephemeral run; its findings will not be retained as historic \
-             results. Pass --source to record property history across runs."
-        );
-    }
-
     params.validate_test_params()?;
 
     if let Some((detected, registry, config_image)) = config_image_ref {
@@ -271,6 +264,18 @@ async fn cmd_launch(
             }
         };
         params.insert("antithesis.config_image", pinned_config);
+    }
+
+    // No --source means the run is ephemeral. Set the flag and tell the user
+    // now — after validation and the config image build have succeeded — so the
+    // notice lands right before the run is sent rather than ahead of work that
+    // might still fail.
+    if !has_source {
+        params.insert("antithesis.is_ephemeral", "true");
+        eprintln!(
+            "Starting an ephemeral run; its findings will not be retained as historic \
+             results. Pass --source to record property history across runs."
+        );
     }
 
     let response = launch_webhook(&args.webhook, params, settings, verbose).await?;

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,5 @@
 use jsonschema::Validator;
+use jsonschema::error::ValidationErrorKind;
 use log::debug;
 use serde_json::{Map, Value};
 
@@ -197,6 +198,34 @@ where
 }
 
 fn validate_against_def(params: &Map<String, Value>, def_name: &str) -> Result<()> {
+    let notes = collect_validation_notes(params, def_name);
+    if notes.is_empty() {
+        debug!("validation passed");
+        return Ok(());
+    }
+
+    debug!("validation failed with {} notes", notes.len());
+    // The message states the failure; each schema violation is its own note.
+    let mut report = user_error("validation failed");
+    for note in notes {
+        debug!("  - {}", note);
+        report = report.note(note);
+    }
+    Err(report)
+}
+
+/// Collect the human-readable notes for every validation error, with the
+/// misleading `unevaluatedProperties` cascade filtered out. Returns an empty
+/// vec when the params are valid.
+///
+/// `unevaluatedProperties: false` reports every sibling property as
+/// "unexpected" whenever a more specific subschema (e.g. the `duration`
+/// pattern) fails: once the failing subschema is dropped, its properties are
+/// left unevaluated and the catch-all fires on all of them. Those properties
+/// are usually valid and required, so the note sends readers chasing fields
+/// that aren't actually wrong. When a more specific violation already fired,
+/// we drop the cascade and surface only the real error(s).
+fn collect_validation_notes(params: &Map<String, Value>, def_name: &str) -> Vec<String> {
     let schema: Value = serde_json::from_str(SCHEMA).expect("valid schema");
 
     // Build a schema that references the specific definition
@@ -208,24 +237,44 @@ fn validate_against_def(params: &Map<String, Value>, def_name: &str) -> Result<(
     let validator = Validator::new(&def_schema).expect("valid schema");
     let instance = Value::Object(params.clone());
 
-    let errors: Vec<String> = validator
-        .iter_errors(&instance)
-        .map(|e| e.to_string())
-        .collect();
+    let errors: Vec<_> = validator.iter_errors(&instance).collect();
+    let is_cascade = |e: &jsonschema::ValidationError| {
+        matches!(e.kind(), ValidationErrorKind::UnevaluatedProperties { .. })
+    };
+    let has_specific_error = errors.iter().any(|e| !is_cascade(e));
 
-    if !errors.is_empty() {
-        debug!("validation failed with {} errors", errors.len());
-        // The message states the failure; each schema violation is its own note.
-        let mut report = user_error("validation failed");
-        for err in &errors {
-            debug!("  - {}", err);
-            report = report.note(err.clone());
+    errors
+        .iter()
+        .filter(|e| !(has_specific_error && is_cascade(e)))
+        .map(note_for_error)
+        .collect()
+}
+
+/// Render a single validation error as a note, prefixed with the offending
+/// field name when the error is attributable to a specific property.
+///
+/// The jsonschema messages describe only the value and the violated
+/// constraint (e.g. `"asdf" does not match "^[0-9]+(\.[0-9]+)?$"`); they never
+/// name the field. The field lives in the error's instance path, so we pull it
+/// from there and put it up front. Object-level errors (e.g. unevaluated
+/// properties) carry an empty instance path and already name the property in
+/// their message, so they pass through unprefixed.
+fn note_for_error(error: &jsonschema::ValidationError) -> String {
+    let pointer = error.instance_path().as_str();
+    match pointer.strip_prefix('/') {
+        Some(field) if !field.is_empty() => {
+            format!("{}: {error}", unescape_pointer_token(field))
         }
-        return Err(report);
+        _ => error.to_string(),
     }
+}
 
-    debug!("validation passed");
-    Ok(())
+/// Decode a JSON Pointer reference token back into the raw property name,
+/// reversing the `~1`/`~0` escapes for `/` and `~` (RFC 6901). Param keys are
+/// flat dotted strings that rarely need this, but keys carrying a literal `/`
+/// or `~` would otherwise surface mangled.
+fn unescape_pointer_token(token: &str) -> String {
+    token.replace("~1", "/").replace("~0", "~")
 }
 
 #[cfg(test)]
@@ -313,6 +362,83 @@ mod tests {
         ];
         let params = Params::from_args(args).unwrap();
         assert!(params.validate_test_params().is_ok());
+    }
+
+    #[test]
+    fn invalid_duration_does_not_cascade_into_unevaluated_properties() {
+        // A bad `antithesis.duration` value used to drag every sibling property
+        // into a misleading "Unevaluated properties are not allowed" note. The
+        // only real error is the duration pattern; the siblings are valid.
+        let params = Params::from_args([
+            "--antithesis.duration",
+            "15m",
+            "--antithesis.test_name",
+            "my-test",
+            "--antithesis.source",
+            "my-source",
+        ])
+        .unwrap();
+
+        // The cascade is surfaced as color_eyre notes, not in the report's
+        // Display, so assert on the collected notes directly.
+        let notes = collect_validation_notes(params.as_map(), "testParams");
+        assert_eq!(
+            notes.len(),
+            1,
+            "exactly one real error expected, got: {notes:?}"
+        );
+        // The real, specific failure is reported, and the note names the
+        // offending field so the reader knows where to look.
+        assert!(
+            notes[0].contains("antithesis.duration") && notes[0].contains("15m"),
+            "expected field-attributed duration note, got: {notes:?}"
+        );
+        // ...but no cascade naming the valid siblings.
+        assert!(
+            notes.iter().all(|n| !n.contains("Unevaluated properties")),
+            "cascade should be suppressed, got: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn genuinely_unexpected_property_is_still_reported() {
+        // When nothing more specific fails, a truly unexpected property must
+        // still surface via the unevaluated-properties check.
+        let params =
+            Params::from_args(["--antithesis.duration", "30", "--antithesis.bogus", "x"]).unwrap();
+
+        let notes = collect_validation_notes(params.as_map(), "testParams");
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.contains("Unevaluated properties") && n.contains("antithesis.bogus")),
+            "expected unexpected-property note, got: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn pattern_violation_note_names_the_field() {
+        // The jsonschema message only describes the value and the pattern; the
+        // note must prepend the field name so the user can find the culprit.
+        let params = Params::from_args(["--antithesis.duration", "asdf"]).unwrap();
+        let notes = collect_validation_notes(params.as_map(), "testParams");
+        assert_eq!(notes.len(), 1, "expected one error, got: {notes:?}");
+        assert!(
+            notes[0].starts_with("antithesis.duration: "),
+            "note should be attributed to the field, got: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn unescape_pointer_token_reverses_rfc6901_escapes() {
+        assert_eq!(
+            unescape_pointer_token("antithesis.duration"),
+            "antithesis.duration"
+        );
+        assert_eq!(unescape_pointer_token("a~1b"), "a/b");
+        assert_eq!(unescape_pointer_token("a~0b"), "a~b");
+        // A literal "~1" is encoded as "~01" and must round-trip, not collapse.
+        assert_eq!(unescape_pointer_token("~01"), "~1");
     }
 
     #[test]

--- a/src/params_schema.json
+++ b/src/params_schema.json
@@ -49,7 +49,7 @@
         "antithesis.duration": {
           "type": "string",
           "pattern": "^[0-9]+(\\.[0-9]+)?$",
-          "description": "Desired test duration"
+          "description": "Desired test duration, in minutes"
         },
         "antithesis.images": {
           "type": "string",

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -24,6 +24,7 @@ use crate::cli::{RunsCommands, RunsListArgs};
 use crate::error::{api_error_status, user_error};
 use crate::render::{render_kv, sanitize, sanitize_multiline};
 use crate::settings::Settings;
+use crate::time::ReportDuration;
 
 /// `print!`/`println!`, but routed through `write!`/`writeln!` to stdout so a
 /// closed pipe (e.g. `snouty runs list | head`) surfaces as an `io::Error` the
@@ -271,6 +272,25 @@ fn format_local_str(raw: &str) -> String {
         Ok(dt) => format_local(dt.with_timezone(&Utc)),
         Err(_) => raw.to_string(),
     }
+}
+
+/// The requested run duration (`antithesis.duration`, a count of minutes),
+/// rendered in the same `1h30m` vocabulary the launcher accepts via
+/// [`ReportDuration`]. A value the backend somehow stored in a form we can't
+/// parse falls back to the raw string, so it still shows something truthful
+/// rather than vanishing.
+fn format_requested_duration(raw: &str) -> String {
+    raw.parse::<ReportDuration>()
+        .map_or_else(|_| raw.to_string(), |d| d.to_string())
+}
+
+/// Wall-clock time the run was (or has been) active, rendered through
+/// [`ReportDuration`] in the same `h`/`m`/`s` units as the requested duration
+/// beside it. A still-running run counts up to `end` (`Utc::now()` at the call
+/// site). Returns `None` on clock skew (a negative span).
+fn elapsed_duration(started: DateTime<Utc>, end: DateTime<Utc>) -> Option<ReportDuration> {
+    let secs = (end - started).num_seconds();
+    (secs >= 0).then(|| ReportDuration::from_seconds(secs as u64))
 }
 
 async fn cmd_runs_show(
@@ -1097,7 +1117,22 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
         rows.push(("Completed", format_local(t)));
     }
 
+    // Requested vs. actual run time. "Duration" is the configured workload
+    // length; "Elapsed" is wall-clock (which also spans provisioning, setup and
+    // teardown), so the two legitimately differ — they aren't a mismatch.
+    if let Some(raw) = run.requested_duration() {
+        rows.push(("Duration", format_requested_duration(raw)));
+    }
+    if let Some(started) = run.started_at
+        && let Some(elapsed) = elapsed_duration(started, run.completed_at.unwrap_or_else(Utc::now))
+    {
+        rows.push(("Elapsed", elapsed.to_string()));
+    }
+
     rows.push(("Launcher", run.launcher.clone()));
+    if let Some(source) = run.source() {
+        rows.push(("Source", source.to_string()));
+    }
 
     if let Some(moment) = failure {
         // Hash before VTime to match the `runs logs <hash> <vtime>` argument
@@ -4852,6 +4887,30 @@ mod tests {
         // Clock skew: a slightly-future timestamp clamps instead of rendering
         // a negative age.
         assert_eq!(relative_time(now + chrono::Duration::hours(1)), "0s ago");
+    }
+
+    #[test]
+    fn requested_duration_renders_via_report_duration() {
+        // Whole minutes, the launcher's h/m vocabulary, and a fractional minute
+        // count from older runs all render through ReportDuration.
+        assert_eq!(format_requested_duration("30"), "30m");
+        assert_eq!(format_requested_duration("90"), "1h30m");
+        assert_eq!(format_requested_duration("15.5"), "15m30s");
+        // A value we can't parse falls back to the raw string rather than
+        // dropping the row entirely.
+        assert_eq!(format_requested_duration("soon"), "soon");
+    }
+
+    #[test]
+    fn elapsed_is_wall_clock_with_second_precision() {
+        let started: DateTime<Utc> = "2025-03-20T02:01:12Z".parse().unwrap();
+        let end: DateTime<Utc> = "2025-03-20T02:31:45Z".parse().unwrap();
+        assert_eq!(
+            elapsed_duration(started, end).unwrap().to_string(),
+            "30m33s"
+        );
+        // Clock skew (end before start) yields no elapsed rather than a negative.
+        assert!(elapsed_duration(end, started).is_none());
     }
 
     #[test]

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -548,6 +548,15 @@ fn mock_route_get_run(run_id: &str) -> (u16, String) {
         fields.push(r#""completed_at":"2025-03-20T02:31:45Z""#.to_string());
     }
     fields.push(format!(r#""launcher":"{launcher}""#));
+    // run-1 carries launch parameters so `runs show` can surface the requested
+    // Duration and Source alongside the timestamp-derived Elapsed; other runs
+    // omit them, exercising the "field absent" path.
+    if run_id == "run-1" {
+        fields.push(
+            r#""parameters":{"antithesis.duration":"30","antithesis.source":"demo-harness"}"#
+                .to_string(),
+        );
+    }
     fields.push(format!(
         r#""links":{{"triage_report":"https://demo.antithesis.com/reports/{run_id}"}}"#
     ));

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,305 @@
+//! Run durations.
+//!
+//! Antithesis takes a run's duration in minutes, and has historically accepted
+//! a fractional value (e.g. `0.05` for three seconds). [`ReportDuration`]
+//! preserves that, while also accepting the unit forms people reach for
+//! (`1h30m`, `2h`, `30s`).
+//!
+//! A bare number is read as a (possibly fractional) count of minutes and
+//! rounded to whole seconds — the finest resolution we keep. Unit forms use
+//! whole-number components (`h`/`m`/`s`, in that order); fractional components
+//! like `1.5h` are rejected, since the bare-minutes form already covers that.
+
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+use std::time::Duration;
+
+const SECS_PER_MINUTE: u64 = 60;
+const SECS_PER_HOUR: u64 = 60 * SECS_PER_MINUTE;
+
+/// A run's configured duration, carried in the `antithesis.duration` report
+/// parameter. Held internally as a [`Duration`] rounded to whole seconds.
+///
+/// Parse one from the strings people type:
+/// ```
+/// # use snouty::time::ReportDuration;
+/// assert_eq!("1h30m".parse::<ReportDuration>().unwrap().minutes(), 90.0);
+/// assert_eq!("0.05".parse::<ReportDuration>().unwrap().minutes(), 0.05); // fractional minutes
+/// assert_eq!("7s".parse::<ReportDuration>().unwrap().minutes(), 0.12);   // rounded to 2 dp
+/// assert!("1.5h".parse::<ReportDuration>().is_err());                    // units stay whole
+/// // Display uses the minimized h/m/s form:
+/// assert_eq!("0.05".parse::<ReportDuration>().unwrap().to_string(), "3s");
+/// assert_eq!("90".parse::<ReportDuration>().unwrap().to_string(), "1h30m");
+/// ```
+///
+/// [`Display`](fmt::Display) renders the minimized `h`/`m`/`s` form. For the
+/// `antithesis.duration` parameter use [`minutes()`](Self::minutes)`.to_string()`
+/// instead — that's the (possibly fractional) minute count the API expects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReportDuration(Duration);
+
+impl ReportDuration {
+    /// Build from a whole number of seconds.
+    pub fn from_seconds(seconds: u64) -> Self {
+        Self(Duration::from_secs(seconds))
+    }
+
+    /// Build from a (possibly fractional) number of minutes, rounded to whole
+    /// seconds. Returns `None` for a non-finite or negative value.
+    pub fn from_minutes(minutes: f64) -> Option<Self> {
+        if !minutes.is_finite() || minutes < 0.0 {
+            return None;
+        }
+        // `as u64` saturates rather than wraps, so an absurd value clamps
+        // instead of panicking.
+        let seconds = (minutes * SECS_PER_MINUTE as f64).round() as u64;
+        Some(Self::from_seconds(seconds))
+    }
+
+    /// The duration as a number of minutes, rounded to 2 decimal places — the
+    /// form the API wants. The hundredths are computed (and rounded) in integer
+    /// space rather than dividing as floats, so a second-granular value stays
+    /// clean instead of turning into a long repeating decimal: e.g. 7s is
+    /// `0.12`, not `0.11666…`.
+    pub fn minutes(&self) -> f64 {
+        let per_min = SECS_PER_MINUTE as u128;
+        let hundredths = (self.seconds() as u128 * 100 + per_min / 2) / per_min;
+        hundredths as f64 / 100.0
+    }
+
+    /// The duration as a whole number of seconds.
+    pub fn seconds(&self) -> u64 {
+        self.0.as_secs()
+    }
+
+    /// The underlying [`Duration`], for use with timers and the like.
+    pub fn as_duration(&self) -> Duration {
+        self.0
+    }
+}
+
+impl fmt::Display for ReportDuration {
+    /// Minimized `h`/`m`/`s` form: each nonzero component in order (e.g.
+    /// `1h30m`, `1m30s`, `1h1m1s`), or `0s` for zero.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let total = self.seconds();
+        let (hours, mins, secs) = (
+            total / SECS_PER_HOUR,
+            (total % SECS_PER_HOUR) / SECS_PER_MINUTE,
+            total % SECS_PER_MINUTE,
+        );
+        if total == 0 {
+            return f.write_str("0s");
+        }
+        if hours != 0 {
+            write!(f, "{hours}h")?;
+        }
+        if mins != 0 {
+            write!(f, "{mins}m")?;
+        }
+        if secs != 0 {
+            write!(f, "{secs}s")?;
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<Duration> for ReportDuration {
+    fn as_ref(&self) -> &Duration {
+        &self.0
+    }
+}
+
+impl From<ReportDuration> for Duration {
+    fn from(value: ReportDuration) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for ReportDuration {
+    type Err = ParseDurationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_ascii_lowercase();
+
+        // A bare number is (fractional) minutes, kept for backwards
+        // compatibility; otherwise expect whole-number `h`/`m`/`s` components.
+        if is_decimal(&s) {
+            let minutes: f64 = s.parse().map_err(|_| ParseDurationError)?;
+            return Self::from_minutes(minutes).ok_or(ParseDurationError);
+        }
+
+        parse_units(&s)
+            .map(Self::from_seconds)
+            .ok_or(ParseDurationError)
+    }
+}
+
+/// Error from parsing a [`ReportDuration`]. Its message lists the accepted
+/// forms; clap prefixes it with the offending value and flag name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseDurationError;
+
+impl fmt::Display for ParseDurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "must be a number of minutes (e.g. `30`) or use h/m units \
+             (e.g. `90m`, `2h`, `1h30m`)",
+        )
+    }
+}
+
+impl Error for ParseDurationError {}
+
+/// Whether `s` matches `^[0-9]+(\.[0-9]+)?$` — a bare integer or decimal.
+fn is_decimal(s: &str) -> bool {
+    let mut parts = s.splitn(2, '.');
+    let int = parts.next().unwrap_or_default();
+    let digits = |part: &str| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit());
+    digits(int) && parts.next().is_none_or(digits)
+}
+
+/// Parse a unit-suffixed duration — whole-number `h`, `m`, and `s` components
+/// in that order — into total seconds. Returns `None` for a missing component,
+/// the wrong order, an unknown unit, or trailing junk.
+fn parse_units(s: &str) -> Option<u64> {
+    let mut rest = s;
+    let mut seconds = 0u64;
+    let mut matched = false;
+
+    for (unit, secs_per_unit) in [('h', SECS_PER_HOUR), ('m', SECS_PER_MINUTE), ('s', 1)] {
+        if let Some((value, after)) = split_unit(rest, unit) {
+            seconds = seconds.checked_add(value.checked_mul(secs_per_unit)?)?;
+            rest = after;
+            matched = true;
+        }
+    }
+
+    (matched && rest.is_empty()).then_some(seconds)
+}
+
+/// If `s` starts with `<digits><unit>`, return the parsed number and the
+/// remainder after the unit; otherwise `None`.
+fn split_unit(s: &str, unit: char) -> Option<(u64, &str)> {
+    let idx = s.find(unit)?;
+    let (number, rest) = s.split_at(idx);
+    if number.is_empty() || !number.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some((number.parse().ok()?, &rest[unit.len_utf8()..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minutes(s: &str) -> f64 {
+        s.parse::<ReportDuration>().unwrap().minutes()
+    }
+
+    fn seconds(s: &str) -> u64 {
+        s.parse::<ReportDuration>().unwrap().seconds()
+    }
+
+    #[test]
+    fn parses_bare_number_as_minutes() {
+        assert_eq!(minutes("30"), 30.0);
+        assert_eq!(minutes("0"), 0.0);
+        assert_eq!(minutes("  15  "), 15.0); // surrounding whitespace tolerated
+        // Fractional minutes are kept (rounded to whole seconds).
+        assert_eq!(seconds("0.05"), 3);
+        assert_eq!(minutes("0.05"), 0.05);
+        assert_eq!(seconds("1.5"), 90);
+    }
+
+    #[test]
+    fn minutes_rounds_to_two_decimals() {
+        // Rounded in integer space, so no float drift and no long decimals.
+        assert_eq!(ReportDuration::from_seconds(3).minutes(), 0.05);
+        assert_eq!(ReportDuration::from_seconds(7).minutes(), 0.12); // 0.11666… rounded up
+        assert_eq!(ReportDuration::from_seconds(5).minutes(), 0.08); // 0.08333… rounded down
+        assert_eq!(ReportDuration::from_seconds(5442).minutes(), 90.7); // float-divide would give 90.69
+        assert_eq!(ReportDuration::from_seconds(5445).minutes(), 90.75);
+        // ...and the string sent to the API stays clean.
+        assert_eq!(
+            ReportDuration::from_seconds(7).minutes().to_string(),
+            "0.12"
+        );
+    }
+
+    #[test]
+    fn rounds_fractional_minutes_to_whole_seconds() {
+        assert_eq!(seconds("0.05"), 3); // 3.0s
+        assert_eq!(seconds("0.051"), 3); // 3.06s -> 3
+        assert_eq!(seconds("0.06"), 4); // 3.6s -> 4
+    }
+
+    #[test]
+    fn parses_unit_suffixes() {
+        assert_eq!(seconds("15m"), 15 * 60);
+        assert_eq!(seconds("1h"), 3600);
+        assert_eq!(seconds("2h"), 7200);
+        assert_eq!(seconds("1h30m"), 5400);
+        assert_eq!(seconds("30s"), 30);
+        assert_eq!(seconds("90s"), 90);
+        assert_eq!(seconds("1m30s"), 90);
+        assert_eq!(seconds("1h30m45s"), 5445);
+        assert_eq!(seconds("1H30M"), 5400); // case-insensitive
+    }
+
+    #[test]
+    fn rejects_unparsable_values() {
+        // Unknown units, fractional unit components, a trailing unitless number,
+        // wrong unit order, and malformed numbers all fail.
+        for bad in [
+            "abc", "15x", "1.5h", "0.5m", "1h30", "1h2h", "30m15h", "1.2.3", "1.2.3h", "h", "",
+            "  ",
+        ] {
+            assert_eq!(
+                bad.parse::<ReportDuration>(),
+                Err(ParseDurationError),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn from_minutes_rejects_non_finite_and_negative() {
+        assert_eq!(ReportDuration::from_minutes(f64::NAN), None);
+        assert_eq!(ReportDuration::from_minutes(f64::INFINITY), None);
+        assert_eq!(ReportDuration::from_minutes(-1.0), None);
+    }
+
+    #[test]
+    fn display_renders_minimized_hms() {
+        let display = |s: &str| s.parse::<ReportDuration>().unwrap().to_string();
+        assert_eq!(display("0"), "0s"); // zero
+        assert_eq!(display("0.05"), "3s"); // sub-minute
+        assert_eq!(display("90s"), "1m30s");
+        assert_eq!(display("45"), "45m"); // sub-hour
+        assert_eq!(display("60"), "1h"); // whole hours
+        assert_eq!(display("120"), "2h");
+        assert_eq!(display("90"), "1h30m"); // hours + minutes
+        assert_eq!(display("1h30m45s"), "1h30m45s"); // all three
+    }
+
+    #[test]
+    fn display_round_trips_by_value() {
+        for s in [
+            "0", "0.05", "45", "60", "90", "120", "1h30m", "30s", "1h30m45s", "90m",
+        ] {
+            let parsed = s.parse::<ReportDuration>().unwrap();
+            let reparsed = parsed.to_string().parse::<ReportDuration>().unwrap();
+            assert_eq!(parsed, reparsed, "{s:?} did not round-trip through Display");
+        }
+    }
+
+    #[test]
+    fn converts_to_duration() {
+        let d = "1h30m".parse::<ReportDuration>().unwrap();
+        assert_eq!(d.as_duration(), Duration::from_secs(5400));
+        assert_eq!(Duration::from(d), Duration::from_secs(5400));
+        assert_eq!(d.as_ref(), &Duration::from_secs(5400));
+    }
+}

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -215,22 +215,38 @@ fn launch_param_cannot_override_typed_flag() {
 
 #[test]
 fn launch_duration_rejects_non_numeric() {
+    // Invalid durations now fail at flag-parse time with a message attributed to
+    // --duration, instead of a deep schema "validation failed" cascade.
     snouty()
         .args(["launch", "-w", "basic_test", "--duration", "abc"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("validation failed"));
+        .stderr(predicate::str::contains("--duration"))
+        .stderr(predicate::str::contains("number of minutes"));
 }
 
 #[test]
 fn launch_duration_accepts_fractional() {
     let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
 
+    // Fractional minutes are kept for backwards compatibility (0.05 -> 3s).
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "0.05"])
         .assert()
         .success()
         .stderr(predicate::str::contains(r#""antithesis.duration": "0.05""#));
+}
+
+#[test]
+fn launch_duration_accepts_unit_suffixes() {
+    let mock_url = start_mock_server(r#"{"runId":"run-123","statusCode":200}"#, 200);
+
+    // 1h30m is sent to the API as a bare 90 minutes.
+    snouty_with_mock(&mock_url)
+        .args(["launch", "-w", "basic_test", "--duration", "1h30m"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(r#""antithesis.duration": "90""#));
 }
 
 #[test]


### PR DESCRIPTION
Resolves the misleading "unevaluated properties" cascade from #152. When `--duration` (or any `antithesis.*` value) was invalid, schema validation reported every valid sibling property as "unexpected" — a `unevaluatedProperties: false` artifact that fired once a more specific subschema failed and dropped its annotations. Readers chased fields that were fine. Validation now suppresses that cascade whenever a more specific violation already fired, so the error points only at the field that's actually wrong.

`--duration` parsing and formatting now live in a `ReportDuration` type (`src/time.rs`) with a real `FromStr`/`Display` and conversions to `std::time::Duration`. The flag accepts a bare minute count or `h`/`m` units (`90m`, `2h`, `1h30m`) and an invalid value now fails at flag-parse time, attributed to the flag, instead of surfacing a raw schema regex deep in validation.

Bare fractional minutes (e.g. `0.05`) stay accepted for backwards compatibility — rounded to whole seconds internally and sent to the API as minutes rounded to two decimal places — but they're not advertised in `--help` or error messages, since whole-minute resolution is the expectation.

`snouty runs show` renders the requested Duration and the wall-clock Elapsed through the same `ReportDuration` vocabulary, so a run launched as `1h30m` reads back as `1h30m`.

fixes #152