### PR TITLE
launch/validate: announce the auto-detected container engine

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -161,6 +161,12 @@ pub trait ContainerRuntime: Send + Sync {
     /// The CLI command name (e.g. "podman" or "docker").
     fn name(&self) -> &str;
 
+    /// The underlying engine ("podman" or "docker"), independent of which binary
+    /// invokes it. These diverge only for podman-in-disguise (podman installed
+    /// as the `docker` binary), where [`name`](Self::name) is `"docker"` but the
+    /// engine is really podman.
+    fn engine_kind(&self) -> &'static str;
+
     /// Clone into a boxed trait object.
     fn clone_box(&self) -> Box<dyn ContainerRuntime>;
 
@@ -1077,6 +1083,10 @@ impl ContainerRuntime for PodmanRuntime {
         &self.cmd
     }
 
+    fn engine_kind(&self) -> &'static str {
+        "podman"
+    }
+
     fn clone_box(&self) -> Box<dyn ContainerRuntime> {
         Box::new(self.clone())
     }
@@ -1176,6 +1186,10 @@ impl ContainerRuntime for DockerRuntime {
 
     fn name(&self) -> &str {
         &self.cmd
+    }
+
+    fn engine_kind(&self) -> &'static str {
+        "docker"
     }
 
     fn remote_manifest(&self, image_ref: &str) -> RemoteManifest {
@@ -1287,11 +1301,20 @@ pub fn announce_auto_detected_engine(settings: &Settings, rt: &dyn ContainerRunt
     if json || settings.container_engine().is_some() {
         return;
     }
-    let engine = rt.name();
+    // Report the real engine, not the binary name: for podman-in-disguise the
+    // command is `docker` but the engine is podman, and the override the user
+    // should set is the engine kind. Call out the disguise so "podman via the
+    // docker binary" doesn't read as a contradiction.
+    let engine = rt.engine_kind();
+    let via = if rt.name() == engine {
+        String::new()
+    } else {
+        format!(" (running as the '{}' binary)", rt.name())
+    };
     eprintln!(
-        "Using auto-detected container engine '{engine}'. If that's not what you \
-         expect, select one explicitly with SNOUTY_CONTAINER_ENGINE={engine} (or \
-         `container_engine = \"{engine}\"` in a snouty settings file)."
+        "Using auto-detected container engine '{engine}'{via}. If that's not what \
+         you expect, select one explicitly with SNOUTY_CONTAINER_ENGINE={engine} \
+         (or `container_engine = \"{engine}\"` in a snouty settings file)."
     );
 }
 
@@ -2773,6 +2796,10 @@ services:
 
     impl ContainerRuntime for FakeRuntime {
         fn name(&self) -> &str {
+            "fake"
+        }
+
+        fn engine_kind(&self) -> &'static str {
             "fake"
         }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1277,6 +1277,24 @@ pub fn runtime(settings: &Settings) -> Result<Box<dyn ContainerRuntime>> {
     }
 }
 
+/// Tell the user which container engine snouty picked, but only when it was
+/// auto-detected. An explicit `SNOUTY_CONTAINER_ENGINE` / `container_engine`
+/// setting means the user already chose, so there's nothing to announce, and
+/// machine-readable (`json`) output stays silent. Prints to stderr (never
+/// stdout, so it can't contaminate `--json`). The note points at the override
+/// so a surprising pick is easy to fix.
+pub fn announce_auto_detected_engine(settings: &Settings, rt: &dyn ContainerRuntime, json: bool) {
+    if json || settings.container_engine().is_some() {
+        return;
+    }
+    let engine = rt.name();
+    eprintln!(
+        "Using auto-detected container engine '{engine}'. If that's not what you \
+         expect, select one explicitly with SNOUTY_CONTAINER_ENGINE={engine} (or \
+         `container_engine = \"{engine}\"` in a snouty settings file)."
+    );
+}
+
 /// Return all container runtimes available on this machine.
 /// Skips `docker` if it is actually podman in disguise.
 pub fn available_engines() -> Vec<Box<dyn ContainerRuntime>> {

--- a/src/container.rs
+++ b/src/container.rs
@@ -1302,19 +1302,12 @@ pub fn announce_auto_detected_engine(settings: &Settings, rt: &dyn ContainerRunt
         return;
     }
     // Report the real engine, not the binary name: for podman-in-disguise the
-    // command is `docker` but the engine is podman, and the override the user
-    // should set is the engine kind. Call out the disguise so "podman via the
-    // docker binary" doesn't read as a contradiction.
+    // command is `docker` but the engine is podman.
     let engine = rt.engine_kind();
-    let via = if rt.name() == engine {
-        String::new()
-    } else {
-        format!(" (running as the '{}' binary)", rt.name())
-    };
     eprintln!(
-        "Using auto-detected container engine '{engine}'{via}. If that's not what \
-         you expect, select one explicitly with SNOUTY_CONTAINER_ENGINE={engine} \
-         (or `container_engine = \"{engine}\"` in a snouty settings file)."
+        "Using auto-detected container engine '{engine}'. If that's not what you \
+         expect, select one explicitly with SNOUTY_CONTAINER_ENGINE={engine} (or \
+         `container_engine = \"{engine}\"` in a snouty settings file)."
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,7 @@ async fn cmd_launch(
 
     if let Some((detected, registry, config_image)) = config_image_ref {
         let rt = container::runtime(settings)?;
+        container::announce_auto_detected_engine(settings, rt.as_ref(), json);
 
         // For compose configs, every service image is pinned to its local
         // digest (snouty never pulls): served from a registry confirmed to

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -202,6 +202,9 @@ async fn validate_with_temp_dir(
         allow_compose_divergence,
     } = args;
     let rt = container::runtime(settings)?;
+    // `snouty validate` has no machine-readable output (`--json` is a no-op),
+    // so the auto-detect notice is always eligible to print.
+    container::announce_auto_detected_engine(settings, rt.as_ref(), false);
     match config::detect_config(&config_path)? {
         Config::Compose(cfg) => {
             validate_compose(


### PR DESCRIPTION
Follow-up on #170.

When the container engine is **auto-detected** (no explicit `SNOUTY_CONTAINER_ENGINE` or `container_engine` setting), `snouty launch` and `snouty validate` now print which engine they picked, along with a note on how to select one explicitly if it isn't what the user expects:

```
Using auto-detected container engine 'podman'. If that's not what you expect,
select one explicitly with SNOUTY_CONTAINER_ENGINE=podman (or
`container_engine = "podman"` in a snouty settings file).
```

Details:
- New shared helper `container::announce_auto_detected_engine`.
- Suppressed when the engine is set explicitly (the user already chose) and for JSON output (`--json`). `validate` has no machine-readable output, so it passes `false`.
- Prints to **stderr** so it never contaminates `--json` on stdout.
- In `launch`, announced only where the runtime is actually resolved (building a config image), so there's no spurious message when launch doesn't touch a container engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUydxGFzvTRiUSNaM6SpNa