### PR TITLE
docs search: literal by default, add --match for FTS5 syntax

### DIFF
--- a/specs/docs_search.txt
+++ b/specs/docs_search.txt
@@ -22,6 +22,50 @@ snouty docs --offline search docker
 stdout '/docs/guides/docker_basics/.*'
 stdout 'Docker basics.*'
 
+# By default the query is searched as literal text, so punctuation such as
+#    `.` or `=` is matched verbatim instead of being parsed as FTS5 syntax
+#    (which would otherwise raise an error).
+snouty docs --offline search fault.injection
+stdout '/docs/environment/fault_injection/.*'
+stdout 'Fault injection.*'
+
+# 2c. `=` in a literal query likewise matches verbatim rather than erroring.
+snouty docs --offline search --list python=sdk
+stdout '/docs/sdk/python_sdk/.*'
+! stderr .+
+
+# 2d. A literal query with no matches still exits successfully.
+snouty docs --offline search zzz.qqq
+stderr 'No results found.*'
+
+# 2e. --match treats the query as a raw FTS5 expression, enabling operators
+#    such as AND.
+snouty docs --offline search --match --list 'fault AND injection'
+stdout '/docs/environment/fault_injection/.*'
+! stderr .+
+
+# 2f. -m is the short form of --match.
+snouty docs --offline search -m --list 'fault OR injection'
+stdout '/docs/environment/fault_injection/.*'
+
+# 2g. In --match mode, invalid FTS5 syntax is the caller's error, reported
+#    with a pointer at the double-quote escape hatch and the default search.
+! snouty docs --offline search --match 'moment.branch'
+stderr 'invalid --match query.*'
+stderr 'double quotes.*'
+stderr 'drop --match.*'
+
+# 2h. Within --match mode, wrapping a punctuation term in FTS5 double quotes
+#    searches for it literally.
+snouty docs --offline search --match --list '"fault.injection"'
+stdout '/docs/environment/fault_injection/.*'
+
+# 2i. An unknown column filter in --match mode (reported by FTS5 without the
+#    `fts5:` prefix) still gets the friendly invalid-query guidance.
+! snouty docs --offline search --match 'bogus:fault'
+stderr 'invalid --match query.*'
+stderr 'drop --match.*'
+
 # When search runs with --json, stdout is always JSON. If --json is
 #    present, any non-JSON stdout is a bug.
 snouty --json docs --offline search sdk

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,10 +252,16 @@ The database is automatically updated before each search unless --offline is pas
 Prints ranked matches (title and page path); pass a path to `snouty docs show`.
 Use --list to print only the paths.
 
+By default the query is searched as literal text. Pass --match to treat the
+query as a raw SQLite FTS5 expression instead, enabling operators like
+AND/OR/NOT/NEAR, "quoted phrases", `title:` column filters, and `prefix*`.
+
 Examples:
   snouty docs search fault injection
   snouty docs search "config image"
