### PR TITLE
Add support for a Snouty-specific proxy setting

### DIFF
--- a/specs/proxy.txt
+++ b/specs/proxy.txt
@@ -1,0 +1,41 @@
+# HTTPS proxy support
+#
+# When ANTITHESIS_HTTPS_PROXY (or the `https_proxy` setting) is set, snouty
+# routes API requests through that proxy. It builds the client with
+# `Proxy::all`, so both http and https targets are proxied.
+#
+# The behavioral steps drive an in-process mock: `mock-proxy` starts the mock
+# Antithesis API behind a forward proxy and points ANTITHESIS_HTTPS_PROXY at it,
+# but does NOT set the base URL. The base URL below is an unresolvable
+# `.invalid` host (RFC 6761), so a request can reach the mock only by traversing
+# the proxy — a direct connection fails to resolve the host. Success against an
+# unreachable base URL is therefore proof the request went through the proxy.
+#
+# Every line is guarded with [!staging]: the whole file targets the local mock
+# and has no meaning against the live staging backend.
+
+# Negative control. The base URL points at an unresolvable host and no proxy is
+# configured, so `runs` cannot reach the API: it exits non-zero and prints no
+# run table. A real API key gets past the auth-presence check so the request is
+# actually attempted (and fails on the network), rather than short-circuiting.
+[!staging] env ANTITHESIS_BASE_URL=http://mock.invalid
+[!staging] env ANTITHESIS_API_KEY=placeholder-key
+[!staging] env ANTITHESIS_TENANT=testtenant
+[!staging] ! snouty runs
+[!staging] ! stdout 'RUN ID'
+
+# With the proxy configured, the identical request reaches the mock and lists
+# runs. `mock-proxy` sets ANTITHESIS_HTTPS_PROXY (and the API key) while the
+# base URL stays pointed at the unresolvable host, so this success can only be
+# via the proxy.
+[!staging] mock-proxy
+[!staging] snouty runs
+[!staging] stdout 'RUN ID.*STATUS.*CREATED.*TEST NAME'
+[!staging] stdout 'run-1.*completed'
+
+# `snouty doctor` reports the resolved proxy so a user can confirm it took
+# effect. doctor exits non-zero here (the proxy target refuses the connection),
+# but the resolved-settings table is printed regardless of exit status.
+env ANTITHESIS_HTTPS_PROXY=http://127.0.0.1:9
+snouty doctor --offline
+stderr '\s*https proxy\s*http://127\.0\.0\.1:9'

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,8 +9,8 @@ use color_eyre::{Section, SectionExt};
 use futures_util::stream;
 use log::debug;
 use progenitor_client::{ClientHooks, ClientInfo, Error as ClientError, OperationInfo};
-use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::{Client, Proxy};
 use reqwest_middleware::ClientWithMiddleware;
 
 use crate::api_cache;
