### PR TITLE
test: add hegel property-based tests for pure parsing/formatting logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 
 # uv project virtualenv (created when running scripts via `uv run`)
 .venv/
+
+# hegel property-testing server cache + failure database
+.hegel/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +314,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +336,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -424,6 +481,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +529,25 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "dashu-base"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993b95dc1b248e3f5747dcb017a41d6e75853a2e5ee4504f7d537c5b8dffdae4"
+
+[[package]]
+name = "dashu-int"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c05a0d5cb0b39fcc87c46432fdac24b90dce239857c7f6b798be4ffc3c42c6"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
 
 [[package]]
 name = "data-encoding"
@@ -860,6 +960,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -887,6 +988,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -929,6 +1041,55 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hegeltest"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d3bacc1e5eac3dc5b6b725ff9969ecb2080ab1b77d09558a0a4fc90366c518"
+dependencies = [
+ "ciborium",
+ "crc32fast",
+ "dashu-int",
+ "hegeltest-c",
+ "hegeltest-macros",
+ "miniz_oxide",
+ "parking_lot",
+ "paste",
+ "rand",
+ "rustc-hash",
+ "serde",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-c"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5b56caca9a102a667c42bb119ed864cf0491193159a96fcfc8f12ecea4f125"
+dependencies = [
+ "cbindgen",
+ "ciborium",
+ "crc32fast",
+ "dashu-int",
+ "miniz_oxide",
+ "parking_lot",
+ "rand",
+ "rustc-hash",
+ "serde",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8609b7dfe2e7fa153e8157001aa2de8c3b82064f49325d8bed65cbc323d27bb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1582,6 +1743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1897,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1956,6 +2129,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2328,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2388,7 +2584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2399,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2410,7 +2606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2458,6 +2654,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "getrandom 0.3.4",
+ "hegeltest",
  "http",
  "http-cache-reqwest",
  "indexmap",
@@ -2485,7 +2682,7 @@ dependencies = [
  "tempfile",
  "testscript-rs",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "wiremock",
 ]
 
@@ -2521,6 +2718,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2751,6 +2954,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -2758,10 +2976,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2779,7 +3006,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3397,6 +3624,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tempfile = "3"
 testscript-rs = "0.2"
 ctor = "0.4"
 wiremock = "0.6"
+hegeltest = "0.21.2"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/container.rs
+++ b/src/container.rs
@@ -1707,9 +1707,81 @@ mod tests {
     use crate::testutils::{
         OCIRegistry, has_compose, require_runtimes, require_runtimes_with_compose, skip_or_fail,
     };
+    use hegel::generators::{self, Generator};
     use std::collections::BTreeMap;
     use std::os::unix::process::ExitStatusExt;
     use std::path::PathBuf;
+
+    /// A text generator whose output never contains `@` — for digest values,
+    /// which never carry an `@` in practice (`sha256:...`), so the
+    /// re-pinning/idempotence reasoning holds.
+    fn no_at() -> impl Generator<String> {
+        generators::text().filter(|s: &String| !s.contains('@'))
+    }
+
+    /// Expanding a repository to its canonical `registry/path` form is stable:
+    /// normalizing an already-normalized repo is a no-op. Run over arbitrary
+    /// text so odd inputs (empty, leading slash, multi-byte) are covered too.
+    #[hegel::test]
+    fn normalize_repo_is_idempotent(tc: hegel::TestCase) {
+        let repo = tc.draw(generators::text());
+        let once = normalize_repo(&repo);
+        let twice = normalize_repo(&once);
+        assert_eq!(once, twice);
+    }
+
+    /// `image_repo` and `image_ref_tag` slice on byte offsets found with
+    /// `rfind`; on arbitrary (multi-byte) input they must never panic on a
+    /// non-char-boundary, and the repo must always be a prefix of the input.
+    #[hegel::test]
+    fn image_repo_is_a_prefix_and_never_panics(tc: hegel::TestCase) {
+        let image_ref = tc.draw(generators::text());
+        let repo = image_repo(&image_ref);
+        assert!(
+            image_ref.starts_with(repo),
+            "repo {repo:?} is not a prefix of {image_ref:?}"
+        );
+        // Just exercising the slicing — the assertion is "it returned".
+        let _ = image_ref_tag(&image_ref);
+    }
+
+    /// Re-pinning replaces the digest rather than appending a second one:
+    /// pinning to `d1` then `d2` is the same as pinning to `d2` directly, and
+    /// the result always ends with `@{d2}`.
+    #[hegel::test]
+    fn pinned_image_ref_replaces_digest(tc: hegel::TestCase) {
+        let image_ref = tc.draw(no_at());
+        let d1 = tc.draw(no_at());
+        let d2 = tc.draw(no_at());
+        let repinned = pinned_image_ref(&pinned_image_ref(&image_ref, &d1), &d2);
+        assert_eq!(repinned, pinned_image_ref(&image_ref, &d2));
+        assert!(repinned.ends_with(&format!("@{d2}")));
+    }
+
+    /// Stripping the tag from a digest-pinned reference is stable: a reference
+    /// already in `name@digest` form is left unchanged by a second pass.
+    #[hegel::test]
+    fn digest_only_ref_is_idempotent(tc: hegel::TestCase) {
+        let image_ref = tc.draw(generators::text());
+        let once = digest_only_ref(&image_ref);
+        assert_eq!(digest_only_ref(&once), once);
+    }
+
+    /// Classifying `manifest inspect` output must never panic on arbitrary
+    /// bytes — malformed JSON classifies as `NotFound`, never a crash.
+    #[hegel::test]
+    fn classify_manifest_json_never_panics(tc: hegel::TestCase) {
+        let bytes = tc.draw(generators::binary());
+        let _ = classify_manifest_json(&bytes);
+    }
+
+    /// Parsing a `docker push` digest line must never panic on arbitrary text —
+    /// it returns an error when no `sha256:` digest is present, never a crash.
+    #[hegel::test]
+    fn parse_docker_push_digest_never_panics(tc: hegel::TestCase) {
+        let stdout = tc.draw(generators::text());
+        let _ = parse_docker_push_digest(&stdout);
+    }
 
     #[tokio::test]
     async fn build_and_push_to_mock_registry() {

--- a/src/params.rs
+++ b/src/params.rs
@@ -692,6 +692,107 @@ mod tests {
         assert!(params.as_map().contains_key("antithesis.source"));
     }
 
+    use hegel::generators::{self, Generator};
+
+    /// `unescape_pointer_token` is the exact inverse of RFC 6901 escaping
+    /// (`~` → `~0`, `/` → `~1`). For *any* string — including ones already
+    /// containing `~0`/`~1` sequences, the case the order-sensitive replacement
+    /// is most likely to mangle — escaping then unescaping is the identity.
+    #[hegel::test]
+    fn unescape_reverses_rfc6901_escaping(tc: hegel::TestCase) {
+        let raw = tc.draw(generators::text());
+        // RFC 6901: `~` must be escaped before `/`, so a literal `/` doesn't
+        // collide with the `~1` it produces.
+        let escaped = raw.replace('~', "~0").replace('/', "~1");
+        assert_eq!(unescape_pointer_token(&escaped), raw);
+    }
+
+    /// `merge` is a right-biased union: the result agrees, key for key, with a
+    /// reference `HashMap` extended by the overlay. This is the model test for
+    /// the merge operation — the overlay wins on conflicts, base-only keys
+    /// survive, and no key is invented or dropped.
+    #[hegel::test]
+    fn merge_agrees_with_map_union(tc: hegel::TestCase) {
+        let kv = || {
+            generators::hashmaps(
+                generators::text().max_size(12),
+                generators::text().max_size(12),
+            )
+            .max_size(8)
+        };
+        let base_model = tc.draw(kv());
+        let overlay_model = tc.draw(kv());
+
+        let mut base = Params::new();
+        for (k, v) in &base_model {
+            base.insert(k.clone(), v.clone());
+        }
+        let mut overlay = Params::new();
+        for (k, v) in &overlay_model {
+            overlay.insert(k.clone(), v.clone());
+        }
+        base.merge(overlay);
+
+        // Reference: a plain right-biased union.
+        let mut model = base_model;
+        model.extend(overlay_model);
+
+        assert_eq!(base.as_map().len(), model.len());
+        for (k, v) in &model {
+            assert_eq!(
+                base.as_map().get(k).and_then(Value::as_str),
+                Some(v.as_str())
+            );
+        }
+    }
+
+    /// `from_key_value_pairs` splits on the *first* `=` only, so the value may
+    /// itself contain `=` and must come back verbatim. For any non-empty key
+    /// without `=` and any value, the parsed pair round-trips exactly.
+    #[hegel::test]
+    fn key_value_pair_round_trips(tc: hegel::TestCase) {
+        let key = tc.draw(generators::text().min_size(1).filter(|k| !k.contains('=')));
+        let value = tc.draw(generators::text());
+        let params = Params::from_key_value_pairs([format!("{key}={value}")])
+            .expect("a non-empty key with a value must parse");
+        assert_eq!(params.as_map().len(), 1);
+        assert_eq!(
+            params.as_map().get(&key).and_then(Value::as_str),
+            Some(value.as_str())
+        );
+    }
+
+    /// Redaction preserves the exact key set and leaves every value either
+    /// untouched or replaced by the marker — it never drops, adds, or reorders
+    /// keys, and only the documented sensitive keys are masked.
+    #[hegel::test]
+    fn redaction_preserves_keys_and_masks_only_sensitive(tc: hegel::TestCase) {
+        let model = tc.draw(
+            generators::hashmaps(
+                generators::text().max_size(20),
+                generators::text().max_size(20),
+            )
+            .max_size(8),
+        );
+        let mut params = Params::new();
+        for (k, v) in &model {
+            params.insert(k.clone(), v.clone());
+        }
+        let redacted = params.to_redacted_map();
+
+        assert_eq!(redacted.len(), model.len());
+        for (k, original) in &model {
+            // Oracle for sensitivity, kept independent of `is_sensitive_key`.
+            let sensitive = k.ends_with(".token") || k == "antithesis.report.recipients";
+            let expected = if sensitive {
+                "[REDACTED]"
+            } else {
+                original.as_str()
+            };
+            assert_eq!(redacted.get(k).and_then(Value::as_str), Some(expected));
+        }
+    }
+
     #[test]
     fn redacted_map_hides_sensitive_values() {
         let args = [

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -2749,7 +2749,73 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hegel::generators;
     use serde_json::json;
+
+    /// `wrap_text` preserves the exact sequence of words — wrapping only inserts
+    /// line breaks, it never drops, splits, reorders, or invents a word.
+    #[hegel::test]
+    fn wrap_text_preserves_word_sequence(tc: hegel::TestCase) {
+        let text = tc.draw(generators::text());
+        let width = tc.draw(generators::integers::<usize>().min_value(1).max_value(40));
+        let lines = wrap_text(&text, width);
+        let words_in: Vec<&str> = text.split_whitespace().collect();
+        let words_out: Vec<&str> = lines.iter().flat_map(|l| l.split_whitespace()).collect();
+        assert_eq!(words_in, words_out);
+    }
+
+    /// Every wrapped line fits within `width` columns, with the one documented
+    /// exception: a single word longer than `width` is kept intact rather than
+    /// split mid-token (such a line has no internal space).
+    #[hegel::test]
+    fn wrap_text_respects_width(tc: hegel::TestCase) {
+        let text = tc.draw(generators::text());
+        // Include 0 to exercise the `width.max(1)` clamp.
+        let width = tc.draw(generators::integers::<usize>().max_value(40));
+        let effective = width.max(1);
+        for line in wrap_text(&text, width) {
+            assert!(
+                line.chars().count() <= effective || !line.contains(' '),
+                "line {line:?} exceeds width {effective} but contains a space",
+            );
+        }
+    }
+
+    /// `truncate_around` never returns more than `width` characters (the `…`
+    /// markers are counted), and returns text unchanged when it already fits.
+    #[hegel::test]
+    fn truncate_around_stays_within_width(tc: hegel::TestCase) {
+        let text = tc.draw(generators::text());
+        let needles = tc.draw(generators::vecs(generators::text().max_size(6)).max_size(3));
+        let width = tc.draw(generators::integers::<usize>().max_value(50));
+        let out = truncate_around(&text, &needles, width);
+        assert!(
+            out.chars().count() <= width,
+            "output {out:?} ({} chars) exceeds width {width}",
+            out.chars().count()
+        );
+        if text.chars().count() <= width {
+            assert_eq!(
+                out, text,
+                "text that already fits must pass through unchanged"
+            );
+        }
+    }
+
+    /// `first_needle_span` returns a span that is a valid window into the text's
+    /// char vector — the returned `(start, len)` never runs off the end.
+    #[hegel::test]
+    fn first_needle_span_is_in_bounds(tc: hegel::TestCase) {
+        let text = tc.draw(generators::text());
+        let needles = tc.draw(generators::vecs(generators::text().max_size(6)).max_size(3));
+        let char_count = text.chars().count();
+        if let Some((start, len)) = first_needle_span(&text, &needles) {
+            assert!(
+                start + len <= char_count,
+                "span {start}+{len} > {char_count}"
+            );
+        }
+    }
 
     #[test]
     fn renders_assertion_records_in_compact_form() {

--- a/src/time.rs
+++ b/src/time.rs
@@ -302,4 +302,62 @@ mod tests {
         assert_eq!(Duration::from(d), Duration::from_secs(5400));
         assert_eq!(d.as_ref(), &Duration::from_secs(5400));
     }
+
+    use hegel::generators;
+
+    /// The minimized `h`/`m`/`s` `Display` form parses back to the same value,
+    /// for *every* whole-second duration the type can hold. (The hand-written
+    /// `display_round_trips_by_value` checks a handful of literals; this checks
+    /// the whole `u64`-seconds domain, including `0` and `u64::MAX`, where the
+    /// component arithmetic in `parse_units` is most likely to misbehave.)
+    #[hegel::test]
+    fn display_round_trips_for_all_durations(tc: hegel::TestCase) {
+        let seconds = tc.draw(generators::integers::<u64>());
+        let d = ReportDuration::from_seconds(seconds);
+        let reparsed = d
+            .to_string()
+            .parse::<ReportDuration>()
+            .expect("Display output must re-parse");
+        assert_eq!(d, reparsed);
+    }
+
+    /// Parsing arbitrary text must never panic — it returns `Ok` or
+    /// `ParseDurationError`, but the `from_str`/`from_minutes`/`parse_units`
+    /// path (with its `as u64` casts and `checked_*` arithmetic) is the kind of
+    /// code that overflows or indexes out of bounds on hostile input.
+    #[hegel::test]
+    fn parse_never_panics(tc: hegel::TestCase) {
+        let s = tc.draw(generators::text());
+        let _ = s.parse::<ReportDuration>();
+    }
+
+    /// `from_minutes` is `Some` exactly for finite, non-negative inputs, and
+    /// when it succeeds the stored seconds are the minutes scaled by 60 and
+    /// rounded (saturating, never panicking, on absurd values). Drawn from the
+    /// full `f64` domain so NaN, infinities, negatives, and huge magnitudes are
+    /// all exercised.
+    #[hegel::test]
+    fn from_minutes_matches_contract(tc: hegel::TestCase) {
+        let minutes = tc.draw(generators::floats::<f64>());
+        match ReportDuration::from_minutes(minutes) {
+            Some(d) => {
+                assert!(minutes.is_finite() && minutes >= 0.0);
+                assert_eq!(d.seconds(), (minutes * 60.0).round() as u64);
+            }
+            None => assert!(!minutes.is_finite() || minutes < 0.0),
+        }
+    }
+
+    /// `minutes()` is the documented integer-space rounding of the second
+    /// count to hundredths of a minute — no float drift, no long decimals.
+    /// Bounded to `u32`-range seconds (~136 years) so the `* 100.0` round-trip
+    /// stays exactly representable in `f64`; the integer arithmetic the test
+    /// mirrors is what actually runs in production.
+    #[hegel::test]
+    fn minutes_is_integer_space_rounding(tc: hegel::TestCase) {
+        let seconds = tc.draw(generators::integers::<u32>()) as u64;
+        let d = ReportDuration::from_seconds(seconds);
+        let expected_hundredths = (seconds as u128 * 100 + 30) / 60;
+        assert_eq!((d.minutes() * 100.0).round() as u128, expected_hundredths);
+    }
 }


### PR DESCRIPTION
Introduces property-based testing with hegel (`hegeltest`), covering the highest-value pure functions across four modules. These exercise combinations and boundary conditions the existing example-based unit tests don't reach, with automatic shrinking to minimal counterexamples. Tests live inline in each module's existing test module; this adds `hegeltest` as a dev-dependency and gitignores its `.hegel/` cache.

- `time.rs`: `ReportDuration` Display→parse roundtrip over the full `u64` domain, parse-never-panics, the `from_minutes` finite/non-negative contract over the full `f64` domain, and `minutes()` integer-space rounding.
- `params.rs`: RFC 6901 escape/unescape roundtrip, a `merge` model test against a `HashMap` union, `key=value` roundtrip (value may contain `=`), and redaction key preservation.
- `container.rs`: image-reference helper idempotence (`normalize_repo`, `digest_only_ref`), `pinned_image_ref` digest replacement, UTF-8-safe no-panic slicing for `image_repo`/`image_ref_tag`, and parser robustness (`classify_manifest_json`, `parse_docker_push_digest`).
- `runs.rs`: `wrap_text` word-sequence and width invariants, `truncate_around` width bound, and `first_needle_span` in-bounds — `wrap_text` and `truncate_around` previously had no tests.

Two generators are deliberately scoped: the duration tests draw unbounded `u64`/`f64` (boundary values are the point), while `minutes_is_integer_space_rounding` bounds seconds to `u32` range so the `* 100.0` round-trip stays exactly representable in `f64` — the integer arithmetic it mirrors is what actually runs.