-  snouty docs --offline search sdk setup"#)]
+  snouty docs search moment.branch
+  snouty docs search sdk setup
+  snouty docs search --match 'sdk NOT java'"#)]
     Search {
         /// Print only matching page paths, one per line
         #[arg(short = 'l', long)]
@@ -264,6 +270,11 @@ Examples:
         /// Maximum number of results to return
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
+
+        /// Treat the query as a raw FTS5 expression (AND/OR/NOT/NEAR, "phrases",
+        /// title: filters, prefix*) instead of literal text
+        #[arg(short = 'm', long = "match")]
+        match_mode: bool,
 
         /// Search query
         query: Vec<String>,

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -55,11 +55,16 @@ pub async fn cmd_docs(command: DocsCommands, offline: bool, json: bool) -> Resul
     ensure_docs_db_available(offline)?;
 
     match command {
-        DocsCommands::Search { query, list, limit } => {
+        DocsCommands::Search {
+            query,
+            list,
+            limit,
+            match_mode,
+        } => {
             if query.is_empty() {
                 return Err(user_error("search query required"));
             }
-            search(&query.join(" "), json, list, limit)
+            search(&query.join(" "), json, list, limit, match_mode)
         }
         DocsCommands::Sqlite => sqlite_path(),
         DocsCommands::Tree { depth, filter } => tree(depth.map(|d| d.get()), filter.as_deref()),
@@ -160,60 +165,63 @@ fn atomic_write_db(bytes: &[u8]) -> Result<()> {
 
 use snippet::{MATCH_END, MATCH_START};
 
-/// Split a query into simple terms if it uses plain alphanumeric tokens only.
-/// Returns None for anything containing FTS5 operators or special syntax.
-fn simple_query_terms(query: &str) -> Option<Vec<&str>> {
+/// Tokenize a literal (default, non-`--match`) query into search terms,
+/// dropping filler words so ranking focuses on content-bearing tokens. Falls
+/// back to the unfiltered tokens when every token is a stopword.
+fn literal_query_terms(query: &str) -> Vec<&str> {
     let terms: Vec<&str> = query.split_whitespace().collect();
-    let is_simple = terms.iter().all(|t| {
-        t.chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-            && !matches!(*t, "AND" | "OR" | "NOT" | "NEAR")
-    });
-    if !is_simple {
-        return None;
-    }
-
-    Some(terms)
-}
-
-/// Normalize simple natural-language queries by dropping filler words so
-/// ranking and title boosts focus on the content-bearing terms.
-fn normalized_query(query: &str) -> String {
-    let Some(terms) = simple_query_terms(query) else {
-        return query.to_string();
-    };
-
     let filtered: Vec<&str> = terms
         .iter()
         .copied()
         .filter(|term| !SEARCH_STOPWORDS.contains(&term.to_ascii_lowercase().as_str()))
         .collect();
-    let selected = if filtered.is_empty() { terms } else { filtered };
-
-    selected.join(" ")
+    if filtered.is_empty() { terms } else { filtered }
 }
 
-/// Build an FTS5 query that matches all terms against the title column.
-/// Only operates on simple queries (alphanumeric terms and spaces).
-/// Returns None for anything containing FTS5 operators or special syntax.
-fn title_match_query(query: &str) -> Option<String> {
-    let terms = simple_query_terms(query)?;
+/// Escape a term as an FTS5 string literal (embedded quotes doubled) so any
+/// punctuation it contains is searched as plain text rather than being parsed
+/// as an FTS5 operator.
+fn fts5_literal(term: &str) -> String {
+    format!("\"{}\"", term.replace('"', "\"\""))
+}
 
+/// Build a literal-text FTS5 `MATCH` query from search terms: each term becomes
+/// a quoted string literal (implicitly AND-ed together). The `unicode61`
+/// tokenizer splits each literal on punctuation, so `moment.branch` matches the
+/// terms `moment` and `branch`.
+fn literal_match_query(terms: &[&str]) -> String {
+    terms
+        .iter()
+        .map(|term| fts5_literal(term))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Build the title-boost query for literal search, matching each term against
+/// the title column. Returns None when there are no terms to boost.
+fn literal_title_query(terms: &[&str]) -> Option<String> {
+    if terms.is_empty() {
+        return None;
+    }
     Some(
         terms
             .iter()
-            .map(|t| format!("title:{t}"))
+            .map(|term| format!("title:{}", fts5_literal(term)))
             .collect::<Vec<_>>()
             .join(" "),
     )
 }
 
-fn search(query: &str, json: bool, list: bool, limit: usize) -> Result<()> {
-    let conn = open_db()?;
-    let normalized_query = normalized_query(query);
-
-    let title_query = title_match_query(&normalized_query);
-
+/// Run the full-text search query, returning `(path, title, content,
+/// title_boosted)` rows. `match_query` is bound to the FTS5 `MATCH` and must be
+/// valid FTS5 query syntax; `title_query`, when present, enables title-match
+/// ranking boosts.
+fn run_search(
+    conn: &Connection,
+    match_query: &str,
+    title_query: Option<&str>,
+    fetch_limit: usize,
+) -> rusqlite::Result<Vec<(String, String, String, bool)>> {
     let order_by = if title_query.is_some() {
         "rank * CASE WHEN pages_fts.rowid IN (
              SELECT rowid FROM pages_fts WHERE pages_fts MATCH ?2
@@ -232,43 +240,108 @@ fn search(query: &str, json: bool, list: bool, limit: usize) -> Result<()> {
          FROM pages_fts
          JOIN pages p ON p.rowid = pages_fts.rowid
          WHERE pages_fts MATCH ?1 AND rank MATCH 'bm25(5.0, 1.0)'
-         ORDER BY {}
-         LIMIT ?3",
-        order_by,
+         ORDER BY {order_by}
+         LIMIT ?3"
     );
 
     let mut stmt = conn.prepare(&sql)?;
 
     // When there's no title query, ?2 is unused but still must be bound
-    let title_param = title_query.as_deref().unwrap_or("");
+    let title_param = title_query.unwrap_or("");
+
+    stmt.query_map(
+        rusqlite::params![match_query, title_param, fetch_limit],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?, // path
+                row.get::<_, String>(1)?, // title
+                row.get::<_, String>(2)?, // content
+                row.get::<_, bool>(3)?,   // title_boosted
+            ))
+        },
+    )?
+    .collect()
+}
+
+/// Whether a rusqlite error comes from a malformed FTS5 `MATCH` query (as
+/// opposed to a genuine failure like a missing table or I/O error). SQLite
+/// reports these two ways, neither with a distinct error code: a parse error is
+/// prefixed `fts5:` (e.g. `fts5: syntax error near "."`), while an unknown
+/// column filter surfaces as `no such column: <name>`. Both can only originate
+/// from the caller-supplied query, since the rest of the SQL is fixed and
+/// references only valid columns.
+fn is_fts5_query_error(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(_, Some(msg))
+            if msg.starts_with("fts5:") || msg.starts_with("no such column:")
+    )
+}
+
+fn search(query: &str, json: bool, list: bool, limit: usize, match_mode: bool) -> Result<()> {
+    let conn = open_db()?;
+
+    // Two distinct modes:
+    //   * default        — the argv is a literal string; every term is quoted so
+    //                       punctuation is searched as text and can never be
+    //                       parsed as an FTS5 operator. Stopwords are dropped and
+    //                       title matches are boosted.
+    //   * --match mode   — the argv is passed straight to FTS5, giving callers
+    //                       its full query syntax (AND/OR/NOT/NEAR, "phrases",
+    //                       `title:`, `prefix*`). No normalization is applied.
+    // `highlight_terms` are the plain words to highlight in each snippet; they
+    // must reflect what actually matched, so they're derived the same way the
+    // MATCH query is (literal tokens vs. an FTS5 expression with its operators
+    // stripped).
+    let (match_query, title_query, highlight_terms) = if match_mode {
+        (query.to_string(), None, snippet::fts5_query_terms(query))
+    } else {
+        let terms = literal_query_terms(query);
+        let highlight_terms = terms
+            .iter()
+            .copied()
+            .flat_map(snippet::word_tokens)
+            .collect();
+        (
+            literal_match_query(&terms),
+            literal_title_query(&terms),
+            highlight_terms,
+        )
+    };
 
     let fetch_limit = limit.saturating_mul(5).max(limit);
 
-    let results: Vec<(String, String, String, bool)> = stmt
-        .query_map(
-            rusqlite::params![normalized_query, title_param, fetch_limit],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?, // path
-                    row.get::<_, String>(1)?, // title
-                    row.get::<_, String>(2)?, // content
-                    row.get::<_, bool>(3)?,   // title_boosted
-                ))
-            },
-        )?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+    // An empty MATCH argument is itself an FTS5 syntax error, so a blank query
+    // (nothing but whitespace) is treated as simply having no results.
+    let results: Vec<(String, String, String)> = if match_query.trim().is_empty() {
+        Vec::new()
+    } else {
+        let rows = match run_search(&conn, &match_query, title_query.as_deref(), fetch_limit) {
+            Ok(rows) => rows,
+            Err(e) if match_mode && is_fts5_query_error(&e) => {
+                // In --match mode the caller controls the query syntax, so a
+                // parse failure is theirs to fix; point them back to the default.
+                return Err(user_error(format!("invalid --match query: {e}")).note(
+                    "--match passes the query straight to the full-text search engine; \
+                     wrap a term in double quotes to match punctuation literally \
+                     (e.g. '\"moment.branch\"'), or drop --match to search the whole \
+                     query as text",
+                ));
+            }
+            Err(e) => return Err(e.into()),
+        };
 
-    let results: Vec<_> = results
-        .into_iter()
-        .take(limit)
-        .map(|(path, title, content, title_boosted)| {
-            (
-                path,
-                title,
-                snippet::extract_snippet(&content, &normalized_query, 300, title_boosted),
-            )
-        })
-        .collect();
+        rows.into_iter()
+            .take(limit)
+            .map(|(path, title, content, title_boosted)| {
+                (
+                    path,
+                    title,
+                    snippet::extract_snippet(&content, &highlight_terms, 300, title_boosted),
+                )
+            })
+            .collect()
+    };
 
     if json {
         if results.is_empty() {
@@ -683,7 +756,76 @@ fn normalized_path(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{generated_sdk_index, normalized_path};
+    use super::{
+        fts5_literal, generated_sdk_index, is_fts5_query_error, literal_match_query,
+        literal_query_terms, literal_title_query, normalized_path,
+    };
+
+    #[test]
+    fn literal_query_terms_drops_stopwords() {
+        assert_eq!(
+            literal_query_terms("how does fault injection work"),
+            vec!["fault", "injection", "work"]
+        );
+    }
+
+    #[test]
+    fn literal_query_terms_keeps_all_when_only_stopwords() {
+        // Don't strip everything away for an all-stopword query.
+        assert_eq!(literal_query_terms("how to"), vec!["how", "to"]);
+    }
+
+    #[test]
+    fn fts5_literal_quotes_and_escapes() {
+        assert_eq!(fts5_literal("moment.branch"), "\"moment.branch\"");
+        assert_eq!(fts5_literal("moment=branch"), "\"moment=branch\"");
+        // Embedded quotes are doubled so the result stays a valid FTS5 literal.
+        assert_eq!(fts5_literal("a\"b"), "\"a\"\"b\"");
+    }
+
+    #[test]
+    fn literal_match_query_quotes_each_term() {
+        // Each whitespace token becomes a quoted literal (implicit AND); the
+        // FTS5 tokenizer later splits punctuation inside each literal.
+        assert_eq!(literal_match_query(&["moment.branch"]), "\"moment.branch\"");
+        assert_eq!(literal_match_query(&["foo", "bar"]), "\"foo\" \"bar\"");
+    }
+
+    #[test]
+    fn literal_title_query_filters_on_title_column() {
+        assert_eq!(
+            literal_title_query(&["foo", "bar"]).as_deref(),
+            Some("title:\"foo\" title:\"bar\"")
+        );
+        assert_eq!(literal_title_query(&[]), None);
+    }
+
+    #[test]
+    fn is_fts5_query_error_detects_fts5_syntax_errors() {
+        let syntax = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(1),
+            Some("fts5: syntax error near \".\"".to_string()),
+        );
+        assert!(is_fts5_query_error(&syntax));
+
+        // An unknown column filter (e.g. `--match foo:bar`) reports without the
+        // `fts5:` prefix but is still a malformed-query error.
+        let bad_column = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(1),
+            Some("no such column: foo".to_string()),
+        );
+        assert!(is_fts5_query_error(&bad_column));
+    }
+
+    #[test]
+    fn is_fts5_query_error_ignores_unrelated_errors() {
+        let other = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(1),
+            Some("no such table: pages".to_string()),
+        );
+        assert!(!is_fts5_query_error(&other));
+        assert!(!is_fts5_query_error(&rusqlite::Error::QueryReturnedNoRows));
+    }
 
     #[test]
     fn generated_sdk_index_resolves_go_alias() {

--- a/src/docs/snippet.rs
+++ b/src/docs/snippet.rs
@@ -38,14 +38,34 @@ fn is_inline_end(tag: &TagEnd) -> bool {
     )
 }
 
-// --- Step 1: Parse query ---
+// --- Step 1: Derive highlight terms ---
+//
+// `extract_snippet` takes the terms to highlight directly; the caller derives
+// them from the query in a mode-appropriate way. These two helpers cover both
+// search modes: `word_tokens` for the default literal search (the query is
+// plain text) and `fts5_query_terms` for `--match` (the query is an FTS5
+// expression whose operators must be stripped first).
 
-fn parse_query_terms(query: &str) -> Vec<String> {
+/// Split a chunk of text into lowercased word tokens — maximal runs of
+/// alphanumerics, `_`, and `-`. Punctuation such as `.` or `=` separates
+/// tokens, so `moment.branch` yields the highlightable words `moment` and
+/// `branch`.
+pub fn word_tokens(text: &str) -> Vec<String> {
+    text.split(|c: char| !is_word_char(c))
+        .filter(|word| !word.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+/// Extract highlightable terms from a raw FTS5 query (`--match` mode) by
+/// dropping the query syntax that can appear in it — `NEAR`, boolean operators,
+/// `-`/`NOT` exclusions, `column:` filters, `prefix*`, and `"phrase"` quotes —
+/// then tokenizing what remains. Excluded terms aren't highlighted because they
+/// don't describe what matched.
+pub fn fts5_query_terms(query: &str) -> Vec<String> {
     let mut terms = Vec::new();
     let mut skip_next = false;
 
-    // Snippets only need highlightable terms, not full FTS semantics, so this
-    // strips the small amount of query syntax that can appear in user input.
     let normalized = query.replace("NEAR(", " ").replace([')', '"'], " ");
 
     for token in normalized.split_whitespace() {
@@ -69,26 +89,12 @@ fn parse_query_terms(query: &str) -> Vec<String> {
         }
 
         // Strip column prefixes like "title:"
-        let token = if let Some((_prefix, rest)) = token.split_once(':') {
-            rest
-        } else {
-            token
-        };
+        let token = token.split_once(':').map_or(token, |(_prefix, rest)| rest);
 
         // Strip trailing * (prefix operator)
         let token = token.trim_end_matches('*');
 
-        if token.is_empty() {
-            continue;
-        }
-
-        // Keep only tokens that are alphanumeric/_/-
-        if token
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-        {
-            terms.push(token.to_lowercase());
-        }
+        terms.extend(word_tokens(token));
     }
 
     terms
@@ -329,16 +335,15 @@ fn highlight_hits(text: &str, hits: &[Hit], multi_term: bool) -> String {
 
 pub fn extract_snippet(
     content: &str,
-    query: &str,
+    terms: &[String],
     max_visible: usize,
     title_boosted: bool,
 ) -> String {
-    // The snippet pipeline is:
+    // Given the highlight terms, the snippet pipeline is:
     // 1. flatten markdown to readable plain text
     // 2. find term hits
     // 3. choose the best excerpt window
     // 4. mark highlighted ranges for later styling/output
-    let terms = parse_query_terms(query);
     if terms.is_empty() {
         return String::new();
     }
@@ -348,7 +353,7 @@ pub fn extract_snippet(
         return String::new();
     }
 
-    let hits = find_hits(&plain, &terms);
+    let hits = find_hits(&plain, terms);
     let multi_term = terms.len() > 1;
 
     let best = pick_best_hit(&hits, multi_term);
@@ -383,7 +388,7 @@ pub fn extract_snippet(
 
     // Recompute hits inside the final window so highlight offsets line up with
     // the text we actually emit.
-    let window_hits = find_hits(window_text, &terms);
+    let window_hits = find_hits(window_text, terms);
 
     let highlighted = highlight_hits(window_text, &window_hits, multi_term);
 
@@ -404,62 +409,92 @@ pub fn extract_snippet(
 mod tests {
     use super::*;
 
+    /// Build an owned term slice, the way `extract_snippet` expects it.
+    fn terms(words: &[&str]) -> Vec<String> {
+        words.iter().map(|w| w.to_string()).collect()
+    }
+
     #[test]
-    fn test_parse_query_simple() {
+    fn test_word_tokens_splits_on_punctuation() {
+        // Punctuation-joined text is split into separate tokens, mirroring the
+        // FTS5 tokenizer (a `-` stays part of the word); tokens are lowercased.
+        assert_eq!(word_tokens("Fault Injection"), vec!["fault", "injection"]);
+        assert_eq!(word_tokens("moment.branch"), vec!["moment", "branch"]);
+        assert_eq!(word_tokens("moment=branch"), vec!["moment", "branch"]);
+        assert_eq!(word_tokens("v1.2.3"), vec!["v1", "2", "3"]);
+        assert_eq!(word_tokens("foo-bar"), vec!["foo-bar"]);
+        assert!(word_tokens("...").is_empty());
+    }
+
+    #[test]
+    fn test_fts5_query_terms_simple() {
         assert_eq!(
-            parse_query_terms("rust instrumentation"),
+            fts5_query_terms("rust instrumentation"),
             vec!["rust", "instrumentation"]
         );
     }
 
     #[test]
-    fn test_parse_query_not() {
+    fn test_fts5_query_terms_not() {
         assert_eq!(
-            parse_query_terms("NOT java instrumentation"),
+            fts5_query_terms("NOT java instrumentation"),
             vec!["instrumentation"]
         );
     }
 
     #[test]
-    fn test_parse_query_dash_prefix() {
+    fn test_fts5_query_terms_dash_prefix() {
         assert_eq!(
-            parse_query_terms("-java instrumentation"),
+            fts5_query_terms("-java instrumentation"),
             vec!["instrumentation"]
         );
     }
 
     #[test]
-    fn test_parse_query_operators() {
+    fn test_fts5_query_terms_operators() {
         assert_eq!(
-            parse_query_terms("rust AND instrumentation"),
+            fts5_query_terms("rust AND instrumentation"),
             vec!["rust", "instrumentation"]
         );
-        assert_eq!(parse_query_terms("rust OR go"), vec!["rust", "go"]);
+        assert_eq!(fts5_query_terms("rust OR go"), vec!["rust", "go"]);
     }
 
     #[test]
-    fn test_parse_query_prefix_star() {
-        assert_eq!(parse_query_terms("setup*"), vec!["setup"]);
+    fn test_fts5_query_terms_prefix_star() {
+        assert_eq!(fts5_query_terms("setup*"), vec!["setup"]);
     }
 
     #[test]
-    fn test_parse_query_column_prefix() {
+    fn test_fts5_query_terms_column_prefix() {
         assert_eq!(
-            parse_query_terms("title:rust content:test"),
+            fts5_query_terms("title:rust content:test"),
             vec!["rust", "test"]
         );
     }
 
     #[test]
-    fn test_parse_query_near() {
-        let terms = parse_query_terms("NEAR(docker compose)");
-        assert_eq!(terms, vec!["docker", "compose"]);
+    fn test_fts5_query_terms_near() {
+        assert_eq!(
+            fts5_query_terms("NEAR(docker compose)"),
+            vec!["docker", "compose"]
+        );
     }
 
     #[test]
-    fn test_parse_query_quoted() {
-        let terms = parse_query_terms("\"docker compose\"");
-        assert_eq!(terms, vec!["docker", "compose"]);
+    fn test_fts5_query_terms_quoted() {
+        assert_eq!(
+            fts5_query_terms("\"docker compose\""),
+            vec!["docker", "compose"]
+        );
+    }
+
+    #[test]
+    fn test_fts5_query_terms_splits_punctuation_bareword() {
+        // A quoted punctuation phrase in --match mode still highlights each word.
+        assert_eq!(
+            fts5_query_terms("\"moment.branch\""),
+            vec!["moment", "branch"]
+        );
     }
 
     #[test]
@@ -494,7 +529,7 @@ mod tests {
     #[test]
     fn test_single_term_highlights_all() {
         let content = "# Setup\n\nFirst setup step. Then another setup.";
-        let result = extract_snippet(content, "setup", 300, false);
+        let result = extract_snippet(content, &terms(&["setup"]), 300, false);
         // Single term should highlight all occurrences
         assert!(result.contains(&format!("{MATCH_START}Setup{MATCH_END}")));
         assert!(result.contains(&format!("{MATCH_START}setup{MATCH_END}")));
@@ -504,15 +539,17 @@ mod tests {
     fn test_multi_term_proximity_filtering() {
         // "docker" and "compose" near each other should be highlighted
         let content = "# Docker\n\nUse docker compose to run services. Some other long text about unrelated things that goes on for a while to create distance. Docker is great.";
-        let result = extract_snippet(content, "docker compose", 300, false);
+        let result = extract_snippet(content, &terms(&["docker", "compose"]), 300, false);
         // Should highlight where they co-occur
         assert!(result.contains(MATCH_START));
     }
 
     #[test]
     fn test_not_term_excluded() {
+        // End-to-end: an FTS5 NOT-excluded term is dropped before highlighting.
         let content = "# Java\n\nJava instrumentation is different from Rust instrumentation.";
-        let result = extract_snippet(content, "NOT java instrumentation", 300, false);
+        let terms = fts5_query_terms("NOT java instrumentation");
+        let result = extract_snippet(content, &terms, 300, false);
         // "java" should NOT be highlighted
         assert!(!result.contains(&format!("{MATCH_START}Java{MATCH_END}")));
         assert!(!result.contains(&format!("{MATCH_START}java{MATCH_END}")));
@@ -524,7 +561,7 @@ mod tests {
     fn test_title_boosted_no_content_match_uses_opening() {
         let content = "# Getting Started\n\nThis is the introduction to the documentation. It covers many topics.";
         // query terms not in content, but title_boosted
-        let result = extract_snippet(content, "nonexistent", 300, true);
+        let result = extract_snippet(content, &terms(&["nonexistent"]), 300, true);
         // Should return opening text (no highlights but text present)
         assert!(result.contains("Getting Started"));
     }
@@ -532,7 +569,7 @@ mod tests {
     #[test]
     fn test_ellipsis_added() {
         let content = "# Start\n\nSome prefix text. The rust language is great. Some suffix text that goes on for a long time to exceed the window size and trigger ellipsis behavior at the end of the snippet.";
-        let result = extract_snippet(content, "rust", 50, false);
+        let result = extract_snippet(content, &terms(&["rust"]), 50, false);
         assert!(result.contains("..."));
     }
 
@@ -544,14 +581,14 @@ mod tests {
 
     #[test]
     fn test_empty_content() {
-        let result = extract_snippet("", "test", 300, false);
+        let result = extract_snippet("", &terms(&["test"]), 300, false);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_no_matches_no_title_boost() {
         let content = "# Hello\n\nSome text about nothing relevant.";
-        let result = extract_snippet(content, "nonexistent", 300, false);
+        let result = extract_snippet(content, &terms(&["nonexistent"]), 300, false);
         // No hits and no title boost → opening text, no highlights
         assert!(result.contains("Hello"));
         assert!(!result.contains(MATCH_START));


### PR DESCRIPTION
`snouty docs search` now treats the query as literal text by default. Each whitespace-separated term is quoted as an FTS5 string literal, so punctuation like `.` or `=` is matched verbatim instead of being parsed as FTS5 syntax. Queries like `fault.injection` or `moment.branch` previously raised a syntax error; now they just work.

For callers who want the raw query language, `--match`/`-m` passes the query straight to FTS5, enabling operators like AND/OR/NOT/NEAR, "quoted phrases", `title:` column filters, and `prefix*`. In `--match` mode a malformed query is the caller's error, reported with a note pointing at the double-quote escape hatch (e.g. `'"moment.branch"'`) or the option to drop `--match` and search the whole query as text.

Snippet highlighting is split along the two modes: `word_tokens` derives highlight terms for literal search and `fts5_query_terms` strips FTS5 operators for `--match`. `extract_snippet` now takes the highlight terms directly instead of re-parsing the query, so the terms it highlights always reflect what actually matched.

The `docs_search` spec covers both modes, including literal punctuation matching, no-result handling, `--match` operators, quoted-phrase escapes, and the invalid-query error path.