### PR TITLE
validate: fail when compose resolves differently in the Antithesis environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "json5"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1523,16 @@ checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
 dependencies = [
  "serde",
  "ucd-trie",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2658,6 +2680,7 @@ dependencies = [
  "http",
  "http-cache-reqwest",
  "indexmap",
+ "json-patch",
  "json5",
  "jsonschema",
  "libc",
@@ -2683,6 +2706,7 @@ dependencies = [
  "testscript-rs",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "which",
  "wiremock",
 ]
 
@@ -3413,6 +3437,15 @@ checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ form_urlencoded = "1"
 # pinned: alpha API churn between releases
 http-cache-reqwest = "=1.0.0-alpha.6"
 json5 = "1.3.0"
+json-patch = "4"
 jsonschema = { version = "0.37.4", default-features = false }
 log = "0.4"
 progenitor-client = "0.14.0"
@@ -40,6 +41,7 @@ ptree = { version = "0.5.2", default-features = false }
 serde_yaml = "0.9"
 toml = "1.1.2"
 http = "1.4.2"
+which = "8"
 
 [[example]]
 name = "mock_api"

--- a/specs/validate.txt
+++ b/specs/validate.txt
@@ -27,6 +27,10 @@ stderr '.*both docker-compose.yaml and a manifests/ subdirectory.*'
 snouty validate --help
 stdout '.*keep-running.*'
 
+# Help text mentions --allow-compose-divergence.
+snouty validate --help
+stdout '.*allow-compose-divergence.*'
+
 # Help text mentions the manifests/ subdirectory option.
 snouty validate --help
 stdout '.*manifests/.*'

--- a/specs_engine/validate_env.txt
+++ b/specs_engine/validate_env.txt
@@ -1,0 +1,82 @@
+# snouty validate — environment-variable resolution (compose)
+#
+# Antithesis runs docker-compose in a hermetic environment with none of the
+# user's shell variables, so a `${VAR}` that resolves locally only because the
+# shell supplied it would be empty (or a hard error) there. validate renders the
+# compose file twice — with the shell and under a scrubbed environment matching
+# Antithesis — and fails when the two differ, so a setup that would break in
+# Antithesis fails locally first.
+
+build-image env-emitter:latest setup_emitter
+
+# A variable that resolves only from the shell (no `.env` entry, no inline
+#    default) is empty in the Antithesis render, so validation fails up front —
+#    before any container starts — naming the field.
+env SNOUTY_TEST_SHELL_VAR=fromshell
+! snouty validate soft --timeout 15
+stderr '.*depends on your shell environment.*'
+stderr '.*SNOUTY_TEST_SHELL_VAR.*'
+
+# --allow-compose-divergence downgrades that to a warning; validation continues
+#    and still succeeds when the empty value is harmless.
+env SNOUTY_TEST_SOFTOK_VAR=fromshell
+snouty validate soft_ok --allow-compose-divergence --timeout 20
+stderr '.*Warning:.*'
+stderr '.*SNOUTY_TEST_SOFTOK_VAR.*'
+stderr '.*Setup validation successful.*'
+
+# A value from the config dir's `.env` resolves the same in both renders —
+#    exactly as it will from the config image — so it is not flagged. Neither is
+#    an empty inline default (`${VAR:-}`): it renders blank in both, so there is
+#    no divergence to report.
+snouty validate clean --timeout 20
+! stderr '.*depends on your shell environment.*'
+stderr '.*Setup validation successful.*'
+
+# A required (${VAR:?}) variable that resolves only from the shell aborts the
+#    Antithesis render; validate reports it, surfacing docker-compose's own
+#    message, rather than letting contents() hit the same abort with a rawer
+#    error later.
+env SNOUTY_TEST_REQ=fromshell
+! snouty validate required --timeout 15
+stderr '.*depends on your shell environment.*'
+stderr '.*SNOUTY_TEST_REQ.*'
+
+-- setup_emitter/Dockerfile --
+FROM busybox
+CMD sh -c 'echo "{\"antithesis_setup\":{\"status\":\"complete\"}}" >> "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl" && sleep 3600'
+
+-- soft/docker-compose.yaml --
+services:
+  app:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      SNOUTY_TEST_SHELL_VAR: ${SNOUTY_TEST_SHELL_VAR}
+
+-- soft_ok/docker-compose.yaml --
+services:
+  emitter:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      SNOUTY_TEST_SOFTOK_VAR: ${SNOUTY_TEST_SOFTOK_VAR}
+
+-- clean/docker-compose.yaml --
+services:
+  emitter:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      FROM_ENV: ${SNOUTY_TEST_ENV_VAR}
+      BLANK: ${SNOUTY_TEST_BLANK:-}
+-- clean/.env --
+SNOUTY_TEST_ENV_VAR=hello
+
+-- required/docker-compose.yaml --
+services:
+  app:
+    image: env-emitter:latest
+    pull_policy: never
+    environment:
+      NEED: ${SNOUTY_TEST_REQ:?must set SNOUTY_TEST_REQ}

--- a/specs_engine/validate_k8s.txt
+++ b/specs_engine/validate_k8s.txt
@@ -9,11 +9,19 @@ stderr 'k8s manifests valid.*'
 ! snouty validate config_invalid
 stderr 'k8s-validator failed.*'
 
+# --allow-compose-divergence is compose-only: it is accepted but inert for k8s
+#    configs, and a stray .env in the config dir is never read.
+snouty validate config_valid --allow-compose-divergence
+stderr 'k8s manifests valid.*'
+! stderr '.*depends on your shell environment.*'
+
 -- config_valid/manifests/ns.yaml --
 apiVersion: v1
 kind: Namespace
 metadata:
   name: snouty-demo
+-- config_valid/.env --
+SHOULD_BE_IGNORED=1
 -- config_invalid/manifests/pod.yaml --
 apiVersion: v1
 kind: Pod

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,6 +160,12 @@ Compose configs:
   discovers test commands from /opt/antithesis/test/v1 inside the
   running containers and validates their structure.
 
+  Before starting anything, validate resolves the compose file twice — with
+  your shell and under a scrubbed environment matching the hermetic Antithesis
+  environment — and fails if any ${VAR} resolves differently, catching setups
+  that only work locally because a value came from your shell. Use
+  --allow-compose-divergence to downgrade that to a warning.
+
   Test commands are discovered by scanning /opt/antithesis/test/v1 from each
   running container for {test_name}/{command} entries. Test commands are
   validated to have recognized prefixes and at least one driver or anytime
@@ -167,9 +173,10 @@ Compose configs:
 
 Kubernetes configs:
   Runs docker.io/antithesishq/k8s-validator against the manifests/
-  directory to perform static analysis of the manifests. --timeout has no
-  effect (the validator does not start any workloads), and --keep-running
-  has no effect (no containers are launched).
+  directory to perform static analysis of the manifests. --timeout,
+  --keep-running, and --allow-compose-divergence have no effect here (no
+  workloads or containers are started, and there is no docker-compose config
+  to render).
 
 Example:
   snouty validate ./config
@@ -338,6 +345,11 @@ pub struct ValidateArgs {
     /// Leave containers running after validation for manual inspection
     #[arg(long)]
     pub keep_running: bool,
+
+    /// Warn instead of failing when docker-compose.yaml renders differently in
+    /// the hermetic Antithesis environment than it does on this machine
+    #[arg(long)]
+    pub allow_compose_divergence: bool,
 }
 
 #[derive(Args)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -494,12 +494,23 @@ const DOCKER_COMPOSE: &str = "docker-compose";
 /// docker-compose is pointed at podman's API socket so podman backs Compose.
 pub fn docker_compose(rt: &dyn ContainerRuntime) -> Result<DockerCompose<'_>> {
     ensure_docker_compose()?;
+    let compose_binary = docker_compose_binary()?;
     let docker_host = if std::env::var_os("DOCKER_HOST").is_some() {
         None
     } else {
         rt.engine_docker_host()?
     };
-    Ok(DockerCompose { rt, docker_host })
+    Ok(DockerCompose {
+        rt,
+        docker_host,
+        compose_binary,
+    })
+}
+
+/// Resolve `docker-compose` before clearing the environment for a hermetic
+/// render. [`Command`] otherwise needs `PATH` to find it.
+fn docker_compose_binary() -> Result<PathBuf> {
+    which::which(DOCKER_COMPOSE).wrap_err("failed to resolve the `docker-compose` binary on PATH")
 }
 
 /// Verify the `docker-compose` binary is present and is Docker Compose v2.
@@ -555,6 +566,7 @@ fn is_compose_v2_version(output: &str) -> bool {
 pub struct DockerCompose<'a> {
     rt: &'a dyn ContainerRuntime,
     docker_host: Option<String>,
+    compose_binary: PathBuf,
 }
 
 impl DockerCompose<'_> {
@@ -572,7 +584,7 @@ impl DockerCompose<'_> {
 
     /// Base `docker-compose` command with engine wiring applied.
     fn command(&self, config: &ComposeConfig) -> Command {
-        let mut cmd = Command::new(DOCKER_COMPOSE);
+        let mut cmd = Command::new(&self.compose_binary);
         cmd.current_dir(config.dir());
         if let Some(host) = &self.docker_host {
             cmd.env("DOCKER_HOST", host);
@@ -623,6 +635,35 @@ impl DockerCompose<'_> {
     ) -> Result<ComposeContents> {
         let yaml = self.config_yaml(config, overlay, &[])?;
         parse_compose_config(&yaml)
+    }
+
+    /// Resolve the compose file to JSON using the normal (local) environment —
+    /// the same interpolation `snouty` sees when it runs compose on this machine.
+    pub fn config_json(&self, config: &ComposeConfig) -> Result<String> {
+        self.config_yaml(config, None, &["--format", "json"])
+    }
+
+    /// Resolve the compose file to JSON under a scrubbed process environment
+    /// that mimics the hermetic Antithesis environment: none of the user's shell
+    /// variables, so `${VAR}` interpolation resolves only from the config dir's
+    /// `.env` file, explicit env files, and inline defaults. The compose binary
+    /// was resolved before the environment is cleared, so no shell variables
+    /// need to be retained.
+    ///
+    /// Returns the raw output rather than a string: a required `${VAR:?}` with no
+    /// value makes compose abort (non-zero exit, empty stdout), which the caller
+    /// reads as a definite "won't resolve in Antithesis".
+    pub fn config_json_hermetic_env(&self, config: &ComposeConfig) -> Result<Output> {
+        // Preserve the command and working directory, but intentionally omit
+        // even compose's own process variables: they are valid interpolation
+        // inputs and Antithesis will not inherit their local values.
+        let mut cmd = Command::new(&self.compose_binary);
+        cmd.current_dir(config.dir());
+        cmd.env_clear();
+        cmd.args(compose_file_args(None));
+        cmd.args(["config", "--format", "json"]);
+        cmd.output()
+            .wrap_err("failed to run 'docker-compose config' for the environment check")
     }
 
     /// Canonicalized compose file for baking into the config image.
@@ -3014,6 +3055,47 @@ services:
     fn is_compose_v2_version_rejects_others() {
         assert!(!is_compose_v2_version("podman-compose version 1.0.6"));
         assert!(!is_compose_v2_version(""));
+    }
+
+    #[test]
+    fn config_json_hermetic_env_scrubs_process_variables() {
+        if !has_compose() {
+            skip_or_fail("docker-compose (Docker Compose v2) is not available");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("docker-compose.yaml"),
+            "\
+services:
+  app:
+    image: alpine
+    environment:
+      HOME_VALUE: \"${HOME}\"
+      PATH_VALUE: \"${PATH}\"
+      DOCKER_HOST_VALUE: \"${DOCKER_HOST}\"
+",
+        )
+        .unwrap();
+        let config = match crate::config::detect_config(dir.path()).unwrap() {
+            crate::config::Config::Compose(config) => config,
+            other => panic!("expected Compose config, got {other:?}"),
+        };
+        let runtime = FakeRuntime::default();
+        let compose = DockerCompose {
+            rt: &runtime,
+            docker_host: Some("unix:///tmp/snouty-hermetic-test.sock".to_string()),
+            compose_binary: docker_compose_binary().unwrap(),
+        };
+
+        let output = compose.config_json_hermetic_env(&config).unwrap();
+        assert!(output.status.success(), "compose config failed: {output:?}");
+        let resolved: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let environment = &resolved["services"]["app"]["environment"];
+        assert_eq!(environment["HOME_VALUE"], "");
+        assert_eq!(environment["PATH_VALUE"], "");
+        assert_eq!(environment["DOCKER_HOST_VALUE"], "");
     }
 
     #[test]

--- a/src/container.rs
+++ b/src/container.rs
@@ -654,11 +654,12 @@ impl DockerCompose<'_> {
     /// value makes compose abort (non-zero exit, empty stdout), which the caller
     /// reads as a definite "won't resolve in Antithesis".
     pub fn config_json_hermetic_env(&self, config: &ComposeConfig) -> Result<Output> {
-        // Preserve the command and working directory, but intentionally omit
-        // even compose's own process variables: they are valid interpolation
-        // inputs and Antithesis will not inherit their local values.
-        let mut cmd = Command::new(&self.compose_binary);
-        cmd.current_dir(config.dir());
+        // Reuse the normal command (binary + working directory), then clear the
+        // whole environment — including the DOCKER_HOST that command() sets.
+        // Those are all valid interpolation inputs Antithesis will not inherit,
+        // so scrubbing them is the point; only the binary and directory carry
+        // over. (env_clear() drops anything command() set via .env().)
+        let mut cmd = self.command(config);
         cmd.env_clear();
         cmd.args(compose_file_args(None));
         cmd.args(["config", "--format", "json"]);

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -5,8 +5,10 @@ use std::path::{Path, PathBuf};
 use color_eyre::Section;
 use color_eyre::SectionExt;
 use color_eyre::eyre::{Context, Result, bail, eyre};
+use json_patch::{PatchOperation, diff};
 use log::{debug, info, warn};
 use serde::Deserialize;
+use serde_json::Value;
 use tokio::time::{Duration, sleep};
 
 use crate::cli::ValidateArgs;
@@ -197,11 +199,20 @@ async fn validate_with_temp_dir(
         config: config_path,
         timeout,
         keep_running,
+        allow_compose_divergence,
     } = args;
     let rt = container::runtime(settings)?;
     match config::detect_config(&config_path)? {
         Config::Compose(cfg) => {
-            validate_compose(rt.as_ref(), cfg, timeout, keep_running, temp_dir).await
+            validate_compose(
+                rt.as_ref(),
+                cfg,
+                timeout,
+                keep_running,
+                allow_compose_divergence,
+                temp_dir,
+            )
+            .await
         }
         Config::Kubernetes(cfg) => validate_kubernetes(rt.as_ref(), &cfg, keep_running).await,
     }
@@ -212,9 +223,11 @@ async fn validate_compose(
     config: ComposeConfig,
     timeout: u64,
     keep_running: bool,
+    allow_compose_divergence: bool,
     temp_dir: &Path,
 ) -> Result<()> {
     let compose = container::docker_compose(rt)?;
+    check_compose_divergence(&compose, &config, allow_compose_divergence)?;
     let contents = compose.contents(&config, None)?;
     container::validate_images_are_available(rt, &contents)?;
     let override_path = generate_setup_override(&contents, temp_dir)?;
@@ -311,6 +324,112 @@ async fn validate_compose(
     }
 
     test_result
+}
+
+const DIVERGENCE_HEADLINE: &str = "docker-compose.yaml depends on your shell environment, which \
+the Antithesis environment does not have";
+
+const DIVERGENCE_FIX: &str = "Antithesis runs docker-compose hermetically, with none of your shell \
+variables. Provide each value in a `.env` file in the config directory (it is baked into the \
+config image) or give the reference an inline default (e.g. ${VAR:-default}).";
+
+/// Fail — or, with `--allow-compose-divergence`, warn — when the compose file
+/// resolves differently in the hermetic Antithesis environment than it does on
+/// this machine.
+///
+/// The trap: `snouty validate` runs docker-compose with the user's full shell,
+/// so a `${VAR}` drawing its value from the shell resolves locally and
+/// validation passes — but Antithesis runs compose hermetically, with none of
+/// those variables, so the same reference is empty (or a hard error) there and
+/// the run breaks. Validation would have given false confidence.
+///
+/// We catch it by rendering the compose file twice — once with the normal
+/// environment, once under a scrubbed one that mimics Antithesis (see
+/// [`container::DockerCompose::config_json_hermetic_env`]) — and comparing the
+/// complete models. Any field that differs is a value that exists only because
+/// of the local shell. Compose does all the interpolation, `.env`, and default
+/// work in both renders, so we never re-derive any of it — and the
+/// `${VAR:-}` "default to blank" idiom, identical in both renders, is correctly
+/// left alone.
+fn check_compose_divergence(
+    compose: &container::DockerCompose,
+    config: &ComposeConfig,
+    allow_compose_divergence: bool,
+) -> Result<()> {
+    // A failing local render is not an environment problem (e.g. a malformed
+    // compose file); let contents() surface it next with its canonical error.
+    let Ok(local) = compose.config_json(config) else {
+        return Ok(());
+    };
+    let hermetic = compose.config_json_hermetic_env(config)?;
+
+    let detail = if hermetic.status.success() {
+        let local: Value = serde_json::from_str(&local)
+            .wrap_err("failed to parse 'docker-compose config' output")?;
+        let hermetic: Value = serde_json::from_slice(&hermetic.stdout)
+            .wrap_err("failed to parse 'docker-compose config' output")?;
+        let fields = diverging_config_fields(&local, &hermetic);
+        (!fields.is_empty()).then(|| fields.join("\n"))
+    } else {
+        // A required `${VAR:?}` with no value aborts the hermetic render while
+        // the local one (which has the shell value) succeeds. Surface compose's
+        // own diagnostic rather than parsing it, falling back to the exit status
+        // if compose aborts without writing to stderr so the detail is never blank.
+        let stderr = String::from_utf8_lossy(&hermetic.stderr);
+        let stderr = stderr.trim();
+        Some(if stderr.is_empty() {
+            format!("docker-compose config aborted ({})", hermetic.status)
+        } else {
+            stderr.to_string()
+        })
+    };
+
+    let Some(detail) = detail else {
+        return Ok(());
+    };
+
+    if allow_compose_divergence {
+        eprintln!("Warning: {DIVERGENCE_HEADLINE}\n{detail}\n{DIVERGENCE_FIX}");
+        Ok(())
+    } else {
+        Err(user_error(DIVERGENCE_HEADLINE)
+            .with_section(move || detail.header("Won't resolve in Antithesis:"))
+            .with_suggestion(|| DIVERGENCE_FIX)
+            .with_suggestion(
+                || "re-run with --allow-compose-divergence to treat this as a warning",
+            ))
+    }
+}
+
+/// JSON Pointer paths at which the resolved compose models differ, each tagged
+/// with the kind of change. Values are deliberately not shown: they may be
+/// secrets. `json-patch` supplies the complete structural comparison.
+fn diverging_config_fields(local: &Value, hermetic: &Value) -> Vec<String> {
+    diff(local, hermetic)
+        .iter()
+        .map(|operation| {
+            let path = operation.path().to_string();
+            let tag = match operation {
+                PatchOperation::Add(_) => "added in Antithesis",
+                PatchOperation::Remove(_) => "missing in Antithesis",
+                PatchOperation::Replace(_) => {
+                    if hermetic.pointer(&path).is_some_and(is_empty) {
+                        "empty in Antithesis"
+                    } else {
+                        "changed in Antithesis"
+                    }
+                }
+                PatchOperation::Move(_) | PatchOperation::Copy(_) | PatchOperation::Test(_) => {
+                    "changed in Antithesis"
+                }
+            };
+            format!("{path} ({tag})")
+        })
+        .collect()
+}
+
+fn is_empty(value: &Value) -> bool {
+    value.as_str() == Some("") || value.is_null()
 }
 
 async fn validate_kubernetes(
@@ -702,7 +821,74 @@ async fn watch_for_setup_complete(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::io::Write;
+
+    #[test]
+    fn diverging_config_fields_flags_shell_only_value() {
+        // BARE draws from the shell locally but is empty under the scrubbed
+        // (Antithesis) render; OK renders the same in both and is left alone.
+        let local = json!({"services": {"app": {"environment": {"BARE": "fromshell", "OK": "x"}}}});
+        let hermetic = json!({"services": {"app": {"environment": {"BARE": "", "OK": "x"}}}});
+        assert_eq!(
+            diverging_config_fields(&local, &hermetic),
+            vec!["/services/app/environment/BARE (empty in Antithesis)".to_string()]
+        );
+    }
+
+    #[test]
+    fn diverging_config_fields_ignores_identical_render() {
+        // An empty inline default (`${VAR:-}`) and a `.env`-provided value both
+        // render identically in the two environments, so nothing is flagged.
+        let v = json!({"services": {"app": {"environment": {"EMPTY": "", "FROM_ENV": "x"}}}});
+        assert!(diverging_config_fields(&v, &v).is_empty());
+    }
+
+    #[test]
+    fn diverging_config_fields_flags_changed_value() {
+        let local = json!({"services": {"app": {"image": "myreg/app:dev"}}});
+        let hermetic = json!({"services": {"app": {"image": "app"}}});
+        assert_eq!(
+            diverging_config_fields(&local, &hermetic),
+            vec!["/services/app/image (changed in Antithesis)".to_string()]
+        );
+    }
+
+    #[test]
+    fn diverging_config_fields_reports_array_element() {
+        let local = json!({"services": {"app": {"command": ["run", "--flag=local"]}}});
+        let hermetic = json!({"services": {"app": {"command": ["run", "--flag="]}}});
+        assert_eq!(
+            diverging_config_fields(&local, &hermetic),
+            vec!["/services/app/command/1 (changed in Antithesis)".to_string()]
+        );
+    }
+
+    #[test]
+    fn diverging_config_fields_flags_top_level_project_name() {
+        let local = json!({"name": "shellname", "services": {"app": {"image": "app"}}});
+        let hermetic = json!({"name": "dirname", "services": {"app": {"image": "app"}}});
+        assert_eq!(
+            diverging_config_fields(&local, &hermetic),
+            vec!["/name (changed in Antithesis)".to_string()]
+        );
+    }
+
+    #[test]
+    fn diverging_config_fields_flags_top_level_volume() {
+        let local = json!({
+            "services": {"app": {"image": "app", "volumes": ["data:/data"]}},
+            "volumes": {"data": {"driver_opts": {"device": "/host/data"}}}
+        });
+        let hermetic = json!({
+            "services": {"app": {"image": "app", "volumes": ["data:/data"]}},
+            "volumes": {"data": {"driver_opts": {"device": ""}}}
+        });
+        assert_eq!(
+            diverging_config_fields(&local, &hermetic),
+            vec!["/volumes/data/driver_opts/device (empty in Antithesis)".to_string()]
+        );
+    }
 
     #[test]
     fn generate_setup_override_basic() {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -348,9 +348,11 @@ config image) or give the reference an inline default (e.g. ${VAR:-default}).";
 /// [`container::DockerCompose::config_json_hermetic_env`]) — and comparing the
 /// complete models. Any field that differs is a value that exists only because
 /// of the local shell. Compose does all the interpolation, `.env`, and default
-/// work in both renders, so we never re-derive any of it — and the
-/// `${VAR:-}` "default to blank" idiom, identical in both renders, is correctly
-/// left alone.
+/// work in both renders, so we never re-derive any of it. An inline default
+/// like `${VAR:-default}` is left alone only when `VAR` is also unset locally —
+/// then both renders produce `default`. If the local shell sets `VAR`, the two
+/// renders differ and we flag it, which is correct: Antithesis would fall back
+/// to the default while the local run silently used the shell value.
 fn check_compose_divergence(
     compose: &container::DockerCompose,
     config: &ComposeConfig,
@@ -389,7 +391,13 @@ fn check_compose_divergence(
     };
 
     if allow_compose_divergence {
-        eprintln!("Warning: {DIVERGENCE_HEADLINE}\n{detail}\n{DIVERGENCE_FIX}");
+        // --allow-compose-divergence is an escape hatch, not a silencer: still
+        // surface the problem (and compose's own error, if any) so the user
+        // knows something is off even though validation proceeds to success.
+        eprintln!(
+            "Warning: {DIVERGENCE_HEADLINE}\n{detail}\n{DIVERGENCE_FIX}\n\
+             Proceeding anyway because --allow-compose-divergence was set."
+        );
         Ok(())
     } else {
         Err(user_error(DIVERGENCE_HEADLINE)
@@ -419,7 +427,16 @@ fn diverging_config_fields(local: &Value, hermetic: &Value) -> Vec<String> {
                         "changed in Antithesis"
                     }
                 }
+                // json_patch::diff only emits add/remove/replace from a
+                // structural comparison, so this arm should never be reached.
+                // Catch it loudly in debug builds, but degrade gracefully in
+                // release rather than panicking on a user's `snouty validate`.
                 PatchOperation::Move(_) | PatchOperation::Copy(_) | PatchOperation::Test(_) => {
+                    debug_assert!(
+                        false,
+                        "json_patch::diff emitted an unexpected move/copy/test operation at {path}"
+                    );
+                    warn!("unexpected json-patch operation at {path} while comparing compose renders; treating as changed");
                     "changed in Antithesis"
                 }
             };

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -714,6 +714,12 @@ engine_spec_case_test!(
     false
 );
 engine_spec_case_test!(
+    podman_engine_validate_env_specs,
+    "podman",
+    "validate_env.txt",
+    false
+);
+engine_spec_case_test!(
     podman_engine_validate_k8s_specs,
     "podman",
     "validate_k8s.txt",
@@ -741,6 +747,12 @@ engine_spec_case_test!(
     docker_engine_validate_network_arch_specs,
     "docker",
     "validate_network_arch.txt",
+    false
+);
+engine_spec_case_test!(
+    docker_engine_validate_env_specs,
+    "docker",
+    "validate_env.txt",
     false
 );
 engine_spec_case_test!(


### PR DESCRIPTION
`snouty validate` runs docker-compose with your full shell environment, so a `${VAR}` that draws its value from the shell resolves fine locally and validation passes. But Antithesis runs compose hermetically, with none of those variables, so the same reference comes back empty — or aborts, for a required `${VAR:?}` — and the run breaks. Validation would have given false confidence.

This teaches `validate` to catch that before launch. It resolves the compose file twice — once with the normal environment, once under a scrubbed environment that mimics the hermetic Antithesis one — and fails when the two renders differ, reporting the JSON-pointer paths that diverge. Values are deliberately withheld from the report since they may be secrets.

Compose does all the interpolation, `.env`, and default handling in both renders, so nothing is re-derived: a value from a `.env` file in the config directory (which is baked into the config image) or an inline default like `${VAR:-default}` resolves identically in both and is left alone. Only values that exist solely because of the local shell are flagged.

`--allow-compose-divergence` downgrades the failure to a warning and proceeds, for when the divergence is understood and intended. The warning still surfaces the problem so it isn't silently swallowed. The check is compose-only and inert for Kubernetes configs.

fixes #160