@@ -269,7 +269,7 @@ impl AntithesisApi {
         debug!("initializing API client for {}", base_url);
 
         let default_headers = default_request_headers(auth)?;
-        let http_client = build_http_client(default_headers.clone())?;
+        let http_client = build_http_client(default_headers.clone(), settings)?;
         let cached = api_cache::build_cached_client(http_client.clone(), cache_dir);
         let state = ClientState {
             cached,
@@ -777,14 +777,20 @@ fn extra_headers_from_env() -> Result<Vec<(HeaderName, HeaderValue)>> {
     }
 }
 
-fn build_http_client(default_headers: HeaderMap) -> Result<Client> {
+fn build_http_client(default_headers: HeaderMap, settings: &Settings) -> Result<Client> {
     // Only a connect timeout (see CONNECT_TIMEOUT): no read or total timeout, so a
     // slow-but-alive Antithesis request is never aborted no matter how long it runs.
-    Client::builder()
+    let mut builder = Client::builder()
         .default_headers(default_headers)
-        .connect_timeout(CONNECT_TIMEOUT)
-        .build()
-        .wrap_err("failed to build API client")
+        .connect_timeout(CONNECT_TIMEOUT);
+
+    if let Some(proxy_address) = settings.https_proxy() {
+        let proxy = Proxy::all(proxy_address)
+            .wrap_err_with(|| eyre!("invalid proxy URL: {proxy_address}"))?;
+        builder = builder.proxy(proxy);
+    }
+
+    builder.build().wrap_err("failed to build API client")
 }
 
 fn auth_header(auth: &Auth) -> Result<HeaderValue> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -280,6 +280,7 @@ fn resolve_settings(settings: &Settings) -> Vec<Setting> {
         Setting::new("profile", settings.profile().unwrap_or("(none)")),
         Setting::new("tenant", settings.tenant().unwrap_or("not set")),
         Setting::new("repository", settings.repository().unwrap_or("not set")),
+        Setting::new("https proxy", settings.https_proxy().unwrap_or("not set")),
         // The explicit override, otherwise auto-detected.
         Setting::new(
             "container engine",
@@ -551,27 +552,41 @@ mod tests {
 
     #[test]
     fn tenant_row_shows_value() {
-        let settings = Settings::for_test(None, Some("acme"), None, None, None);
+        let settings = Settings::for_test(None, Some("acme"), None, None, None, None);
         let rows = resolve_settings(&settings);
         assert_eq!(row(&rows, "tenant").value, "acme");
     }
 
     #[test]
     fn missing_settings_render_as_not_set() {
-        let rows = resolve_settings(&Settings::for_test(None, None, None, None, None));
+        let rows = resolve_settings(&Settings::for_test(None, None, None, None, None, None));
         assert_eq!(row(&rows, "tenant").value, "not set");
     }
 
     #[test]
+    fn https_proxy_row_shows_value() {
+        let settings =
+            Settings::for_test(None, None, None, None, Some("http://proxy.corp:8080"), None);
+        let rows = resolve_settings(&settings);
+        assert_eq!(row(&rows, "https proxy").value, "http://proxy.corp:8080");
+    }
+
+    #[test]
+    fn https_proxy_row_defaults_to_not_set() {
+        let rows = resolve_settings(&Settings::for_test(None, None, None, None, None, None));
+        assert_eq!(row(&rows, "https proxy").value, "not set");
+    }
+
+    #[test]
     fn container_engine_row_auto_detects_when_unset() {
-        let settings = Settings::for_test(None, Some("acme"), None, None, None);
+        let settings = Settings::for_test(None, Some("acme"), None, None, None, None);
         let rows = resolve_settings(&settings);
         assert_eq!(row(&rows, "container engine").value, "auto-detect");
     }
 
     #[test]
     fn profile_row_reflects_no_active_profile() {
-        let rows = resolve_settings(&Settings::for_test(None, None, None, None, None));
+        let rows = resolve_settings(&Settings::for_test(None, None, None, None, None, None));
         assert_eq!(row(&rows, "profile").value, "(none)");
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,7 @@ pub const SNOUTY_SETTINGS_PATH_VAR_NAME: &str = "SNOUTY_SETTINGS_PATH";
 pub const ANTITHESIS_TENANT_VAR_NAME: &str = "ANTITHESIS_TENANT";
 pub const ANTITHESIS_REPOSITORY_VAR_NAME: &str = "ANTITHESIS_REPOSITORY";
 pub const ANTITHESIS_BASE_URL_VAR_NAME: &str = "ANTITHESIS_BASE_URL";
+pub const ANTITHESIS_HTTPS_PROXY_VAR_NAME: &str = "ANTITHESIS_HTTPS_PROXY";
 pub const CONTAINER_ENGINE_VAR_NAME: &str = "SNOUTY_CONTAINER_ENGINE";
 const PROJECT_SETTINGS_FILENAME: &str = ".snouty.toml";
 const GLOBAL_SETTINGS_FILENAME: &str = "settings.toml";
@@ -77,6 +78,7 @@ pub struct Settings {
     tenant: Option<String>,
     repository: Option<String>,
     base_url: Option<String>,
+    https_proxy: Option<String>,
     container_engine: Option<String>,
 }
 
@@ -138,6 +140,7 @@ impl Settings {
         let tenant = resolve("tenant", ANTITHESIS_TENANT_VAR_NAME)?;
         let repository = resolve("repository", ANTITHESIS_REPOSITORY_VAR_NAME)?;
         let base_url = resolve("base_url", ANTITHESIS_BASE_URL_VAR_NAME)?;
+        let https_proxy = resolve("https_proxy", ANTITHESIS_HTTPS_PROXY_VAR_NAME)?;
         let container_engine = resolve("container_engine", CONTAINER_ENGINE_VAR_NAME)?;
 
         // A derived base URL interpolates the tenant into the request host
@@ -156,6 +159,7 @@ impl Settings {
             tenant,
             repository,
             base_url,
+            https_proxy,
             container_engine,
         ))
     }
@@ -169,6 +173,7 @@ impl Settings {
         tenant: Option<String>,
         repository: Option<String>,
         base_url: Option<String>,
+        https_proxy: Option<String>,
         container_engine: Option<String>,
     ) -> Self {
         let base_url = base_url.or_else(|| {
@@ -182,6 +187,7 @@ impl Settings {
             tenant,
             repository,
             base_url,
+            https_proxy,
             container_engine,
         }
     }
@@ -204,6 +210,10 @@ impl Settings {
         self.base_url.as_deref()
     }
 
+    pub fn https_proxy(&self) -> Option<&str> {
+        self.https_proxy.as_deref()
+    }
+
     pub fn container_engine(&self) -> Option<&str> {
         self.container_engine.as_deref()
     }
@@ -220,6 +230,7 @@ impl Settings {
         tenant: Option<&str>,
         repository: Option<&str>,
         base_url: Option<&str>,
+        https_proxy: Option<&str>,
         container_engine: Option<&str>,
     ) -> Self {
         Self::assemble(
@@ -227,6 +238,7 @@ impl Settings {
             tenant.map(str::to_string),
             repository.map(str::to_string),
             base_url.map(str::to_string),
+            https_proxy.map(str::to_string),
             container_engine.map(str::to_string),
         )
     }
@@ -236,7 +248,7 @@ impl Settings {
     /// without touching the environment.
     #[cfg(test)]
     pub(crate) fn for_test_base_url(base_url: String) -> Self {
-        Self::for_test(None, None, None, Some(&base_url), None)
+        Self::for_test(None, None, None, Some(&base_url), None, None)
     }
 }
 
@@ -606,33 +618,61 @@ mod tests {
 
     #[test]
     fn base_url_falls_back_to_tenant_host() {
-        let settings = Settings::for_test(None, Some("acme"), None, None, None);
+        let settings = Settings::for_test(None, Some("acme"), None, None, None, None);
         assert_eq!(settings.base_url(), Some("https://acme.antithesis.com"));
     }
 
     #[test]
     fn explicit_base_url_overrides_tenant_host() {
-        let settings =
-            Settings::for_test(None, Some("acme"), None, Some("https://example.test"), None);
+        let settings = Settings::for_test(
+            None,
+            Some("acme"),
+            None,
+            Some("https://example.test"),
+            None,
+            None,
+        );
         assert_eq!(settings.base_url(), Some("https://example.test"));
     }
 
     #[test]
     fn base_url_without_tenant_is_none() {
-        let settings = Settings::for_test(None, None, None, None, None);
+        let settings = Settings::for_test(None, None, None, None, None, None);
         assert_eq!(settings.base_url(), None);
     }
 
     #[test]
     fn container_engine_absent_resolves_to_none() {
-        let settings = Settings::for_test(None, None, None, None, None);
+        let settings = Settings::for_test(None, None, None, None, None, None);
         assert_eq!(settings.container_engine(), None);
     }
 
     #[test]
     fn container_engine_resolves_when_set() {
-        let settings = Settings::for_test(None, None, None, None, Some("podman"));
+        let settings = Settings::for_test(None, None, None, None, None, Some("podman"));
         assert_eq!(settings.container_engine(), Some("podman"));
+    }
+
+    #[test]
+    fn https_proxy_absent_resolves_to_none() {
+        let settings = Settings::for_test(None, None, None, None, None, None);
+        assert_eq!(settings.https_proxy(), None);
+    }
+
+    #[test]
+    fn https_proxy_resolves_when_set() {
+        let settings =
+            Settings::for_test(None, None, None, None, Some("http://proxy.corp:8080"), None);
+        assert_eq!(settings.https_proxy(), Some("http://proxy.corp:8080"));
+    }
+
+    #[test]
+    fn https_proxy_resolves_from_a_settings_file() {
+        let project = settings_file("https_proxy = \"http://proxy.corp:8080\"\n");
+        assert_eq!(
+            resolve_value("https_proxy", UNSET_ENV, None, Some(&project), None).unwrap(),
+            Some("http://proxy.corp:8080".to_string())
+        );
     }
 
     // ---- validate_tenant_host -----------------------------------------
@@ -682,6 +722,7 @@ mod tests {
             Some("evil.com#"),
             None,
             Some("https://ok.example"),
+            None,
             None,
         );
         assert_eq!(s.base_url(), Some("https://ok.example"));

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -3,7 +3,7 @@ use snouty::testutils::{
 };
 use std::cell::RefCell;
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::process::Stdio;
 use std::thread;
 use testscript_rs::testscript;
@@ -269,6 +269,136 @@ fn cmd_mock_runs_server(
     Ok(())
 }
 
+fn cmd_mock_proxy(
+    env: &mut testscript_rs::TestEnvironment,
+    _args: &[String],
+) -> testscript_rs::Result<()> {
+    // Usage: mock-proxy
+    //
+    // Starts the mock Antithesis API behind an in-process HTTP forward proxy and
+    // points snouty's proxy env var (ANTITHESIS_HTTPS_PROXY) at it. It sets the
+    // API key and tenant but deliberately does NOT set ANTITHESIS_BASE_URL: the
+    // spec sets that to an unresolvable host, so a request can only reach the
+    // mock by traversing the proxy. That makes a successful `snouty runs` proof
+    // that the proxy setting is honored end to end.
+    if is_staging() {
+        return Err(err(
+            "mock-proxy is not supported against staging; guard the block with [!staging]"
+                .to_string(),
+        ));
+    }
+
+    let server = MockApiServer::start();
+    let mock_addr = server
+        .url()
+        .strip_prefix("http://")
+        .ok_or_else(|| err("mock server url missing http scheme".to_string()))?
+        .to_string();
+    let token = server.token().to_string();
+    // Keep the mock server (and its listener thread) alive for the process.
+    std::mem::forget(server);
+
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| err(format!("bind proxy: {e}")))?;
+    let proxy_addr = listener
+        .local_addr()
+        .map_err(|e| err(format!("proxy addr: {e}")))?;
+
+    thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            let mock_addr = mock_addr.clone();
+            thread::spawn(move || {
+                // A forwarding failure just drops the connection; snouty then
+                // reports a request error and the spec's assertion fails loudly.
+                let _ = proxy_forward(stream, &mock_addr);
+            });
+        }
+    });
+
+    env.set_env_var("ANTITHESIS_HTTPS_PROXY", &format!("http://{proxy_addr}"));
+    env.set_env_var("ANTITHESIS_API_KEY", &token);
+    env.set_env_var("ANTITHESIS_TENANT", "testtenant");
+    Ok(())
+}
+
+/// A minimal HTTP forward proxy for one request/response exchange.
+///
+/// reqwest, configured with an HTTP proxy for an `http://` target, sends the
+/// proxy a request line in absolute form (`GET http://host/path HTTP/1.1`). We
+/// rewrite it to origin form (`GET /path HTTP/1.1`), relay it to `mock_addr`
+/// (ignoring the — unresolvable — target host), and copy the response back
+/// verbatim. The mock closes the connection after responding (`Connection:
+/// close`), so `read_to_end` returns the full response and reqwest opens a
+/// fresh connection per request (one exchange per proxy connection).
+fn proxy_forward(mut client: TcpStream, mock_addr: &str) -> std::io::Result<()> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = client.read(&mut chunk)?;
+        if n == 0 {
+            return Ok(()); // client closed before sending a full request head
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") else {
+            continue;
+        };
+
+        let headers_end = pos + 4;
+        let head = String::from_utf8_lossy(&buf[..headers_end]).into_owned();
+        let content_length = proxy_content_length(&head);
+        let mut body = buf[headers_end..].to_vec();
+        while body.len() < content_length {
+            let n = client.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            body.extend_from_slice(&chunk[..n]);
+        }
+
+        let mut upstream = TcpStream::connect(mock_addr)?;
+        upstream.write_all(proxy_rewrite_request_line(&head).as_bytes())?;
+        upstream.write_all(&body)?;
+        let mut response = Vec::new();
+        upstream.read_to_end(&mut response)?;
+        client.write_all(&response)?;
+        return Ok(());
+    }
+}
+
+/// Parse `Content-Length` from an HTTP header block (0 if absent).
+fn proxy_content_length(head: &str) -> usize {
+    head.lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().ok())
+                .flatten()
+        })
+        .unwrap_or(0)
+}
+
+/// Rewrite the request line of `head` from absolute form to origin form,
+/// leaving every subsequent header (and the terminating blank line) untouched.
+fn proxy_rewrite_request_line(head: &str) -> String {
+    let request_line = head.split("\r\n").next().unwrap_or("");
+    let mut parts = request_line.splitn(3, ' ');
+    let method = parts.next().unwrap_or("GET");
+    let uri = parts.next().unwrap_or("/");
+    let version = parts.next().unwrap_or("HTTP/1.1");
+
+    // `http://host[:port]/path?query` -> `/path?query`.
+    let origin = match uri.split_once("://") {
+        Some((_, authority_and_path)) => match authority_and_path.find('/') {
+            Some(idx) => &authority_and_path[idx..],
+            None => "/",
+        },
+        None => uri,
+    };
+
+    // `head[request_line.len()..]` keeps the leading "\r\n", the remaining
+    // headers, and the trailing "\r\n\r\n" exactly as received.
+    format!("{method} {origin} {version}{}", &head[request_line.len()..])
+}
+
 fn is_staging() -> bool {
     std::env::var("SNOUTY_STAGING")
         .ok()
@@ -495,6 +625,7 @@ fn spec_tests() {
             .command("snouty", cmd_snouty)
             .command("mock-server", cmd_mock_server)
             .command("mock-runs-server", cmd_mock_runs_server)
+            .command("mock-proxy", cmd_mock_proxy)
             .command("env_from_json", cmd_env_from_json)
             .command("set-env", |env, args| {
                 // Usage: set-env KEY value...


### PR DESCRIPTION
Add a configuration setting (`https_proxy` in a settings file or the `ANTITHESIS_HTTPS_PROXY` environment variable) that directs Snouty to forward its requests to Antithesis through a proxy.

This was previously supported by some commands via the `HTTP(S)_PROXY`, as reqwest will use proxy addresses specified there unless an explicit proxy is supplied in code. Those environment variables are  also honored by podman/docker, which some commands invoke on the user's behalf. So if a user wants *everything* to go through a proxy, they can continue to use `HTTP(S)_PROXY` to configure reqwest, podman, and docker; if they want to just proxy Antithesis traffic, `ANTITHESIS_HTTPS_PROXY` will be honored by Snouty but not by any other tools. If the user has set both, `ANTITHESIS_HTTPS_PROXY` takes precedence.