### PR TITLE
Allow additional images via --param antithesis.images

### DIFF
--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -54,11 +54,6 @@ mock-server 200 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
 
-# antithesis.images must not be passed via --param.
-mock-server 200 '{"runId":"run-123","statusCode":202}'
-! snouty launch -w basic_test --duration 30 --param antithesis.images=app:latest
-stderr 'antithesis.images cannot be set via --param.*'
-
 [staging] skip
 
 # Parameters are provided as --key value typed flags
@@ -110,6 +105,13 @@ mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param my.custom.prop=value --param antithesis.integrations.github.callback_url=https://example.com/cb
 stderr '"my.custom.prop": "value"'
 stderr '"antithesis.integrations.github.callback_url": "https://example.com/cb"'
+
+# 6e. antithesis.images may be passed via --param to register additional
+#    images (e.g. an image referenced only in a CRD field) that the config
+#    parser can't discover. Semicolon-delimited [REGISTRY/]NAME(:TAG|@DIGEST).
+mock-server 200 '{"runId":"run-123","statusCode":202}'
+snouty launch -w basic_test --duration 30 --param 'antithesis.images=app@sha256:abc;db:latest'
+stderr '"antithesis.images": "app@sha256:abc;db:latest"'
 
 # On API failure, the command exits with an error showing the HTTP status
 #    and response body.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,13 @@ Extra parameters can be passed with --param:
     --param antithesis.integrations.github.token=TOKEN \
     --param my.custom.property=value
 
+Additional container images that the config parser can't discover (e.g. an
+image referenced only in a Kubernetes CRD field) can be registered with the
+antithesis.images param, a semicolon-delimited [REGISTRY/]NAME(:TAG|@DIGEST)
+list:
+  snouty launch -w basic_k8s_test --config ./config --duration 30 \
+    --param 'antithesis.images=app@sha256:...;db:latest'
+
 Tenant and repository may be set via the environment variables below, or in a
 settings file (./.snouty.toml by default; see the global --settings/--profile
 flags and the README). Environment variables take precedence.

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,12 +230,6 @@ async fn cmd_launch(
         params.merge(extra);
     }
 
-    if params.contains_key("antithesis.images") {
-        return Err(user_error(
-            "invalid argument: antithesis.images cannot be set via --param",
-        ));
-    }
-
     if params.is_empty() {
         return Err(user_error("invalid arguments: no parameters provided"));
     }

--- a/src/params.rs
+++ b/src/params.rs
@@ -355,6 +355,15 @@ mod tests {
     }
 
     #[test]
+    fn validate_images_from_param_key_value_pairs() {
+        // `--param antithesis.images=...` flows through from_key_value_pairs;
+        // the restored image registration must validate cleanly there too.
+        let params =
+            Params::from_key_value_pairs(["antithesis.images=app@sha256:abc;db:latest"]).unwrap();
+        assert!(params.validate_test_params().is_ok());
+    }
+
+    #[test]
     fn validate_images_semicolon_delimited_with_registries() {
         let args = [
             "--antithesis.images",


### PR DESCRIPTION
Re-allow `snouty launch --param antithesis.images=...` so images that the config parser can't discover (e.g. an image referenced only in a Kubernetes CRD field) can be registered for pulling and instrumentation.

The rejection dated to when `api webhook` was the raw escape hatch for this param; that command has since been removed, leaving no CLI-native way to pass images even though the API and schema already support it. Removing the guard lets the param flow through the normal merge, schema-validation, and API-builder path. The launch help now documents the param, and a spec plus a unit test cover the restored behavior.

fixes #159