### PR TITLE
login: success confirmation, satisfaction gallery, and a real macOS keychain test

### DIFF
--- a/.claude/skills/satisfaction-review/SKILL.md
+++ b/.claude/skills/satisfaction-review/SKILL.md
@@ -71,6 +71,31 @@ _Automated check: PASS|FAIL — <detail>_
 (Help stories show an `Exit code:` line under each command block — the `--help`,
 the default output, and every variant.)
 
+**Interactive / stateful stories** (the `login-*` slugs) have a different shape.
+`snouty login` reads answers from stdin and *writes files*, so instead of a
+single output block these stories show:
+
+```
+## Transcript
+```shell
+$ snouty login
+# stdin> acme                     ← the answers fed to each prompt, in order
+# stdin> registry.example.com/...
+<the prompt transcript snouty printed>
+```
+Exit code: `<n>`
+
+## Persisted state
+`~/.config/snouty/settings.toml`      ← the files login actually wrote,
+```toml                                  with secrets already [REDACTED];
+...                                      "(not written)" when a file was
+```                                      deliberately not created
+```
+
+Judge these on the transcript **and** the persisted state together (see Step 3).
+They run in a throwaway `$HOME`, so the paths are temp dirs — judge the shape and
+content, not the exact path.
+
 Read every story file. For the **large** outputs (e.g. `runs-build-logs`,
 `runs-logs-incomplete` can be tens/hundreds of KB) do **not** read the whole
 file — measure its width with the tool below and read only the head and tail to
@@ -111,8 +136,8 @@ command**? Concretely:
 If a needed coordinate is truncated, omitted, or buried, that's a follow-up
 failure even if the command "worked".
 
-### Axis C — Terminal rendering at ~100 columns
-Assume an average terminal is **100 characters wide**. Measure the widest line
+### Axis C — Terminal rendering at ~140 columns
+Assume an average terminal is **140 characters wide**. Measure the widest line
 of actual command output per story:
 
 ```bash
@@ -126,9 +151,9 @@ done | sort -t= -k2 -rn
 ```
 
 Interpret the widest-line width:
-- **≤ 100** → fits cleanly (✅).
-- **101–120** → wraps a little; usually ⚠️ unless the wrap mangles a table.
-- **> 120** → likely wraps badly; tables become unreadable, columns desync (❌).
+- **≤ 140** → fits cleanly (✅).
+- **141–160** → wraps a little; usually ⚠️ unless the wrap mangles a table.
+- **> 160** → likely wraps badly; tables become unreadable, columns desync (❌).
 
 Also judge rendering quality beyond raw width:
 - **Wasted width**: mostly-empty columns padded to a huge fixed width (e.g. a
@@ -141,11 +166,35 @@ Also judge rendering quality beyond raw width:
   overlap), or is it reasonable?
 - **Density**: walls of near-identical lines, redundant repetition, no grouping.
 
+### Interactive / stateful stories (`login-*`)
+These are `snouty login` runs, so reinterpret the axes — the deliverable is a
+prompt conversation plus files written, not a table:
+- **Axis A (correctness):** were the prompts the right ones, in a sensible order,
+  and *only* for values not already known (a flag or a stored previous value
+  shouldn't be re-prompted)? Was invalid input rejected? And — judged against the
+  **Persisted state** section, not just stdout — did it write the *correct*
+  result (right tenant/repo, right credential type, right `[profile.x]` scope)?
+- **Axis B (follow-up readiness):** after it finishes, does the user know **what
+  was saved, where, and the obvious next step** (e.g. "run `snouty doctor` to
+  verify")? A login that exits `0` in silence — never confirming what it wrote —
+  is an Axis B failure even though the file is correct. For the error/repair
+  paths, does the message say what went wrong *and* how to recover?
+- **Axis C (rendering):** less about 140-col tables, more about **prompt clarity
+  and secret hygiene** — is the menu readable, are previous-value defaults shown
+  legibly, and is the password never echoed into the transcript?
+- **Axis D — safety of a mutating command** (interactive/stateful stories only):
+  before overwriting or discarding existing state, does it warn and/or back up
+  (e.g. `settings.toml.bak`)? Does it scope writes to the intended profile? Does a
+  rejected/aborted run leave nothing half-written? A mutating command that
+  clobbers or half-writes silently fails this axis regardless of how the happy
+  path reads.
+
 ### Per-story verdict
-Combine the three axes into one verdict — **satisfied**, **partial**, or
+Combine the axes into one verdict — **satisfied**, **partial**, or
 **unsatisfied** — and, when not fully satisfied, a **concrete suggested fix**
 (e.g. "round vtime to 3 decimals", "drop the GROUP column when empty",
-"print full run ID, truncate the description instead").
+"print full run ID, truncate the description instead"). For `login-*` stories,
+weigh all four axes (A–D); for every other story, the three (A–C).
 
 ## Step 4 — Write the report
 
@@ -207,6 +256,11 @@ Guidance for a high-signal report:
 - The gallery is pinned to whatever live run IDs were fresh at generation time,
   so exact IDs/values differ between runs. Judge the *shape and quality* of the
   output, not the specific data.
-- Width and rendering are judged for a plain ~100-col terminal; snouty may
+- Width and rendering are judged for a plain ~140-col terminal; snouty may
   detect a wider TTY when run interactively, but the gallery captures
   non-interactive output, which is the conservative case worth reviewing.
+- The `login-*` stories run in a throwaway `$HOME` that is removed after capture,
+  and are fed fake secrets that are redacted again in the file — so the "Persisted
+  state" you review never contains a real credential or touches real config. On
+  Linux these exercise the file-backed credential store (the keychain is a no-op
+  there), which is the realistic default for a CI/gallery run.

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -35,6 +35,7 @@ how snouty changes affect command output.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -123,10 +124,17 @@ class Snouty:
     def cleanup(self) -> None:
         shutil.rmtree(self._shim, ignore_errors=True)
 
-    def run(self, args: list[str], env: dict[str, str | None] | None = None) -> Result:
+    def run(
+        self,
+        args: list[str],
+        env: dict[str, str | None] | None = None,
+        stdin: str | None = None,
+    ) -> Result:
         # `env` overrides individual vars for this call only: a string sets the
         # var, None unsets it (so a story can model an environment missing some
         # credential). Everything else inherits the live ANTITHESIS_* env.
+        # `stdin`, when given, is fed to the process's standard input — used by the
+        # interactive stories (`snouty login`) that read answers line-by-line.
         run_env = self._env
         if env is not None:
             run_env = dict(self._env)
@@ -140,6 +148,7 @@ class Snouty:
             capture_output=True,
             text=True,
             env=run_env,
+            input=stdin,
         )
         return Result(args, proc.stdout, proc.stderr, proc.returncode)
 
