### PR TITLE
chore: typos spell-check consistency (Stop hook, exclude openapi.json, bump CI to v1.47.2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,19 @@
             "rewakeMessage": "cargo check reported errors. Fix them before finishing:"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v typos >/dev/null 2>&1 || exit 0; out=$(typos --color never 2>&1) || { echo \"$out\"; exit 2; }",
+            "asyncRewake": true,
+            "timeout": 60,
+            "statusMessage": "typos spell check",
+            "rewakeSummary": "typos found spelling mistakes",
+            "rewakeMessage": "typos found spelling mistakes. Fix them, or add legitimate words to _typos.toml, before finishing:"
+          }
+        ]
       }
     ]
   }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Spell Check Repo
-        uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06 # v1.40.0
+        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
   test:
     runs-on: ${{ matrix.os }}
     needs: skip-check

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+# Spell-checker config, read by both CI (crate-ci/typos) and the local Stop hook.
+#
+# openapi.json is fetched from the Antithesis API, not hand-edited, so it
+# shouldn't be spell-checked — its identifiers (base64-ish command ids, etc.)
+# trip the dictionary with corrections we can't act on.
+[files]
+extend-exclude = ["src/openapi.json"]


### PR DESCRIPTION
Catch spelling mistakes locally before they reach CI, and stop CI and local checks from disagreeing.

Adds a `Stop` hook to the committed `.claude/settings.json` (alongside the existing cargo fmt/check one) that runs `typos` when it's installed on PATH and feeds any findings back so they get fixed before a turn finishes. It no-ops cleanly for contributors who don't have `typos` installed.

Excludes the downloaded `src/openapi.json` from spell-checking via a new `_typos.toml`. That file is fetched from the Antithesis API and isn't hand-edited, and its identifiers (base64-ish command ids, etc.) trip the dictionary with corrections we can't act on. Both CI (`crate-ci/typos`) and the local hook read this config, so the exclusion applies everywhere.

Bumps the CI `crate-ci/typos` action from v1.40.0 to v1.47.2 (latest, pinned by SHA). The old version's dictionary differed from a current local `typos`, which is how the same repo could pass CI while a local run flagged `openapi.json` (and vice-versa for `unparseable`). CI and a current local `typos` now run the same version, invocation, and exclusions. Verified the repo is clean under v1.47.2 with the new config.