### PR TITLE
validate: fail when compose references env vars absent from the Antithesis environment

### DIFF
--- a/specs/validate.txt
+++ b/specs/validate.txt
@@ -31,6 +31,10 @@ stdout '.*keep-running.*'
 snouty validate --help
 stdout '.*manifests/.*'
 
+# Help text mentions --allow-unresolved-env.
+snouty validate --help
+stdout '.*allow-unresolved-env.*'
+
 -- empty/.keep --
 -- yml_dir/docker-compose.yml --
 -- ambiguous/docker-compose.yaml --

--- a/specs_engine/validate_env.txt
+++ b/specs_engine/validate_env.txt
@@ -1,0 +1,74 @@
+# snouty validate — environment-variable resolution checks
+#
+# Antithesis runs docker-compose from the config image in a hermetic
+# environment that has none of the user's shell variables. Interpolation
+# (`${VAR}`) there resolves only from a `.env` file baked into the config image
+# or from inline defaults. validate reproduces that by resolving the compose
+# file under a scrubbed environment and failing when a referenced variable
+# can't be resolved, so a run that would fail in Antithesis fails locally first.
+
+# A variable that resolves only from the shell (no `.env` entry, no inline
+#    default) fails validation before any container starts, naming the variable.
+! snouty validate config_unresolved --timeout 15
+stderr '.*will not resolve in the Antithesis environment.*'
+stderr '.*SNOUTY_TEST_UNSET_VAR.*'
+
+# --allow-unresolved-env downgrades that failure to a warning; validation
+#    continues and still succeeds when the missing variable is harmless.
+build-image env-emitter:latest setup_emitter
+snouty validate config_unresolved_ok --allow-unresolved-env --timeout 20
+stderr '.*Warning:.*'
+stderr '.*SNOUTY_TEST_UNSET_VAR.*'
+stderr '.*Setup validation successful.*'
+
+# A variable satisfied by a `.env` file in the config dir resolves cleanly —
+#    exactly as it would from the config image — so validation neither warns
+#    nor fails on it.
+snouty validate config_env_file --timeout 20
+! stderr '.*will not resolve.*'
+stderr '.*Setup validation successful.*'
+
+# A required (${VAR:?}) variable with no resolution is reported as required and
+#    fails up front. Because the check runs before contents(), the user sees the
+#    actionable message rather than docker-compose's raw abort on the required var.
+! snouty validate config_required --timeout 15
+stderr '.*will not resolve in the Antithesis environment.*'
+stderr '.*SNOUTY_TEST_REQ \(required\).*'
+
+-- setup_emitter/Dockerfile --
+FROM busybox
+CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl" && sleep 3600'
+
+-- config_unresolved/docker-compose.yaml --
+services:
+  app:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      NEEDS_THIS: ${SNOUTY_TEST_UNSET_VAR}
+
+-- config_unresolved_ok/docker-compose.yaml --
+services:
+  emitter:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      HARMLESS: ${SNOUTY_TEST_UNSET_VAR}
+
+-- config_env_file/docker-compose.yaml --
+services:
+  emitter:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      RESOLVED: ${SNOUTY_TEST_SET_VAR}
+-- config_env_file/.env --
+SNOUTY_TEST_SET_VAR=hello
+
+-- config_required/docker-compose.yaml --
+services:
+  app:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      NEEDS_THIS: ${SNOUTY_TEST_REQ:?must provide SNOUTY_TEST_REQ}

--- a/specs_engine/validate_k8s.txt
+++ b/specs_engine/validate_k8s.txt
@@ -9,11 +9,19 @@ stderr 'k8s manifests valid.*'
 ! snouty validate config_invalid
 stderr 'k8s-validator failed.*'
 