@@ -587,6 +596,22 @@ class Story:
     # validate stories require a container runtime (see `ensure_validate_runtime`);
     # this flag just documents which ones spin up live containers.
     needs_docker: bool = False
+    # -- interactive / stateful stories (`snouty login`) -------------------
+    # When `sandbox_home` is set the story is an interactive, stateful story: it
+    # runs in a throwaway `$HOME` so the credentials/settings it persists never
+    # touch the operator's real config, and `post_capture` files are read back
+    # from that HOME and shown as the command's result. `stdin` feeds the
+    # interactive prompts their answers.
+    sandbox_home: bool = False
+    # Scripted answers fed to the command's stdin, one per line (login prompts).
+    stdin: str | None = None
+    # Files to pre-write into the sandbox HOME before running, keyed by
+    # HOME-relative path — models pre-existing state (a prior login, a broken
+    # settings file). Mirrors the spec fixtures' txtar `-- path --` sections.
+    seed_files: dict[str, str] | None = None
+    # HOME-relative files to read back after the run and render under a
+    # "Persisted state" section (secrets are redacted before embedding).
+    post_capture: tuple[str, ...] = ()
 
 
 @dataclass
@@ -596,6 +621,9 @@ class StoryRun:
     rows: list[dict] | None  # structured rows from the --json variant, if any
     help_result: Result | None = None  # `<help_cmd> --help` capture, for help stories
     sample_results: list[tuple[str, Result]] | None = None  # extra labelled captures
+    # (rel_path, contents|None) for each `post_capture` file, in order; None means
+    # the file was not written (which some login stories assert on).
+    captured_files: list[tuple[str, str | None]] | None = None
 
 
 class Registry:
@@ -681,6 +709,72 @@ def contains_all(*needles: str):
         text = sr.result.combined
         missing = [n for n in needles if n not in text]
         return (not missing, "all present" if not missing else f"missing {missing!r}")