+# --allow-unresolved-env is compose-only: it is inert for k8s configs (accepted
+#    but ignored), and a stray .env in the config dir is never read.
+snouty validate config_valid --allow-unresolved-env
+stderr 'k8s manifests valid.*'
+! stderr '.*will not resolve.*'
+
 -- config_valid/manifests/ns.yaml --
 apiVersion: v1
 kind: Namespace
 metadata:
   name: snouty-demo
+-- config_valid/.env --
+SHOULD_BE_IGNORED=1
 -- config_invalid/manifests/pod.yaml --
 apiVersion: v1
 kind: Pod

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,9 +160,10 @@ Compose configs:
 
 Kubernetes configs:
   Runs docker.io/antithesishq/k8s-validator against the manifests/
-  directory to perform static analysis of the manifests. --timeout has no
-  effect (the validator does not start any workloads), and --keep-running
-  has no effect (no containers are launched).
+  directory to perform static analysis of the manifests. --timeout,
+  --keep-running, and --allow-unresolved-env have no effect here (no
+  workloads or containers are started, and there is no docker-compose-style
+  ${VAR} interpolation to check).
 
 Example:
   snouty validate ./config
@@ -320,6 +321,11 @@ pub struct ValidateArgs {
     /// Leave containers running after validation for manual inspection
     #[arg(long)]
     pub keep_running: bool,
+
+    /// Warn instead of failing when docker-compose.yaml references environment
+    /// variables that won't resolve in the Antithesis environment
+    #[arg(long)]
+    pub allow_unresolved_env: bool,
 }
 
 #[derive(Args)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -625,6 +625,38 @@ impl DockerCompose<'_> {
         parse_compose_config(&yaml)
     }
 
+    /// Run `docker-compose config` with a scrubbed process environment so that
+    /// `${VAR}` interpolation resolves only from the config dir's `.env` file and
+    /// inline defaults — reproducing the Antithesis environment, which carries
+    /// none of the user's shell variables. `.env` is read from the project
+    /// directory by path, independent of the process environment, so it (and its
+    /// full dotenv semantics — BOM stripping, `export`, quoting) still applies.
+    ///
+    /// Returns the raw command output for the caller to parse: stderr carries the
+    /// diagnostics — `The "X" variable is not set…` for soft-missing variables
+    /// and `required variable X is missing a value` for `${X:?}` ones — and the
+    /// exit status is non-zero when a required variable is unresolved.
+    pub fn config_isolated_env(&self, config: &ComposeConfig) -> Result<std::process::Output> {
+        let mut cmd = Command::new(DOCKER_COMPOSE);
+        cmd.current_dir(config.dir());
+        cmd.env_clear();
+        // Keep only the machinery docker-compose needs to run. These are not
+        // interpolation sources Antithesis lacks, so retaining them can't mask a
+        // missing variable; dropping them would just break the binary.
+        for key in ["PATH", "HOME"] {
+            if let Some(val) = std::env::var_os(key) {
+                cmd.env(key, val);
+            }
+        }
+        if let Some(host) = &self.docker_host {
+            cmd.env("DOCKER_HOST", host);
+        }
+        cmd.args(compose_file_args(None));
+        cmd.arg("config");
+        cmd.output()
+            .wrap_err("failed to run 'docker-compose config' for the environment check")
+    }
+
     /// Canonicalized compose file for baking into the config image.
     ///
     /// `docker-compose config` itself does the canonicalization: anchors,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -197,11 +197,20 @@ async fn validate_with_temp_dir(
         config: config_path,
         timeout,
         keep_running,
+        allow_unresolved_env,
     } = args;
     let rt = container::runtime(settings)?;
     match config::detect_config(&config_path)? {
         Config::Compose(cfg) => {
-            validate_compose(rt.as_ref(), cfg, timeout, keep_running, temp_dir).await
+            validate_compose(
+                rt.as_ref(),
+                cfg,
+                timeout,
+                keep_running,
+                allow_unresolved_env,
+                temp_dir,
+            )
+            .await
         }
         Config::Kubernetes(cfg) => validate_kubernetes(rt.as_ref(), &cfg, keep_running).await,
     }
@@ -212,9 +221,14 @@ async fn validate_compose(
     config: ComposeConfig,
     timeout: u64,
     keep_running: bool,
+    allow_unresolved_env: bool,
     temp_dir: &Path,
 ) -> Result<()> {
     let compose = container::docker_compose(rt)?;
+    // Check env-var resolution before contents(): contents() interpolates with
+    // the inherited shell env and would abort on an unset required `${VAR:?}`
+    // before this check could produce its actionable message.
+    check_env_resolution(&compose, &config, allow_unresolved_env)?;
     let contents = compose.contents(&config, None)?;
     container::validate_images_are_available(rt, &contents)?;
     let override_path = generate_setup_override(&contents, temp_dir)?;
@@ -311,6 +325,125 @@ async fn validate_compose(
     }
 
     test_result
+}
+
+/// A compose interpolation variable that won't resolve in the Antithesis
+/// environment: it has no inline default/alternate and no `.env` entry, so it
+/// draws only from the user's shell — which the hermetic Antithesis environment
+/// doesn't have.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct UnresolvedVar {
+    name: String,
+    /// `${VAR:?}` — compose hard-errors on this rather than defaulting to blank.
+    required: bool,
+}
+
+/// Fail (or, with `allow_unresolved_env`, warn) when the compose file
+/// references a `${VAR}` that won't resolve in the Antithesis environment.
+///
+/// Antithesis runs docker-compose from the config image in a hermetic
+/// environment with none of the user's shell variables, so interpolation there
+/// draws only from a `.env` file baked into the config image or an inline
+/// default. We reproduce that by resolving the compose file under a scrubbed
+/// environment (see [`container::DockerCompose::config_isolated_env`]) and
+/// reading which variables compose itself reports as unresolved — delegating all
+/// dotenv/default semantics to compose rather than re-deriving them.
+///
+/// One caveat: an unresolved required `${VAR:?}` makes compose abort, so if such
+/// a variable coexists with soft-missing ones the soft list may be truncated;
+/// the required error is still reported, and a re-run after the fix surfaces the
+/// rest.
+fn check_env_resolution(
+    compose: &container::DockerCompose,
+    config: &ComposeConfig,
+    allow_unresolved_env: bool,
+) -> Result<()> {
+    let output = compose.config_isolated_env(config)?;
+    let unresolved = parse_unresolved_env(&String::from_utf8_lossy(&output.stderr));
+
+    // An empty result means either the compose file resolves cleanly or `config`
+    // failed for a non-env reason (e.g. a malformed file); in the latter case
+    // `contents()` re-runs `config` next and surfaces that with its canonical
+    // error, so there is nothing to report here.
+    if unresolved.is_empty() {
+        return Ok(());
+    }
+
+    if allow_unresolved_env {
+        eprintln!("Warning: {}", unresolved_report(&unresolved));
+        Ok(())
+    } else {
+        Err(unresolved_error(&unresolved))
+    }
+}
+
+/// Parse the unresolved interpolation variables out of `docker-compose config`
+/// stderr produced under a scrubbed environment. Recognizes both the
+/// soft-missing warning (`The "X" variable is not set…`) and the required-var
+/// error (`required variable X is missing a value`).
+///
+/// `ANTITHESIS_*` variables are excluded: the platform injects those itself, so
+/// flagging them would be a false positive.
+fn parse_unresolved_env(stderr: &str) -> Vec<UnresolvedVar> {
+    // name -> required; a variable referenced both ways is treated as required.
+    let mut found: BTreeMap<String, bool> = BTreeMap::new();
+    for raw in stderr.lines() {
+        // logrus escapes the inner quotes of its quoted `msg` field when output
+        // is captured; normalize so escaped and bare quote forms parse alike.
+        let line = raw.replace("\\\"", "\"");
+        if let Some((_, rest)) = line.split_once("required variable ")
+            && let Some((name, _)) = rest.split_once(" is missing a value")
+        {
+            found.insert(name.trim().to_string(), true);
+        } else if let Some((_, rest)) = line.split_once("The \"")
+            && let Some((name, _)) = rest.split_once("\" variable is not set")
+        {
+            found.entry(name.trim().to_string()).or_insert(false);
+        }
+    }
+
+    found
+        .into_iter()
+        .filter(|(name, _)| !name.starts_with("ANTITHESIS_"))
+        .map(|(name, required)| UnresolvedVar { name, required })
+        .collect()
+}
+
+/// The unresolved variables, one indented `(required)`-annotated line each.
+fn unresolved_listing(vars: &[UnresolvedVar]) -> String {
+    vars.iter()
+        .map(|v| {
+            if v.required {
+                format!("  {} (required)", v.name)
+            } else {
+                format!("  {}", v.name)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+const UNRESOLVED_HEADLINE: &str = "docker-compose.yaml references environment variables that will \
+not resolve in the Antithesis environment";
+
+const UNRESOLVED_FIX: &str = "These resolve from your shell locally, but the Antithesis \
+environment has none of your shell variables. Provide each one in a `.env` file in the config \
+directory (it is baked into the config image) or give it an inline default (e.g. ${VAR:-default}).";
+
+/// The `--allow-unresolved-env` warning body (headline + listing + fix).
+fn unresolved_report(vars: &[UnresolvedVar]) -> String {
+    format!(
+        "{UNRESOLVED_HEADLINE}:\n{}\n{UNRESOLVED_FIX}",
+        unresolved_listing(vars),
+    )
+}
+
+/// The hard-failure report; points at `--allow-unresolved-env` to downgrade it.
+fn unresolved_error(vars: &[UnresolvedVar]) -> color_eyre::Report {
+    user_error(UNRESOLVED_HEADLINE)
+        .with_section(|| unresolved_listing(vars).header("Unresolved:"))
+        .with_suggestion(|| UNRESOLVED_FIX)
+        .with_suggestion(|| "re-run with --allow-unresolved-env to treat this as a warning")
 }
 
 async fn validate_kubernetes(
@@ -1095,6 +1228,111 @@ services:
         assert!(msg.contains("  init"));
         assert!(msg.contains("  migrate"));
         assert!(msg.contains("exits 0"));
+    }
+
+    #[test]
+    fn parse_unresolved_env_soft_warnings() {
+        // Real captured form: logrus escapes the inner quotes of `msg`. An empty
+        // inline default (`${VAR:-}`) or `.env`-provided var emits no such warning,
+        // so it never appears here — compose does that filtering for us.
+        let stderr = concat!(
+            "time=\"...\" level=warning msg=\"The \\\"TAG\\\" variable is not set. Defaulting to a blank string.\"\n",
+            "time=\"...\" level=warning msg=\"The \\\"PW\\\" variable is not set. Defaulting to a blank string.\"\n",
+        );
+        assert_eq!(
+            parse_unresolved_env(stderr),
+            vec![
+                UnresolvedVar {
+                    name: "PW".to_string(),
+                    required: false,
+                },
+                UnresolvedVar {
+                    name: "TAG".to_string(),
+                    required: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_unresolved_env_required_and_soft_together() {
+        let stderr = concat!(
+            "time=\"...\" level=warning msg=\"The \\\"PW\\\" variable is not set. Defaulting to a blank string.\"\n",
+            "error while interpolating services.app.environment.REQ: required variable REQ is missing a value: must set REQ\n",
+        );
+        assert_eq!(
+            parse_unresolved_env(stderr),
+            vec![
+                UnresolvedVar {
+                    name: "PW".to_string(),
+                    required: false,
+                },
+                UnresolvedVar {
+                    name: "REQ".to_string(),
+                    required: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_unresolved_env_required_wins_over_soft() {
+        let stderr = concat!(
+            "msg=\"The \\\"X\\\" variable is not set. Defaulting to a blank string.\"\n",
+            "required variable X is missing a value: set it\n",
+        );
+        assert_eq!(
+            parse_unresolved_env(stderr),
+            vec![UnresolvedVar {
+                name: "X".to_string(),
+                required: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_unresolved_env_tolerates_bare_quotes() {
+        // TTY form, without logrus backslash escaping.
+        let stderr = "The \"BARE\" variable is not set. Defaulting to a blank string.\n";
+        assert_eq!(
+            parse_unresolved_env(stderr),
+            vec![UnresolvedVar {
+                name: "BARE".to_string(),
+                required: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_unresolved_env_excludes_antithesis_vars() {
+        // Antithesis injects these itself, so they must not be flagged.
+        let stderr = "msg=\"The \\\"ANTITHESIS_OUTPUT_DIR\\\" variable is not set. Defaulting to a blank string.\"\n";
+        assert!(parse_unresolved_env(stderr).is_empty());
+    }
+
+    #[test]
+    fn parse_unresolved_env_empty_when_clean() {
+        assert!(parse_unresolved_env("").is_empty());
+        assert!(parse_unresolved_env("name: proj\nservices: {}\n").is_empty());
+    }
+
+    #[test]
+    fn unresolved_error_names_vars_and_points_at_flag() {
+        let vars = vec![
+            UnresolvedVar {
+                name: "PW".to_string(),
+                required: false,
+            },
+            UnresolvedVar {
+                name: "REQ".to_string(),
+                required: true,
+            },
+        ];
+        let rendered = format!("{:?}", unresolved_error(&vars));
+        assert!(rendered.contains("will not resolve in the Antithesis environment"));
+        assert!(rendered.contains("PW"));
+        assert!(rendered.contains("REQ (required)"));
+        assert!(rendered.contains("--allow-unresolved-env"));
     }
 
     #[test]

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -589,6 +589,12 @@ engine_spec_case_test!(
     false
 );
 engine_spec_case_test!(
+    podman_engine_validate_env_specs,
+    "podman",
+    "validate_env.txt",
+    false
+);
+engine_spec_case_test!(
     docker_engine_launch_config_push_specs,
     "docker",
     "launch_config_push.txt",
@@ -616,5 +622,11 @@ engine_spec_case_test!(
     docker_engine_validate_k8s_specs,
     "docker",
     "validate_k8s.txt",
+    false
+);
+engine_spec_case_test!(
+    docker_engine_validate_env_specs,
+    "docker",
+    "validate_env.txt",
     false
 );


### PR DESCRIPTION
`snouty validate` ran docker-compose with the full shell environment, so a docker-compose.yaml that interpolates `${VAR}` could pass locally by drawing the value from the user's shell — while the Antithesis run, which is hermetic and has none of those variables, later failed with an empty (or missing) value. Validation gave false confidence.

validate now checks, before starting anything, that every interpolation variable the compose file references will resolve in the Antithesis environment: from a `.env` file baked into the config image or an inline default. It resolves the compose file under a scrubbed environment and reads which variables docker-compose itself reports as unresolved — its `variable is not set` warnings and `required variable ... is missing` errors — so all dotenv and default semantics (BOM stripping, empty defaults, quoting) are handled by compose rather than re-derived. Any unresolved variable (excluding `ANTITHESIS_*`, which the platform injects) fails validation and is named, with required (`${VAR:?}`) ones annotated.

`--allow-unresolved-env` downgrades the failure to a warning for anyone who bakes the values in some other way. The check runs before the config is otherwise resolved, and is compose-only; Kubernetes configs are unaffected (documented, and guarded by a spec).

An `env_file:` whose path points outside the config dir is out of scope for now; that surfaces clearly on the Antithesis side.

fixes #160