+
+    return chk
+
+
+# -- login (interactive/stateful) check factories ---------------------------
+#
+# These read `sr.captured_files` (the `post_capture` files read back from the
+# throwaway HOME) rather than stdout, because the interesting outcome of a
+# stateful command is the file it wrote, not what it printed.
+
+
+def _captured(sr: StoryRun, rel_path: str) -> str | None:
+    for path, contents in sr.captured_files or []:
+        if path == rel_path:
+            return contents
+    return None
+
+
+def login_persisted(
+    *,
+    prompts: tuple[str, ...] = (),
+    absent_prompts: tuple[str, ...] = (),
+    files: tuple[tuple[str, tuple[str, ...]], ...] = (),
+    absent_files: tuple[str, ...] = (),
+    secrets_absent: tuple[str, ...] = (),
+    expect_ok: bool = True,
+):
+    """Gate an interactive login story. Combines the concerns a single login
+    story cares about: the command exits with the expected success/failure; the
+    expected `prompts` all appear in the transcript and no `absent_prompts` do;
+    each `(rel_path, needles)` in `files` was written and contains every needle;
+    each path in `absent_files` was NOT written; and no raw `secrets_absent` value
+    leaks into the transcript. Any failure lists what went wrong."""
+
+    def chk(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
+        text = sr.result.combined
+        problems: list[str] = []
+
+        if sr.result.ok != expect_ok:
+            problems.append(f"exit={sr.result.returncode} (want ok={expect_ok})")
+
+        missing_prompts = [p for p in prompts if p not in text]
+        if missing_prompts:
+            problems.append(f"missing prompts={missing_prompts!r}")
+        shown_absent = [p for p in absent_prompts if p in text]
+        if shown_absent:
+            problems.append(f"unexpected prompts={shown_absent!r}")
+
+        for rel_path, needles in files:
+            contents = _captured(sr, rel_path)
+            if contents is None:
+                problems.append(f"{rel_path} not written")
+                continue
+            missing = [n for n in needles if n not in contents]
+            if missing:
+                problems.append(f"{rel_path} missing {missing!r}")
+
+        for rel_path in absent_files:
+            if _captured(sr, rel_path) is not None:
+                problems.append(f"{rel_path} was written (expected absent)")
+
+        leaked = [s for s in secrets_absent if s in text]
+        if leaked:
+            problems.append(f"secret leaked into transcript={leaked!r}")
+
+        return (not problems, "; ".join(problems) or "prompts + persisted state as expected")
 
     return chk
 
@@ -1766,6 +1860,198 @@ def build_validate_stories(ephemeral: Path | None) -> list[Story]:
 
 
 # ---------------------------------------------------------------------------
+# Login stories: `snouty login` is interactive (reads answers from stdin) and
+# stateful (writes settings.toml/credentials.toml). Each runs in a throwaway
+# `$HOME`, feeds scripted answers, and captures the files it wrote so a reviewer
+# can judge both the prompt transcript AND the persisted result. No API,
+# discovery, or container runtime is needed. On Linux the keychain is a no-op, so
+# credentials land in the file backend — the realistic default here.
+# ---------------------------------------------------------------------------
+
+# Fake, obviously-not-real secrets fed on stdin — never a real credential, and
+# redacted again before embedding (see `_redact_secrets`).
+_FAKE_KEY = "sk-FAKE-not-a-real-key"
+_FAKE_PASS = "FAKE-not-a-real-password"
+_TENANT = "acme"
+_REPO = "registry.example.com/acme/app"
+_SETTINGS = ".config/snouty/settings.toml"
+_CREDS = ".config/snouty/credentials.toml"
+_SETTINGS_BAK = ".config/snouty/settings.toml.bak"
+
+# Shared satisfaction rubric for the interactive login stories: judge the prompt
+# transcript AND the persisted result, not just the exit code.
+_LOGIN_RUBRIC = (
+    "Judge the prompt transcript and the persisted state together. Are the "
+    "prompts clear, in a sensible order, and only for values not already known? "
+    "After it finishes, does the user know WHAT was saved, WHERE, and the next "
+    "step (e.g. `snouty doctor`)? Are secrets never echoed? For the error/repair "
+    "paths, is the message clear about what went wrong and how to recover, and is "
+    "a mutating overwrite done safely (warn + back up)?"
+)
+
+
+def _login_story(
+    slug: str,
+    title: str,
+    goal: str,
+    args: list[str],
+    stdin: str,
+    check,
+    *,
+    pre: list[str] | None = None,
+    seed_files: dict[str, str] | None = None,
+    post_capture: tuple[str, ...] = (_SETTINGS, _CREDS),
+    env: dict[str, str | None] | None = None,
+) -> Story:
+    # `pre` holds global flags that must precede the `login` subcommand (e.g.
+    # `--profile`); `args` holds `login`'s own flags.
+    return Story(
+        slug=slug,
+        title=title,
+        goal=goal,
+        judge=_LOGIN_RUBRIC,
+        args=[*(pre or []), "login", *args],
+        check=check,
+        json_capable=False,
+        sandbox_home=True,
+        stdin=stdin,
+        seed_files=seed_files,
+        post_capture=post_capture,
+        env=env,
+    )
+
+
+def build_login_stories() -> list[Story]:
+    return [
+        _login_story(
+            "login-fresh-apikey",
+            "First-time setup with an API key",
+            "I just installed snouty and want to configure my tenant, repository, and API key.",
+            [],
+            f"{_TENANT}\n{_REPO}\n2\n{_FAKE_KEY}\n",
+            login_persisted(
+                prompts=(
+                    "What Antithesis tenant",
+                    "What container repository",
+                    "What kind of credentials",
+                ),
+                files=(
+                    (_SETTINGS, (f'tenant = "{_TENANT}"', f'repository = "{_REPO}"')),
+                    (_CREDS, ('type = "ApiKey"',)),
+                ),
+                secrets_absent=(_FAKE_KEY,),
+            ),
+        ),
+        _login_story(
+            "login-reuse-default",
+            "Re-run login and keep my stored values",
+            "I already logged in; re-running should offer my previous tenant/repo/key as defaults so I can just hit enter.",
+            [],
+            "\n\n\n\n",  # blank tenant, repo, auth-menu (default), api key (reuse)
+            login_persisted(
+                prompts=(
+                    f"Hit enter to use the previous value of [{_TENANT}]",
+                    f"Hit enter to use the previous value of [{_REPO}]",
+                ),
+                files=((_CREDS, ('type = "ApiKey"',)),),
+                secrets_absent=("sk-SEED-not-a-real-key",),
+            ),
+            seed_files={
+                _SETTINGS: f'tenant = "{_TENANT}"\nrepository = "{_REPO}"\n',
+                _CREDS: '[default]\ntype = "ApiKey"\napi_key = "sk-SEED-not-a-real-key"\n',
+            },
+        ),
+        _login_story(
+            "login-flags",
+            "Supply tenant and repository as flags",
+            "I know my tenant and repository already; I only want to be prompted for credentials.",
+            ["--tenant", _TENANT, "--repository", _REPO],
+            f"2\n{_FAKE_KEY}\n",
+            login_persisted(
+                prompts=("What kind of credentials",),
+                absent_prompts=("What Antithesis tenant", "What container repository"),
+                files=(
+                    (_SETTINGS, (f'tenant = "{_TENANT}"',)),
+                    (_CREDS, ('type = "ApiKey"',)),
+                ),
+                secrets_absent=(_FAKE_KEY,),
+            ),
+        ),
+        _login_story(
+            "login-password",
+            "Set up legacy username/password auth",
+            "I authenticate with a username and password rather than an API key.",
+            [],
+            f"{_TENANT}\n{_REPO}\n3\npuser\n{_FAKE_PASS}\n",
+            login_persisted(
+                prompts=("What kind of credentials",),
+                files=((_CREDS, ('type = "Password"', 'username = "puser"')),),
+                secrets_absent=(_FAKE_PASS,),
+            ),
+        ),
+        _login_story(
+            "login-profile",
+            "Scope a login to a named profile",
+            "I keep separate configs per environment and want this login saved under the `prod` profile.",
+            [],
+            f"{_TENANT}\n{_REPO}\n2\n{_FAKE_KEY}\n",
+            login_persisted(
+                files=(
+                    (_SETTINGS, ("[profile.prod]", f'tenant = "{_TENANT}"')),
+                    (_CREDS, ("[profile.prod]", 'type = "ApiKey"')),
+                ),
+                secrets_absent=(_FAKE_KEY,),
+            ),
+            pre=["--profile", "prod"],
+        ),
+        _login_story(
+            "login-skip-creds",
+            "Configure tenant/repo but skip credential storage",
+            "I use environment variables for credentials; I just want snouty to remember my tenant and repository.",
+            [],
+            f"{_TENANT}\n{_REPO}\n1\n",
+            login_persisted(
+                prompts=("What kind of credentials",),
+                files=((_SETTINGS, (f'tenant = "{_TENANT}"',)),),
+                absent_files=(_CREDS,),
+            ),
+        ),
+        _login_story(
+            "login-bad-tenant",
+            "A malformed tenant is rejected safely",
+            "I fat-finger a tenant that isn't a valid hostname; I want a clear error and nothing half-saved.",
+            [],
+            "evil.com/x\n",
+            login_persisted(
+                prompts=("What Antithesis tenant", "invalid tenant"),
+                absent_files=(_SETTINGS, _CREDS),
+                expect_ok=False,
+            ),
+        ),
+        _login_story(
+            "login-repair-broken",
+            "Repair a broken settings file",
+            "My settings.toml got corrupted; I want `snouty login` to fix it without silently destroying the old one.",
+            [],
+            f"1\n{_TENANT}\n{_REPO}\n1\n",  # proceed, tenant, repo, skip creds
+            login_persisted(
+                prompts=(
+                    "The current settings failed to load",
+                    "Would you like to proceed",
+                    "has been backed up to",
+                ),
+                files=(
+                    (_SETTINGS, (f'tenant = "{_TENANT}"',)),
+                    (_SETTINGS_BAK, ("unparsable-settings-marker",)),
+                ),
+            ),
+            seed_files={_SETTINGS: "this is = = not valid toml unparsable-settings-marker\n"},
+            post_capture=(_SETTINGS, _SETTINGS_BAK),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Rendering + main
 # ---------------------------------------------------------------------------
 
@@ -1814,10 +2100,52 @@ def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, d
     (out_dir / f"{story.slug}.md").write_text("\n\n".join(parts) + "\n")
 
 
+# Redact the secret values from persisted TOML before embedding it in a story —
+# belt-and-suspenders on top of the fake secrets the login stories feed on stdin.
+_SECRET_LINE = re.compile(r'^(\s*(?:api_key|password)\s*=\s*)"[^"]*"', re.MULTILINE)
+
+
+def _redact_secrets(text: str) -> str:
+    return _SECRET_LINE.sub(r'\1"[REDACTED]"', text)
+
+
+def _write_login_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
+    # The `$ snouty ...` block with the scripted answers shown as a comment, so a
+    # reviewer sees exactly what the user typed at each prompt. `splitlines()`
+    # keeps every answer, including blank "just hit enter" ones (a reuse story
+    # feeds several) that `.rstrip("\n").split("\n")` would collapse.
+    answers = (story.stdin or "").splitlines()
+    stdin_note = "".join(f"# stdin> {a}\n" for a in answers)
+    transcript = (
+        f"```shell\n$ snouty {' '.join(story.args)}\n{stdin_note}"
+        f"{sr.result.combined.rstrip(chr(10))}\n```\nExit code: `{sr.result.returncode}`"
+    )
+    parts = [
+        f"# {story.title}",
+        f"**User goal:** {story.goal}",
+        f"**Judge satisfaction by:** {story.judge}",
+        "## Transcript",
+        transcript,
+    ]
+    if story.post_capture:
+        parts.append("## Persisted state")
+        for rel_path, contents in sr.captured_files or []:
+            if contents is None:
+                parts.append(f"`~/{rel_path}` — _(not written)_")
+            else:
+                body = _redact_secrets(contents).rstrip("\n")
+                parts.append(f"`~/{rel_path}`\n```toml\n{body}\n```")
+    parts.append(f"_Automated check: {verdict} — {detail}_")
+    (out_dir / f"{story.slug}.md").write_text("\n\n".join(parts) + "\n")
+
+
 def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail: str) -> None:
     verdict = "PASS" if passed else "FAIL"
     if story.help_cmd is not None:
         _write_help_story(out_dir, story, sr, verdict, detail)
+        return
+    if story.sandbox_home:
+        _write_login_story(out_dir, story, sr, verdict, detail)
         return
     md = (
         f"# {story.title}\n\n"
@@ -1829,7 +2157,43 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
     (out_dir / f"{story.slug}.md").write_text(md)
 
 
+def run_login_story(sn: Snouty, story: Story) -> StoryRun:
+    """Run an interactive, stateful story in a throwaway `$HOME` so the
+    credentials/settings it persists never touch the operator's real config. The
+    home is seeded with `seed_files`, the answers are piped to stdin, and the
+    `post_capture` files are read back before the home is removed."""
+    home = Path(tempfile.mkdtemp(prefix="snouty-gallery-login."))
+    try:
+        for rel_path, contents in (story.seed_files or {}).items():
+            dest = home / rel_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(contents)
+
+        # Pin HOME, clear XDG_CONFIG_HOME (snouty treats empty as unset), and drop
+        # any ambient ANTITHESIS_* credentials so the "previous value" defaults are
+        # deterministic and no real secret can leak into a captured file.
+        env: dict[str, str | None] = {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": None,
+            **{k: None for k in os.environ if k.startswith("ANTITHESIS_")},
+        }
+        if story.env:
+            env.update(story.env)
+
+        result = sn.run(story.args, env=env, stdin=story.stdin)
+
+        captured: list[tuple[str, str | None]] = []
+        for rel_path in story.post_capture:
+            path = home / rel_path
+            captured.append((rel_path, path.read_text() if path.is_file() else None))
+        return StoryRun(story, result, None, captured_files=captured)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
 def run_story(sn: Snouty, story: Story) -> StoryRun:
+    if story.sandbox_home:
+        return run_login_story(sn, story)
     # Help-only stories pass no `args`; don't invoke a bare `snouty`.
     result = sn.run(story.args, story.env) if story.args else Result([], "", "", 0)
     rows = None
@@ -1865,7 +2229,12 @@ def main() -> int:
         default=15,
         help="recent completed runs to probe for one with events",
     )
-    parser.add_argument("--only", nargs="+", metavar="SLUG", help="only generate these stories")
+    parser.add_argument(
+        "--only",
+        nargs="+",
+        metavar="SLUG",
+        help="only generate stories matching these slugs (globs allowed, e.g. 'login-*')",
+    )
     parser.add_argument("--list", action="store_true", help="list story slugs and exit")
     parser.add_argument("--fail-fast", action="store_true", help="stop at the first failing story")
     args = parser.parse_args()
@@ -1876,6 +2245,8 @@ def main() -> int:
         for s in build_stories(Discovery()):
             print(s.slug)
         for s in build_validate_stories(None):
+            print(s.slug)
+        for s in build_login_stories():
             print(s.slug)
         return 0
 
@@ -1900,34 +2271,56 @@ def main() -> int:
     # manifests/ dir) are synthesized here for this run only.
     fixtures_dir = Path(tempfile.mkdtemp(prefix="snouty-gallery-fixtures."))
 
+    # Which story groups does this run actually need? The login stories need no
+    # API, discovery, or container runtime, so `--only login-*` must not drag in
+    # (and fail on) live-API discovery or a Docker daemon. Decide up front from
+    # cheaply-enumerable slugs which groups are in scope.
+    def selected(slug: str) -> bool:
+        return not args.only or any(fnmatch.fnmatch(slug, pat) for pat in args.only)
+
+    api_slugs = {s.slug for s in build_stories(Discovery())}
+    validate_slugs = {s.slug for s in build_validate_stories(None)}
+    login_slugs = {s.slug for s in build_login_stories()}
+    need_api = any(selected(s) for s in api_slugs)
+    need_validate = any(selected(s) for s in validate_slugs)
+
+    if args.only:
+        known = api_slugs | validate_slugs | login_slugs
+        unmatched = [p for p in args.only if not any(fnmatch.fnmatch(s, p) for s in known)]
+        if unmatched:
+            print(f"error: --only matched no stories: {unmatched}", file=sys.stderr)
+            return 1
+
     sn = Snouty(snouty_bin)
     failures: list[tuple[str, str]] = []
     try:
-        disc = discover(sn, args.runs_to_scan)
-        stories = build_stories(disc)
+        stories: list[Story] = []
+        if need_api:
+            disc = discover(sn, args.runs_to_scan)
+            stories += build_stories(disc)
 
-        # Validate stories run against the committed sample projects, all of
-        # which require a container runtime (`snouty validate` resolves
-        # docker/podman before inspecting any config). gen-gallery is a developer
-        # tool, so the runtime is mandatory: build the sample images and hard-fail
-        # if it isn't available, rather than silently dropping stories.
-        ensure_validate_runtime()
-        validate_stories = build_validate_stories(fixtures_dir)
-        n_live = sum(s.needs_docker for s in validate_stories)
-        print(
-            f"including all {len(validate_stories)} validate stories "
-            f"({n_live} start live containers)",
-            file=sys.stderr,
-        )
-        stories += validate_stories
+        if need_validate:
+            # Validate stories run against the committed sample projects, all of
+            # which require a container runtime (`snouty validate` resolves
+            # docker/podman before inspecting any config). gen-gallery is a
+            # developer tool, so the runtime is mandatory: build the sample images
+            # and hard-fail if it isn't available, rather than silently dropping
+            # stories.
+            ensure_validate_runtime()
+            validate_stories = build_validate_stories(fixtures_dir)
+            n_live = sum(s.needs_docker for s in validate_stories)
+            print(
+                f"including all {len(validate_stories)} validate stories "
+                f"({n_live} start live containers)",
+                file=sys.stderr,
+            )
+            stories += validate_stories
+
+        # Login stories need no external dependencies, so they always run.
+        stories += build_login_stories()
 
         if args.only:
-            wanted = set(args.only)
-            stories = [s for s in stories if s.slug in wanted]
-            unknown = wanted - {s.slug for s in stories}
-            if unknown:
-                print(f"error: unknown story slug(s): {sorted(unknown)}", file=sys.stderr)
-                return 1
+            stories = [s for s in stories if selected(s.slug)]
 
         # Capture concurrently (subprocess + API roundtrips dominate), preserving
         # story order in the results list. Checks are then evaluated serially in

--- a/specs/login.txt
+++ b/specs/login.txt
@@ -34,6 +34,13 @@ file ~/.config/snouty/settings.toml 'repository = "myrepo"'
 file ~/.config/snouty/credentials.toml '\[default\]'
 file ~/.config/snouty/credentials.toml 'type = "ApiKey"'
 file ~/.config/snouty/credentials.toml 'api_key = "sk-test-key"'
+# On success it confirms what was saved, where, and the next step (so a
+# successful login is never silent). (Patterns need a regex metachar — here `.`,
+# which also matches the literal backticks — or testscript does an exact
+# whole-output match instead of a search.)
+stdout 'Saved tenant .mytenant. and repository .myrepo. to .*settings\.toml'
+stdout 'Stored your API key in .*credentials\.toml'
+stdout 'Run .snouty doctor. to verify'
 
 # 2. A second login (same $HOME) reads the values persisted by step 1 and offers
 #    them back as the default. Leaving the API key blank reuses the stored key —
@@ -75,6 +82,8 @@ isolate-home profile
 stdin login_profile.txt
 snouty --profile prod login
 ! stdout 'Hit enter to use the previous value'
+# The success summary names the profile scope.
+stdout 'under profile .prod.'
 stdin login_profile_reuse.txt
 snouty --profile prod login
 stdout '\(Hit enter to use the previous value of \[ptenant2\]\)'

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -372,11 +372,21 @@ pub fn initialize_credential_store() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn persist(credentials: PersistableCredentials, profile: Option<&str>) -> Result<()> {
+/// Where [`persist`] stored the credentials, so `snouty login` can tell the user
+/// exactly where they landed.
+pub(crate) enum CredentialStorage {
+    Keychain,
+    File(PathBuf),
+}
+
+pub(crate) fn persist(
+    credentials: PersistableCredentials,
+    profile: Option<&str>,
+) -> Result<CredentialStorage> {
     match try_persist_to_keychain(&credentials, profile) {
         Err(err) => Err(err),
-        Ok(Some(())) => Ok(()),
-        Ok(None) => persist_to_file(credentials, profile),
+        Ok(Some(())) => Ok(CredentialStorage::Keychain),
+        Ok(None) => persist_to_file(credentials, profile).map(CredentialStorage::File),
     }
 }
 
@@ -435,7 +445,7 @@ fn clear_from_file_if_present(profile: Option<&str>) {
     }
 }
 
-fn persist_to_file(credentials: PersistableCredentials, profile: Option<&str>) -> Result<()> {
+fn persist_to_file(credentials: PersistableCredentials, profile: Option<&str>) -> Result<PathBuf> {
     let (settings_dir, path) = try_get_credentials_file_path().ok_or_eyre(
         "Could not determine settings directory. Please ensure $XDG_CONFIG_HOME or $HOME is set",
     )?;
@@ -481,7 +491,7 @@ fn persist_to_file(credentials: PersistableCredentials, profile: Option<&str>) -
 
     temp.persist(&path)?;
 
-    Ok(())
+    Ok(path)
 }
 
 fn parse_credentials_file_toml(contents: String, path: &Path) -> Result<CredentialsFile> {

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,10 +1,11 @@
 use std::io::{self, IsTerminal, Write};
+use std::path::Path;
 
 use color_eyre::eyre::{Context, Result, eyre};
 
 use crate::{
     attributed_value::AttributedValue,
-    auth::{AuthenticationInfo, PersistableCredentials, persist},
+    auth::{AuthenticationInfo, CredentialStorage, PersistableCredentials, persist},
     env,
     settings::{
         ANTITHESIS_PROFILE_ENV_VAR_NAME, Settings, update_settings_in_global_file,
@@ -64,19 +65,73 @@ pub fn cmd_login(
         )?,
     };
 
-    if let Some(credentials) = prompt_for_auth(profile_to_use.as_deref())? {
-        persist(credentials, profile_to_use.as_deref())?;
-    }
+    // Capture the credential kind and where it was stored so the summary can name
+    // both; `None` when the user chose to skip credential setup.
+    let credential_summary = match prompt_for_auth(profile_to_use.as_deref())? {
+        Some(credentials) => {
+            let kind = match &credentials {
+                PersistableCredentials::ApiKey { .. } => "API key",
+                PersistableCredentials::Password { .. } => "username and password",
+            };
+            Some((kind, persist(credentials, profile_to_use.as_deref())?))
+        }
+        None => None,
+    };
 
-    update_settings_in_global_file(
-        Some(tenant_to_use),
-        Some(repository_to_use),
+    let settings_path = update_settings_in_global_file(
+        Some(tenant_to_use.clone()),
+        Some(repository_to_use.clone()),
         None,
         None,
         profile_to_use.as_deref(),
     )?;
 
+    print_login_summary(
+        &tenant_to_use,
+        &repository_to_use,
+        profile_to_use.as_deref(),
+        &settings_path,
+        credential_summary,
+    );
+
     Ok(())
+}
+
+/// Confirm what `snouty login` persisted, where, and the obvious next step —
+/// otherwise a successful login exits silently, leaving the user unsure it took.
+fn print_login_summary(
+    tenant: &str,
+    repository: &str,
+    profile: Option<&str>,
+    settings_path: &Path,
+    credentials: Option<(&str, CredentialStorage)>,
+) {
+    let scope = match profile {
+        Some(p) => format!(" under profile `{p}`"),
+        None => String::new(),
+    };
+    // Only mention what was actually recorded: a blank repository is intentionally
+    // not persisted (see `insert_key_if_non_empty` in settings.rs), so don't claim
+    // we saved one.
+    let mut saved = format!("tenant `{tenant}`");
+    if !repository.is_empty() {
+        saved.push_str(&format!(" and repository `{repository}`"));
+    }
+    println!("\nSaved {saved}{scope} to {}.", settings_path.display());
+    match credentials {
+        Some((kind, CredentialStorage::Keychain)) => {
+            println!("Stored your {kind}{scope} in the system keychain.");
+        }
+        Some((kind, CredentialStorage::File(path))) => {
+            println!("Stored your {kind}{scope} in {}.", path.display());
+        }
+        None => {
+            println!(
+                "Skipped credential storage — snouty will use the ANTITHESIS_API_KEY or ANTITHESIS_USERNAME/PASSWORD environment variables."
+            );
+        }
+    }
+    println!("Run `snouty doctor` to verify your setup.");
 }
 
 fn prompt_for_value(value_name: &str, previous_value: Option<&str>) -> Result<String> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -254,13 +254,15 @@ impl Settings {
     }
 }
 
+/// Writes the given fields into the global `settings.toml`, returning the path it
+/// wrote so callers (e.g. `snouty login`) can tell the user where it landed.
 pub(crate) fn update_settings_in_global_file(
     tenant: Option<String>,
     repository: Option<String>,
     base_url: Option<String>,
     container_engine: Option<String>,
     profile_to_update: Option<&str>,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let settings_dir = global_settings_dir().ok_or_eyre("Could not determine global settings directory. Ensure either $XDG_CONFIG_HOME or $HOME is set.")?;
     let path = settings_dir.join(GLOBAL_SETTINGS_FILENAME);
     let mut contents = match read_to_string_if_file_exists(&path)? {
@@ -311,7 +313,7 @@ pub(crate) fn update_settings_in_global_file(
 
     temp.persist(&path)?;
 
-    Ok(())
+    Ok(path)
 }
 
 fn entry_as_table_mut<'a>(table: &'a mut Table, key: &str) -> &'a mut Table {

--- a/tests/keychain_macos.rs
+++ b/tests/keychain_macos.rs
@@ -1,0 +1,219 @@
+//! Exercises `snouty login`'s **real macOS Keychain** path end-to-end.
+//!
+//! Every other test forces `SNOUTY_DISABLE_KEYCHAIN_CREDENTIAL_STORAGE=1` — the
+//! keychain "isn't something we can mock for each test case" (see
+//! `tests/spec.rs` / `tests/support/mod.rs`) — so the Security-framework path is
+//! otherwise never covered. This test drives it for real.
+//!
+//! It only runs for real on a **GitHub macOS runner**. To stay hermetic it has
+//! to redirect snouty away from the developer's `login.keychain`: snouty's store
+//! resolves the User-domain *default* keychain (`SecKeychain::default_for_domain`
+//! in `apple-native-keyring-store`), which honors
+//! `security default-keychain -d user -s`. So the test creates a throwaway
+//! keychain, points the user default at it, and restores + deletes it afterward
+//! (even on panic). Changing the machine's default keychain is why it's gated to
+//! CI — we don't want to touch a real Mac's keychain during `cargo test`. It's
+//! safe alongside the parallel test suite because every *other* test disables the
+//! keychain, so nothing else reads or writes it during the window.
+//!
+//! The body compiles on every platform (so Linux CI still type-checks it) and
+//! no-ops unless it is actually running on a macOS GitHub runner.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn security(args: &[&str]) -> Output {
+    Command::new("/usr/bin/security")
+        .args(args)
+        .output()
+        .expect("run /usr/bin/security")
+}
+
+/// Restores the user default keychain and deletes the throwaway one — even if the
+/// test panics partway through.
+struct KeychainGuard {
+    keychain: PathBuf,
+    original_default: String,
+}
+
+impl Drop for KeychainGuard {
+    fn drop(&mut self) {
+        security(&[
+            "default-keychain",
+            "-d",
+            "user",
+            "-s",
+            &self.original_default,
+        ]);
+        if let Some(path) = self.keychain.to_str() {
+            security(&["delete-keychain", path]);
+        }
+    }
+}
+
+/// Run `snouty <args>` under an isolated `$HOME`, feeding `stdin` to the prompts,
+/// with the keychain **enabled** (unlike the rest of the suite).
+fn run_snouty(home: &Path, args: &[&str], stdin: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_snouty"))
+        .args(args)
+        .env("HOME", home)
+        // Empty XDG_CONFIG_HOME is treated as unset, so settings/credentials land
+        // under our temp HOME's ~/.config/snouty rather than the runner's.
+        .env("XDG_CONFIG_HOME", "")
+        .env_remove("SNOUTY_DISABLE_KEYCHAIN_CREDENTIAL_STORAGE")
+        .env_remove("ANTITHESIS_API_KEY")
+        .env_remove("ANTITHESIS_USERNAME")
+        .env_remove("ANTITHESIS_PASSWORD")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn snouty");
+    child
+        .stdin
+        .take()
+        .expect("snouty stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write snouty stdin");
+    child.wait_with_output().expect("wait for snouty")
+}
+
+fn combined(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn login_persists_to_real_macos_keychain() {
+    // Runs for real only on a macOS GitHub runner (it mutates the machine's user
+    // default keychain, which we won't do on a developer's Mac).
+    if !cfg!(target_os = "macos") || std::env::var_os("GITHUB_ACTIONS").is_none() {
+        eprintln!("skipping real-keychain test: not a macOS GitHub Actions runner");
+        return;
+    }
+
+    let base = std::env::temp_dir().join(format!("snouty-keychain-it-{}", std::process::id()));
+    let home = base.join("home");
+    std::fs::create_dir_all(&home).expect("create temp HOME");
+    let keychain = base.join("snouty-test.keychain-db");
+    let kc = keychain.to_str().expect("keychain path utf-8");
+    let password = "snouty-test-keychain";
+
+    // Create the throwaway keychain and capture the current default before we
+    // repoint it, so the guard can put everything back.
+    assert!(
+        security(&["create-keychain", "-p", password, kc])
+            .status
+            .success(),
+        "create-keychain failed"
+    );
+    let original_default = {
+        let out = security(&["default-keychain", "-d", "user"]);
+        // Prints e.g. `    "/Users/runner/Library/Keychains/login.keychain-db"`.
+        String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .trim_matches('"')
+            .to_string()
+    };
+    // From here on, always restore the default and delete the keychain.
+    let _guard = KeychainGuard {
+        keychain: keychain.clone(),
+        original_default,
+    };
+    // No auto-lock timeout (so it can't relock mid-test), unlocked, and made the
+    // user default so snouty's store resolves to it.
+    assert!(
+        security(&["set-keychain-settings", kc]).status.success(),
+        "set-keychain-settings failed"
+    );
+    assert!(
+        security(&["unlock-keychain", "-p", password, kc])
+            .status
+            .success(),
+        "unlock-keychain failed"
+    );
+    assert!(
+        security(&["default-keychain", "-d", "user", "-s", kc])
+            .status
+            .success(),
+        "setting default keychain failed"
+    );
+
+    // --- Write an API key; it must land in the keychain, not a file. ---
+    let out = run_snouty(
+        &home,
+        &["login"],
+        "acme\nregistry.example.com/acme/app\n2\nsk-KEYCHAIN-TEST\n",
+    );
+    let text = combined(&out);
+    assert!(out.status.success(), "login failed:\n{text}");
+    assert!(
+        text.contains("in the system keychain"),
+        "login summary should name the keychain, got:\n{text}"
+    );
+    assert!(
+        !home.join(".config/snouty/credentials.toml").exists(),
+        "credentials.toml must not be written when the keychain is used"
+    );
+
+    // The credential is really in the keychain, stored as snouty's JSON blob.
+    let found = security(&[
+        "find-generic-password",
+        "-s",
+        "snouty",
+        "-a",
+        "_default_",
+        "-w",
+        kc,
+    ]);
+    assert!(found.status.success(), "credential not found in keychain");
+    let stored = String::from_utf8_lossy(&found.stdout);
+    assert!(
+        stored.contains("sk-KEYCHAIN-TEST") && stored.contains("ApiKey"),
+        "unexpected keychain payload: {stored}"
+    );
+
+    // --- Read-back: a second login reusing the stored key (all blank) succeeds
+    // only if snouty read it back out of the keychain. ---
+    let reuse = run_snouty(&home, &["login"], "\n\n\n\n");
+    let reuse_text = combined(&reuse);
+    assert!(reuse.status.success(), "reuse login failed:\n{reuse_text}");
+    assert!(
+        reuse_text.contains("in the system keychain"),
+        "reuse should still resolve/store via the keychain, got:\n{reuse_text}"
+    );
+
+    // --- Profile scoping uses a distinct keychain entry (`profile_<name>`). ---
+    let prof = run_snouty(
+        &home,
+        &["--profile", "prod", "login"],
+        "acme\nregistry.example.com/acme/app\n2\nsk-PROD-KEY\n",
+    );
+    let prof_text = combined(&prof);
+    assert!(prof.status.success(), "profile login failed:\n{prof_text}");
+    let prof_found = security(&[
+        "find-generic-password",
+        "-s",
+        "snouty",
+        "-a",
+        "profile_prod",
+        "-w",
+        kc,
+    ]);
+    assert!(
+        prof_found.status.success(),
+        "profile credential not found under `profile_prod`"
+    );
+    assert!(
+        String::from_utf8_lossy(&prof_found.stdout).contains("sk-PROD-KEY"),
+        "profile keychain entry has the wrong payload"
+    );
+
+    // Best-effort cleanup of the temp tree (the keychain itself is handled by the
+    // guard via `security delete-keychain`).
+    let _ = std::fs::remove_dir_all(&base);
+}


### PR DESCRIPTION
Based on #157 (targets `jeskew/use_keychain`, not `main`, so it stacks on the login work rather than pushing to that branch while it's in flight).

## What & why

### 1. `snouty login` confirms what it did (was silent on success)
Previously a successful `login` printed its last prompt and exited `0` with no confirmation — the user couldn't tell it worked, what changed, or the next step. The spec tests pass because they assert the *files*, not the human-facing feedback. It now prints:

```
Saved tenant `acme` and repository `registry.example.com/acme/app` to ~/.config/snouty/settings.toml.
Stored your API key in ~/.config/snouty/credentials.toml.
Run `snouty doctor` to verify your setup.
```

- Names the credential type and **where** it landed (system keychain vs `credentials.toml`), or that credential setup was skipped (env vars will be used).
- Names the **profile scope** when one is in use (`…under profile \`prod\`…`).
- Omits a blank repository (which is intentionally not persisted).

To report where credentials landed, `persist` now returns a `CredentialStorage` (`Keychain` | `File(path)`) and `update_settings_in_global_file` returns the path it wrote — both have a single caller.

### 2. `snouty login` folded into the satisfaction review + gallery
`scripts/gen-gallery.py` gains an interactive/stateful story kind: scripted stdin, a throwaway `$HOME`, seeded pre-existing state, and capture of the files login wrote (secrets redacted). Adds 8 `login-*` stories. They need no API, discovery, or container runtime, so `--only 'login-*'` skips discovery. The satisfaction-review skill documents the new transcript/persisted-state shape, reinterprets axes A–C for interactive commands, adds **Axis D (safety of a mutating command)**, and raises the width target to 140 cols.

### 3. A real macOS Keychain integration test
Every existing test forces `SNOUTY_DISABLE_KEYCHAIN_CREDENTIAL_STORAGE=1`, so the Security-framework path had zero coverage. `tests/keychain_macos.rs` drives it end-to-end on GitHub macOS runners: it creates a throwaway keychain, points the user default at it (snouty resolves `SecKeychain::default_for_domain(User)`, which honors `security default-keychain -d user -s`), runs `login`, verifies the credential is in the keychain and **not** a file, checks read-back and profile scoping, and restores + deletes the keychain via a `Drop` guard. It compiles everywhere (Linux CI type-checks it) and no-ops unless it's a macOS GitHub runner. No workflow change needed — the `macos-15-intel` matrix entry already runs `cargo nextest run`.

## Testing
`cargo fmt --check`, `cargo clippy --all-targets`, and the full test suite pass on Linux. The macOS keychain test only executes on the macOS runner (this PR's CI is where it first runs for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)