### PR TITLE
Events v2: update OpenAPI spec and add --limit to runs events

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,27 +18,28 @@ fn main() {
 
 fn generate_api_client(out_dir: &Path) {
     let file = std::fs::File::open("src/openapi.json").unwrap();
-    let mut spec_value: serde_json::Value = serde_json::from_reader(file).unwrap();
+    let spec_value: serde_json::Value = serde_json::from_reader(file).unwrap();
 
     // A schema's `additionalProperties: false` makes progenitor/typify emit
     // `#[serde(deny_unknown_fields)]`, which turns a forwards-compatible server
     // change (a new field added to a response) into a hard deserialization
     // error — e.g. `snouty doctor` would report a healthy API as "unreachable"
-    // the day `/api/version` grows a field. typify has no setting to disable
-    // this (the choice is hardwired from the schema value), so strip the
-    // constraint from the spec itself before generating, rather than patching
-    // the generated text afterwards. Removing the key is equivalent to the
-    // permissive default: no `deny_unknown_fields` is emitted, and no flattened
-    // `extra` map is added, so struct shapes are unchanged. Operating on the
-    // structured spec (not the formatted output) also handles the attribute
-    // wherever it would appear — including combined with other serde options on
-    // one line (`#[serde(rename = "…", deny_unknown_fields)]`) and on enums —
-    // which a line-text patch could silently miss.
-    let stripped = strip_additional_properties_false(&mut spec_value);
+    // the day `/api/version` grows a field. As of tenant release 58.6 the
+    // published spec no longer marks any schema `additionalProperties: false`:
+    // the server describes fully lenient schemas itself, so no transform is
+    // needed. Assert that invariant so a future spec that reintroduces the
+    // constraint fails the build loudly — prompting a conscious decision to
+    // re-add stripping — instead of silently regenerating a brittle client.
+    // The recursive scan catches the attribute wherever it appears, including on
+    // nested schemas and enums, which a line-text grep could miss.
+    let offenders = additional_properties_false_paths(&spec_value);
     assert!(
-        stripped > 0,
-        "expected the openapi spec to mark some schema `\"additionalProperties\": false`; \
-         none found — the lenient-client transform is now a no-op and can be removed"
+        offenders.is_empty(),
+        "openapi spec marks {} schema(s) `\"additionalProperties\": false`, which would \
+         make the generated client reject unknown response fields; strip them before \
+         generating (see git history for the previous transform). Offending paths: {}",
+        offenders.len(),
+        offenders.join(", ")
     );
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
@@ -54,29 +55,31 @@ fn generate_api_client(out_dir: &Path) {
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
 }
 
-/// Recursively remove every `"additionalProperties": false` from the spec so
-/// the generated client is lenient about unknown response fields (see the call
-/// site for why). Returns the number of occurrences removed.
-fn strip_additional_properties_false(value: &mut serde_json::Value) -> usize {
-    let mut count = 0;
-    match value {
-        serde_json::Value::Object(map) => {
-            if map.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
-                map.remove("additionalProperties");
-                count += 1;
+/// Recursively collect the JSON-pointer path of every `"additionalProperties":
+/// false` in the spec, so the caller can assert none exist (see the call site
+/// for why they would break the generated client).
+fn additional_properties_false_paths(value: &serde_json::Value) -> Vec<String> {
+    fn walk(value: &serde_json::Value, path: &str, out: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if map.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
+                    out.push(format!("{path}/additionalProperties"));
+                }
+                for (k, v) in map {
+                    walk(v, &format!("{path}/{k}"), out);
+                }
             }
-            for v in map.values_mut() {
-                count += strip_additional_properties_false(v);
+            serde_json::Value::Array(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    walk(v, &format!("{path}/{i}"), out);
+                }
             }
+            _ => {}
         }
-        serde_json::Value::Array(items) => {
-            for v in items.iter_mut() {
-                count += strip_additional_properties_false(v);
-            }
-        }
-        _ => {}
     }
-    count
+    let mut out = Vec::new();
+    walk(value, "", &mut out);
+    out
 }
 
 // The API represents booleans as the strings "true"/"false", but some

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -113,12 +113,13 @@ stdin moment_run_input.txt
 snouty --json debug --stdin
 stdout '\s*"runId": "run-123".*'
 
-# On API failure, the command exits with an error showing the HTTP status.
-# Launch endpoints report failures with the Launch_Error_Response envelope
-# ({ statusCode }), which carries no message text.
-mock-server 401 '{"statusCode":401}'
+# Gateway-level rejections (auth, rate limiting) on the launch/debug endpoints
+# return an EMPTY body rather than the Launch_Error_Response envelope — verified
+# against the live API, which answers a bad token with 401/403 and no payload.
+# snouty must surface that permissively instead of choking on the empty body.
+mock-server 401 ''
 ! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
-stderr 'API error: 401.*'
+stderr '.*empty response body.*'
 
 # ANTITHESIS_EXTRA_HEADERS adds arbitrary headers to every API request (for
 #    consumption by proxies). With --verbose, the merged request headers are

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -113,9 +113,10 @@ stdin moment_run_input.txt
 snouty --json debug --stdin
 stdout '\s*"runId": "run-123".*'
 
-# On API failure, the command exits with an error showing the HTTP status
-#    and response body.
-mock-server 401 '{"message": "unauthorized"}'
+# On API failure, the command exits with an error showing the HTTP status.
+# Launch endpoints report failures with the Launch_Error_Response envelope
+# ({ statusCode }), which carries no message text.
+mock-server 401 '{"statusCode":401}'
 ! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stderr 'API error: 401.*'
 

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -113,10 +113,11 @@ mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param 'antithesis.images=app@sha256:abc;db:latest'
 stderr '"antithesis.images": "app@sha256:abc;db:latest"'
 
-# On API failure, the command exits with an error showing the HTTP status.
-# Launch endpoints report failures with the Launch_Error_Response envelope
-# ({ statusCode }), which carries no message text.
-mock-server 400 '{"statusCode":400}'
+# On API failure that reaches the test launcher, the command exits with an
+# error showing the HTTP status. Such errors carry the Launch_Error_Response
+# envelope ({ statusCode, runId: null }), verified against the live API — there
+# is no message text, and runId is null once the request reaches the launcher.
+mock-server 400 '{"statusCode":400,"runId":null}'
 ! snouty launch -w basic_test --duration 30
 stderr 'API error: 400.*'
 

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -113,13 +113,15 @@ mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param 'antithesis.images=app@sha256:abc;db:latest'
 stderr '"antithesis.images": "app@sha256:abc;db:latest"'
 
-# On API failure that reaches the test launcher, the command exits with an
-# error showing the HTTP status. Such errors carry the Launch_Error_Response
-# envelope ({ statusCode, runId: null }), verified against the live API — there
-# is no message text, and runId is null once the request reaches the launcher.
-mock-server 400 '{"statusCode":400,"runId":null}'
-! snouty launch -w basic_test --duration 30
-stderr 'API error: 400.*'
+# On an error that reaches the test launcher (e.g. an unknown launcher name),
+# the command exits with an error showing the HTTP status. Such errors carry
+# the Launch_Error_Response envelope ({ statusCode, runId: null }), verified
+# against the live API — no message text, and runId is null. (The launcher does
+# no request validation beyond auth, so it never returns a 400; 404 is the
+# canonical reachable failure.)
+mock-server 404 '{"statusCode":404,"runId":null}'
+! snouty launch -w no_such_launcher --duration 30
+stderr 'API error: 404.*'
 
 # `snouty run` still works but prints a deprecation warning.
 mock-server 200 '{"runId":"run-123","statusCode":202}'

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -113,9 +113,10 @@ mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty launch -w basic_test --duration 30 --param 'antithesis.images=app@sha256:abc;db:latest'
 stderr '"antithesis.images": "app@sha256:abc;db:latest"'
 
-# On API failure, the command exits with an error showing the HTTP status
-#    and response body.
-mock-server 400 '{"message":"bad request"}'
+# On API failure, the command exits with an error showing the HTTP status.
+# Launch endpoints report failures with the Launch_Error_Response envelope
+# ({ statusCode }), which carries no message text.
+mock-server 400 '{"statusCode":400}'
 ! snouty launch -w basic_test --duration 30
 stderr 'API error: 400.*'
 

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -399,3 +399,15 @@ stderr '.*empty search term.*'
 mock-runs-server
 snouty runs events $R_run_id request
 [!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
+
+# `--limit` caps how many events the server returns. Three events match
+# parallel_driver_fetch; --limit 1 keeps only the first (vtime 400.5).
+mock-runs-server
+snouty --json runs events $R_run_id --match parallel_driver_fetch --limit 1
+[!staging] stdout '"vtime":"400\.5"'
+[!staging] ! stdout '"vtime":"401\.75"'
+
+# The default limit (50) exceeds the fixture, so all three matches come back.
+mock-runs-server
+snouty --json runs events $R_run_id --match parallel_driver_fetch
+[!staging] stdout '"vtime":"401\.75"'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -407,7 +407,7 @@ snouty --json runs events $R_run_id --match parallel_driver_fetch --limit 1
 [!staging] stdout '"vtime":"400\.5"'
 [!staging] ! stdout '"vtime":"401\.75"'
 
-# The default limit (50) exceeds the fixture, so all three matches come back.
+# Without --limit no cap is sent at all, so all three matches come back.
 mock-runs-server
 snouty --json runs events $R_run_id --match parallel_driver_fetch
 [!staging] stdout '"vtime":"401\.75"'

--- a/src/api.rs
+++ b/src/api.rs
@@ -392,15 +392,21 @@ impl AntithesisApi {
         })
     }
 
-    pub async fn search_run_events(&self, run_id: &str, query: &str) -> Result<ByteStream> {
-        match self
+    pub async fn search_run_events(
+        &self,
+        run_id: &str,
+        query: &str,
+        limit: u16,
+    ) -> Result<ByteStream> {
+        // The endpoint caps the returned events at `limit`; the CLI always
+        // supplies one (defaulting to 50), and the server validates the range.
+        let request = self
             .client
             .search_run_events()
             .run_id(run_id)
             .q(query)
-            .send()
-            .await
-        {
+            .limit(u64::from(limit));
+        match request.send().await {
             Ok(response) => Ok(response.into_inner()),
             Err(err) => Err(format_api_client_error(err).await),
         }
@@ -1932,7 +1938,7 @@ mod tests {
         let api = test_api_optionally_with_cache(&mock_server, None);
 
         let mut stream = api
-            .search_run_events("run-1", "slow request")
+            .search_run_events("run-1", "slow request", 50)
             .await
             .unwrap()
             .into_inner();
@@ -1943,6 +1949,23 @@ mod tests {
         let body = String::from_utf8(body).unwrap();
 
         assert!(body.contains("slow request"));
+    }
+
+    #[tokio::test]
+    async fn search_run_events_forwards_limit() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/events"))
+            .and(query_param("q", "slow"))
+            .and(query_param("limit", "5"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = test_api_optionally_with_cache(&mock_server, None);
+        api.search_run_events("run-1", "slow", 5).await.unwrap();
     }
 
     fn rid(version: u32) -> String {

--- a/src/api.rs
+++ b/src/api.rs
@@ -248,31 +248,30 @@ impl AntithesisApi {
     pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
         let body = launch_mvd_request(params)?;
         match self.client.launch_mvd().body(body).send().await {
-            // Documented 202 whose body is the spec shape (`{ "run_id": ... }`):
-            // the generated client parsed it into `LaunchMvdResponse` for us.
-            // Normalize to the `runId`/`statusCode` envelope the live API uses
-            // (and that `snouty launch` emits) so `--json` output is consistent.
-            Ok(response) => Ok(LaunchResponse {
-                run_id: response.into_inner().run_id,
-                status_code: 202,
-            }),
             // Documented 202 whose body is the live `{ "runId", "statusCode" }`
-            // envelope: the generated client expected the spec's snake_case
-            // `run_id` and rejected the camelCase body as an invalid payload.
-            //
-            // Unlike `UnexpectedResponse` below, this variant carries no HTTP
-            // status (`ClientError::status()` is `None`), so we can't gate on
-            // `is_success()`. A documented *error* whose body fails `ErrorResponse`
-            // parsing (e.g. a 4xx that omits the required `message`) also lands
-            // here, so blindly trusting it would let an error masquerade as
-            // success. Lean on this webhook reporting its real status in the
-            // body: recover only when the body itself reports a 2xx, and fall
-            // back to the standard error path otherwise.
+            // envelope: the spec now models exactly that shape, so the generated
+            // client parses it into `LaunchMvdResponse` for us. Carry the body's
+            // own `statusCode` through rather than assuming 202.
+            Ok(response) => {
+                let response = response.into_inner();
+                Ok(LaunchResponse {
+                    run_id: response.run_id,
+                    status_code: response.status_code,
+                })
+            }
+            // A body that fails to parse as `LaunchMvdResponse` lands here. This
+            // variant carries no HTTP status (`ClientError::status()` is `None`),
+            // so we can't gate on `is_success()`. A documented *error* whose body
+            // fails `LaunchErrorResponse` parsing also lands here, so blindly
+            // trusting it would let an error masquerade as success. Lean on this
+            // webhook reporting its real status in the body: recover only when the
+            // body itself reports a 2xx, and fall back to the standard error path
+            // otherwise.
             Err(ClientError::InvalidResponsePayload(body, source)) => {
                 match parse_debug_launch_body(&body) {
                     Ok((run_id, Some(status_code))) if (200..300).contains(&status_code) => {
                         Ok(LaunchResponse {
-                            run_id,
+                            run_id: Some(run_id),
                             status_code,
                         })
                     }
@@ -295,7 +294,7 @@ impl AntithesisApi {
                     .wrap_err("reading debug launch response")?;
                 let (run_id, status_code) = parse_debug_launch_body(&body)?;
                 Ok(LaunchResponse {
-                    run_id,
+                    run_id: Some(run_id),
                     status_code: status_code.unwrap_or(202),
                 })
             }
@@ -792,7 +791,7 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
 async fn finish_launch<T>(
     result: std::result::Result<
         progenitor_client::ResponseValue<T>,
-        ClientError<generated::types::ErrorResponse>,
+        ClientError<generated::types::LaunchErrorResponse>,
     >,
     from_body: impl FnOnce(serde_json::Value) -> Result<T>,
 ) -> Result<T> {
@@ -1034,11 +1033,23 @@ fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
 }
 
 async fn format_api_client_error(err: ClientError<generated::types::ErrorResponse>) -> Report {
+    format_client_error(err, |body| body.message).await
+}
+
+/// Core error formatter shared across endpoints. The only endpoint-specific bit
+/// is how a documented error body yields a human message: the standard
+/// endpoints carry it in `Error_Response.message`, while the launch webhooks use
+/// the message-less `Launch_Error_Response` envelope (status code only). Callers
+/// supply that projection via `body_message`.
+async fn format_client_error<T>(
+    err: ClientError<T>,
+    body_message: impl FnOnce(T) -> String,
+) -> Report {
     match err {
         ClientError::ErrorResponse(response) => {
             let status = response.status().as_u16();
             let body = response.into_inner();
-            format_api_error(status, &body.message)
+            format_api_error(status, &body_message(body))
         }
         ClientError::UnexpectedResponse(response) => {
             let status = response.status().as_u16();
@@ -1071,13 +1082,17 @@ async fn format_api_client_error(err: ClientError<generated::types::ErrorRespons
 /// when the server returned an empty body where a launch response (with
 /// `run_id`) was expected. Call from launch_test / launch_debugging only —
 /// other endpoints have their own meaningful responses for empty bodies.
-async fn format_launch_client_error(err: ClientError<generated::types::ErrorResponse>) -> Report {
+async fn format_launch_client_error(
+    err: ClientError<generated::types::LaunchErrorResponse>,
+) -> Report {
     let body_is_empty = matches!(
         &err,
         ClientError::InvalidResponsePayload(body, _)
             if body.iter().all(u8::is_ascii_whitespace)
     );
-    let report = format_api_client_error(err).await;
+    // Launch_Error_Response carries no message field — only a status code that
+    // already matches the HTTP status — so there is nothing to project.
+    let report = format_client_error(err, |_body| String::new()).await;
     if body_is_empty {
         report.with_suggestion(|| {
             "this can happen when the Antithesis server is on an older version that omits expected fields (for example, run_id from a launch response). Contact Antithesis support to confirm whether your tenant needs to be upgraded."
@@ -1258,7 +1273,7 @@ mod tests {
     #[tokio::test]
     async fn format_launch_client_error_attaches_suggestion_for_empty_body() {
         let parse_err = serde_json::from_slice::<serde_json::Value>(b"").unwrap_err();
-        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+        let err = ClientError::<generated::types::LaunchErrorResponse>::InvalidResponsePayload(
             Default::default(),
             parse_err,
         );
@@ -1280,7 +1295,7 @@ mod tests {
     async fn format_launch_client_error_skips_suggestion_for_non_empty_body() {
         let body: &[u8] = b"not json";
         let parse_err = serde_json::from_slice::<serde_json::Value>(body).unwrap_err();
-        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
+        let err = ClientError::<generated::types::LaunchErrorResponse>::InvalidResponsePayload(
             body.to_vec().into(),
             parse_err,
         );
@@ -1436,7 +1451,7 @@ mod tests {
         let response = api.launch_test("basic_test", &params).await.unwrap();
         let requests = mock_server.received_requests().await.unwrap();
 
-        assert_eq!(response.run_id, "run-123");
+        assert_eq!(response.run_id.as_deref(), Some("run-123"));
         assert_eq!(response.status_code, 202);
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].url.path(), "/api/v1/launch/basic_test");
@@ -1480,7 +1495,7 @@ mod tests {
         let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
 
         let response = api.launch_test("basic_test", &params).await.unwrap();
-        assert_eq!(response.run_id, "run-123");
+        assert_eq!(response.run_id.as_deref(), Some("run-123"));
         assert_eq!(response.status_code, 202);
     }
 
@@ -1507,9 +1522,12 @@ mod tests {
         .unwrap();
 
         let response = api.launch_debugging(&params).await.unwrap();
-        assert_eq!(response.run_id, "debug-run-123");
+        assert_eq!(response.run_id.as_deref(), Some("debug-run-123"));
     }
 
+    // The documented 202 body and the live webhook envelope have converged on
+    // `{ statusCode, runId }`, which the generated client parses directly. We
+    // carry the body's own status code through rather than assuming 202.
     #[tokio::test]
     async fn launch_debugging_accepts_202_documented() {
         let mock_server = MockServer::start().await;
@@ -1517,36 +1535,8 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/api/v1/launch/debugging"))
             .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
-                "run_id": "debug-run-456"
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let api = test_api_optionally_with_cache(&mock_server, None);
-        let params = Params::from_key_value_pairs([
-            "antithesis.debugging.run_id=a2a4-53-1",
-            "antithesis.debugging.input_hash=-1",
-            "antithesis.debugging.vtime=1.0",
-        ])
-        .unwrap();
-
-        let response = api.launch_debugging(&params).await.unwrap();
-        assert_eq!(response.run_id, "debug-run-456");
-    }
-
-    // If the webhook is corrected to return the documented 202 while keeping the
-    // live `{ runId, statusCode }` envelope, the generated client rejects the
-    // camelCase body as an invalid payload. We must still recover the run id.
-    #[tokio::test]
-    async fn launch_debugging_accepts_202_live_envelope() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/debugging"))
-            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
                 "statusCode": 202,
-                "runId": "debug-run-789"
+                "runId": "debug-run-456"
             })))
             .expect(1)
             .mount(&mock_server)
@@ -1561,15 +1551,14 @@ mod tests {
         .unwrap();
 
         let response = api.launch_debugging(&params).await.unwrap();
-        assert_eq!(response.run_id, "debug-run-789");
+        assert_eq!(response.run_id.as_deref(), Some("debug-run-456"));
         assert_eq!(response.status_code, 202);
     }
 
-    // A documented error status whose body fails `ErrorResponse` parsing (here a
-    // 403 that omits the required `message`) also surfaces as
-    // `InvalidResponsePayload` — which carries no HTTP status. An error body that
-    // happens to carry a runId must not be mistaken for success: the body's own
-    // statusCode gates it, so this stays an error.
+    // A documented error status carries the `Launch_Error_Response` envelope
+    // (`{ statusCode, runId }`). Its `runId` is informational only and must never
+    // be mistaken for a successful launch: the non-2xx HTTP status keeps this an
+    // error even though the body parses cleanly.
     #[tokio::test]
     async fn launch_debugging_rejects_error_body_carrying_run_id() {
         let mock_server = MockServer::start().await;

--- a/src/api.rs
+++ b/src/api.rs
@@ -271,7 +271,7 @@ impl AntithesisApi {
                 match parse_debug_launch_body(&body) {
                     Ok((run_id, Some(status_code))) if (200..300).contains(&status_code) => {
                         Ok(LaunchResponse {
-                            run_id: Some(run_id),
+                            run_id,
                             status_code,
                         })
                     }
@@ -294,7 +294,7 @@ impl AntithesisApi {
                     .wrap_err("reading debug launch response")?;
                 let (run_id, status_code) = parse_debug_launch_body(&body)?;
                 Ok(LaunchResponse {
-                    run_id: Some(run_id),
+                    run_id,
                     status_code: status_code.unwrap_or(202),
                 })
             }
@@ -396,7 +396,7 @@ impl AntithesisApi {
         &self,
         run_id: &str,
         query: &str,
-        limit: u16,
+        limit: usize,
     ) -> Result<ByteStream> {
         // The endpoint caps the returned events at `limit`; the CLI always
         // supplies one (defaulting to 50), and the server validates the range.
@@ -405,7 +405,7 @@ impl AntithesisApi {
             .search_run_events()
             .run_id(run_id)
             .q(query)
-            .limit(u64::from(limit));
+            .limit(limit as u64);
         match request.send().await {
             Ok(response) => Ok(response.into_inner()),
             Err(err) => Err(format_api_client_error(err).await),
@@ -820,17 +820,18 @@ async fn finish_launch<T>(
 /// `status_code` is the body's own `statusCode`, if present. This webhook family
 /// reports its real status in the body rather than (only) the HTTP status line,
 /// which lets a caller that has lost the transport status still tell a success
-/// envelope from an error one. Errors if the body isn't JSON or carries no run
-/// id.
-fn parse_debug_launch_body(body: &[u8]) -> Result<(String, Option<i64>)> {
+/// envelope from an error one. Errors only if the body isn't JSON: a missing
+/// `run_id`/`runId` yields `None`, matching the generated `LaunchMvdResponse`
+/// deserializer the documented-202 path relies on (the tenant-58.6 schema makes
+/// the field optional) so both paths agree on a run-id-less success body.
+fn parse_debug_launch_body(body: &[u8]) -> Result<(Option<String>, Option<i64>)> {
     let value: serde_json::Value =
         serde_json::from_slice(body).wrap_err("parsing debug launch response")?;
     let run_id = value
         .get("run_id")
         .or_else(|| value.get("runId"))
         .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| eyre!("debug launch response missing run_id/runId: {value}"))?
-        .to_string();
+        .map(str::to_string);
     let status_code = value.get("statusCode").and_then(serde_json::Value::as_i64);
     Ok((run_id, status_code))
 }
@@ -1119,7 +1120,7 @@ mod tests {
     #[test]
     fn parse_debug_launch_body_reads_snake_case_run_id() {
         let (run_id, status) = parse_debug_launch_body(br#"{"run_id":"abc-1"}"#).unwrap();
-        assert_eq!(run_id, "abc-1");
+        assert_eq!(run_id.as_deref(), Some("abc-1"));
         assert_eq!(status, None);
     }
 
@@ -1127,13 +1128,17 @@ mod tests {
     fn parse_debug_launch_body_reads_camel_case_run_id_and_status_code() {
         let (run_id, status) =
             parse_debug_launch_body(br#"{"runId":"xyz-2","statusCode":202}"#).unwrap();
-        assert_eq!(run_id, "xyz-2");
+        assert_eq!(run_id.as_deref(), Some("xyz-2"));
         assert_eq!(status, Some(202));
     }
 
+    // The tenant-58.6 schema makes runId optional, so a success body may omit it.
+    // Both parsing paths must treat that as run_id: None, not a hard error.
     #[test]
-    fn parse_debug_launch_body_errors_without_a_run_id() {
-        assert!(parse_debug_launch_body(br#"{"statusCode":200}"#).is_err());
+    fn parse_debug_launch_body_tolerates_missing_run_id() {
+        let (run_id, status) = parse_debug_launch_body(br#"{"statusCode":202}"#).unwrap();
+        assert_eq!(run_id, None);
+        assert_eq!(status, Some(202));
     }
 
     #[test]
@@ -1529,6 +1534,36 @@ mod tests {
 
         let response = api.launch_debugging(&params).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("debug-run-123"));
+    }
+
+    // A success body may legally omit runId under the tenant-58.6 schema. When it
+    // arrives via the undocumented-200 fallback path (not the documented-202
+    // deserializer), we must still accept it as success with run_id: None rather
+    // than hard-erroring on the missing field.
+    #[tokio::test]
+    async fn launch_debugging_accepts_200_without_run_id() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/debugging"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "statusCode": 202 })),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = test_api_optionally_with_cache(&mock_server, None);
+        let params = Params::from_key_value_pairs([
+            "antithesis.debugging.run_id=a2a4-53-1",
+            "antithesis.debugging.input_hash=-1",
+            "antithesis.debugging.vtime=1.0",
+        ])
+        .unwrap();
+
+        let response = api.launch_debugging(&params).await.unwrap();
+        assert_eq!(response.run_id, None);
+        assert_eq!(response.status_code, 202);
     }
 
     // The documented 202 body and the live webhook envelope have converged on

--- a/src/api.rs
+++ b/src/api.rs
@@ -1086,9 +1086,10 @@ async fn format_client_error<T>(
 }
 
 /// Same as [`format_api_client_error`] but adds a launch-specific suggestion
-/// when the server returned an empty body where a launch response (with
-/// `run_id`) was expected. Call from launch_test / launch_debugging only —
-/// other endpoints have their own meaningful responses for empty bodies.
+/// when the server returned an empty body. The launch/debug endpoints answer
+/// some gateway-level rejections (auth, rate limiting) with no payload at all,
+/// so the empty body is expected there. Call from launch_test / launch_debugging
+/// only — other endpoints have their own meaningful responses for empty bodies.
 async fn format_launch_client_error(
     err: ClientError<generated::types::LaunchErrorResponse>,
 ) -> Report {
@@ -1102,7 +1103,7 @@ async fn format_launch_client_error(
     let report = format_client_error(err, |_body| String::new()).await;
     if body_is_empty {
         report.with_suggestion(|| {
-            "this can happen when the Antithesis server is on an older version that omits expected fields (for example, run_id from a launch response). Contact Antithesis support to confirm whether your tenant needs to be upgraded."
+            "the launch endpoints return an empty body for some gateway-level rejections (for example authentication or rate limiting). Check that your credentials are valid and have access to this tenant; if the problem persists, contact Antithesis support."
         })
     } else {
         report
@@ -1297,8 +1298,8 @@ mod tests {
             "expected launch-specific suggestion, got: {debug}"
         );
         assert!(
-            debug.contains("run_id from a launch response"),
-            "expected run_id wording in suggestion, got: {debug}"
+            debug.contains("authentication or rate limiting"),
+            "expected gateway-rejection wording in suggestion, got: {debug}"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -401,7 +401,7 @@ impl AntithesisApi {
         // The endpoint caps the returned events at `limit`. Only send the
         // parameter when the user asked for one: tenants that predate it would
         // otherwise receive a query param they may not accept, and omitting it
-        // lets the server apply its own default. The server validates the range.
+        // lets the server apply its default. The server validates the range.
         let mut request = self.client.search_run_events().run_id(run_id).q(query);
         if let Some(limit) = limit {
             request = request.limit(limit as u64);

--- a/src/api.rs
+++ b/src/api.rs
@@ -396,16 +396,16 @@ impl AntithesisApi {
         &self,
         run_id: &str,
         query: &str,
-        limit: usize,
+        limit: Option<usize>,
     ) -> Result<ByteStream> {
-        // The endpoint caps the returned events at `limit`; the CLI always
-        // supplies one (defaulting to 50), and the server validates the range.
-        let request = self
-            .client
-            .search_run_events()
-            .run_id(run_id)
-            .q(query)
-            .limit(limit as u64);
+        // The endpoint caps the returned events at `limit`. Only send the
+        // parameter when the user asked for one: tenants that predate it would
+        // otherwise receive a query param they may not accept, and omitting it
+        // lets the server apply its own default. The server validates the range.
+        let mut request = self.client.search_run_events().run_id(run_id).q(query);
+        if let Some(limit) = limit {
+            request = request.limit(limit as u64);
+        }
         match request.send().await {
             Ok(response) => Ok(response.into_inner()),
             Err(err) => Err(format_api_client_error(err).await),
@@ -1974,7 +1974,7 @@ mod tests {
         let api = test_api_optionally_with_cache(&mock_server, None);
 
         let mut stream = api
-            .search_run_events("run-1", "slow request", 50)
+            .search_run_events("run-1", "slow request", None)
             .await
             .unwrap()
             .into_inner();
@@ -2001,7 +2001,28 @@ mod tests {
             .await;
 
         let api = test_api_optionally_with_cache(&mock_server, None);
-        api.search_run_events("run-1", "slow", 5).await.unwrap();
+        api.search_run_events("run-1", "slow", Some(5))
+            .await
+            .unwrap();
+    }
+
+    // Tenants that predate the `limit` parameter must not receive it, so an
+    // unset `--limit` leaves the query param off entirely.
+    #[tokio::test]
+    async fn search_run_events_omits_limit_when_unset() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/runs/run-1/events"))
+            .and(query_param("q", "slow"))
+            .and(query_param_is_missing("limit"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let api = test_api_optionally_with_cache(&mock_server, None);
+        api.search_run_events("run-1", "slow", None).await.unwrap();
     }
 
     fn rid(version: u32) -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -599,10 +599,10 @@ and VTIME into `runs logs` to see the surrounding logs."#
         #[arg(short = 'm', long = "match")]
         matches: Vec<String>,
 
-        /// Maximum number of events the server returns (1-999). Raise it to make
-        /// a search more exhaustive.
+        /// Maximum number of events the server returns. Raise it to make a
+        /// search more exhaustive. The server enforces the accepted range.
         #[arg(short = 'n', long, default_value = "50")]
-        limit: u16,
+        limit: usize,
 
         /// Substrings to match, as a positional alias for `-m` (all must match).
         /// At least one needle (via `-m` or here) is required.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -599,6 +599,11 @@ and VTIME into `runs logs` to see the surrounding logs."#
         #[arg(short = 'm', long = "match")]
         matches: Vec<String>,
 
+        /// Maximum number of events the server returns (1-999). Raise it to make
+        /// a search more exhaustive.
+        #[arg(short = 'n', long, default_value = "50")]
+        limit: u16,
+
         /// Substrings to match, as a positional alias for `-m` (all must match).
         /// At least one needle (via `-m` or here) is required.
         query: Vec<String>,
@@ -766,5 +771,30 @@ mod tests {
         };
         assert!(matches.is_empty());
         assert_eq!(query, vec!["request".to_string(), "slow".to_string()]);
+    }
+
+    // `runs events --limit` defaults to 50 and otherwise takes the given value.
+    // Range checking is left to the server, so clap accepts any u16.
+    #[test]
+    fn events_limit_defaults_and_parses() {
+        let cli = parse(&["snouty", "runs", "events", "RUN", "-m", "request"]);
+        let Commands::Runs {
+            command: Some(RunsCommands::Events { limit, .. }),
+        } = cli.command
+        else {
+            panic!("expected `runs events`");
+        };
+        assert_eq!(limit, 50);
+
+        let cli = parse(&[
+            "snouty", "runs", "events", "RUN", "-m", "x", "--limit", "999",
+        ]);
+        let Commands::Runs {
+            command: Some(RunsCommands::Events { limit, .. }),
+        } = cli.command
+        else {
+            panic!("expected `runs events`");
+        };
+        assert_eq!(limit, 999);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -599,10 +599,11 @@ and VTIME into `runs logs` to see the surrounding logs."#
         #[arg(short = 'm', long = "match")]
         matches: Vec<String>,
 
-        /// Maximum number of events the server returns. Raise it to make a
-        /// search more exhaustive. The server enforces the accepted range.
-        #[arg(short = 'n', long, default_value = "50")]
-        limit: usize,
+        /// Maximum number of events the server returns (default: the server's
+        /// own, currently 50). Raise it to make a search more exhaustive. The
+        /// server enforces the accepted range.
+        #[arg(short = 'n', long)]
+        limit: Option<usize>,
 
         /// Substrings to match, as a positional alias for `-m` (all must match).
         /// At least one needle (via `-m` or here) is required.
@@ -773,10 +774,11 @@ mod tests {
         assert_eq!(query, vec!["request".to_string(), "slow".to_string()]);
     }
 
-    // `runs events --limit` defaults to 50 and otherwise takes the given value.
-    // Range checking is left to the server, so clap accepts any u16.
+    // `runs events --limit` is unset unless given (so the parameter is left off
+    // the request entirely) and otherwise takes the given value. Range checking
+    // is left to the server, so clap accepts any usize.
     #[test]
-    fn events_limit_defaults_and_parses() {
+    fn events_limit_is_unset_by_default_and_parses() {
         let cli = parse(&["snouty", "runs", "events", "RUN", "-m", "request"]);
         let Commands::Runs {
             command: Some(RunsCommands::Events { limit, .. }),
@@ -784,7 +786,7 @@ mod tests {
         else {
             panic!("expected `runs events`");
         };
-        assert_eq!(limit, 50);
+        assert_eq!(limit, None);
 
         let cli = parse(&[
             "snouty", "runs", "events", "RUN", "-m", "x", "--limit", "999",
@@ -795,6 +797,6 @@ mod tests {
         else {
             panic!("expected `runs events`");
         };
-        assert_eq!(limit, 999);
+        assert_eq!(limit, Some(999));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -599,9 +599,9 @@ and VTIME into `runs logs` to see the surrounding logs."#
         #[arg(short = 'm', long = "match")]
         matches: Vec<String>,
 
-        /// Maximum number of events the server returns (default: the server's
-        /// own, currently 50). Raise it to make a search more exhaustive. The
-        /// server enforces the accepted range.
+        /// Maximum number of events the server returns (default 50). Raise it
+        /// to make a search more exhaustive. The server enforces the accepted
+        /// range.
         #[arg(short = 'n', long)]
         limit: Option<usize>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,10 @@ async fn cmd_launch(
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
-        println!("Test run started: run_id {}", response.run_id);
+        println!(
+            "Test run started: run_id {}",
+            response.run_id.as_deref().unwrap_or("(unknown)")
+        );
     }
 
     Ok(())
@@ -364,7 +367,10 @@ async fn cmd_debug(args: DebugArgs, settings: &Settings, json: bool, verbose: bo
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
-        println!("Debugging session started: run_id {}", response.run_id);
+        println!(
+            "Debugging session started: run_id {}",
+            response.run_id.as_deref().unwrap_or("(unknown)")
+        );
     }
 
     Ok(())

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -48,12 +48,14 @@
         "operationId": "listRuns",
         "summary": "List all test runs",
         "description": "Returns a paginated list of test runs. Results are ordered by creation time, newest first.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of results to return. Server-capped at 100.",
+            "description": "Maximum number of results to return. Must be between 1 and 100; values outside this range return 400 Bad Request.",
             "required": false,
             "schema": {
               "type": "integer",
@@ -198,7 +200,9 @@
         "operationId": "getRun",
         "summary": "Get test run details",
         "description": "Returns the full details of a single test run, including results.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "run_id",
@@ -314,7 +318,9 @@
         "operationId": "getRunLogs",
         "summary": "Get logs for a specific moment",
         "description": "Streams the logs for a moment in the test run as newline-delimited JSON (NDJSON) in chronological order. Each line is a self-contained JSON object. The response is streamed and the connection remains open until all matching log lines have been sent.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "run_id",
@@ -456,7 +462,9 @@
         "operationId": "getRunBuildLogs",
         "summary": "Stream build logs",
         "description": "Streams the build logs for a test run as newline-delimited JSON (NDJSON). Each line contains a timestamp, a stream indicator, and the log text. The response is streamed and the connection remains open until all matching log lines have been sent.\n\n**Known limitation:** Build logs are not available for test runs created before Antithesis version 54.5. Requests for such runs return `404 Not Found`.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "run_id",
@@ -476,7 +484,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/Build_Log_Line"
                 },
-                "example": "{\"timestamp\":\"2026-05-14T03:03:23.481Z\",\"text\":\"\",\"stream\":\"stdout\"}\n{\"timestamp\":\"2026-05-14T03:03:24.668Z\",\"text\":\"About to wait for the flock. If the script is hanging here, somebody else is doing a build.\",\"stream\":\"stdout\"}"
+                "example": {
+                  "timestamp": "2026-05-14T03:03:24.668Z",
+                  "text": "About to wait for the flock. If the script is hanging here, somebody else is doing a build.",
+                  "stream": "stdout"
+                }
               }
             }
           },
@@ -512,7 +524,9 @@
         "operationId": "listRunProperties",
         "summary": "List test run properties",
         "description": "Returns a paginated list of property results for a test run, including both passing and failing properties by default. Use the `status` parameter to filter by a specific status.\n\n**Known limitation:** Property results are not available for test runs created before Antithesis version 54.5. Requests for such runs return `404 Not Found`.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "run_id",
@@ -535,7 +549,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Maximum number of results to return. Server-capped at 100.",
+            "description": "Maximum number of results to return. Must be between 1 and 100; values outside this range return 400 Bad Request.",
             "required": false,
             "schema": {
               "type": "integer",
@@ -587,17 +601,17 @@
                       "counterexamples": []
                     },
                     {
-                        "name": "Input count",
-                        "description": null,
-                        "status": "Passing",
-                        "is_event": false,
-                        "is_group": false,
-                        "example_count": 1,
-                        "counterexample_count": 0,
-                        "examples": [
-                            318446
-                        ],
-                        "counterexamples": []
+                      "name": "Input count",
+                      "description": null,
+                      "status": "Passing",
+                      "is_event": false,
+                      "is_group": false,
+                      "example_count": 1,
+                      "counterexample_count": 0,
+                      "examples": [
+                        318446
+                      ],
+                      "counterexamples": []
                     }
                   ]
                 }
@@ -636,7 +650,9 @@
         "operationId": "searchRunEvents",
         "summary": "Search run events",
         "description": "Searches events in a test run for the given query string. The search matches against output text, assertion messages, function names, and test composer commands. Results are streamed as newline-delimited JSON (NDJSON). Each line is a self-contained JSON object representing an event.",
-        "tags": ["Test runs"],
+        "tags": [
+          "Test runs"
+        ],
         "parameters": [
           {
             "name": "run_id",
@@ -650,10 +666,23 @@
           {
             "name": "q",
             "in": "query",
-            "description": "The search term. Matches events where this string is contained in the output text, assertion message, function name, or test command.",
-            "required": true,
+            "description": "The search term. Matches events where this string is contained in the output text, assertion message, function name, or test command. When omitted, defaults to an empty string, which matches all events.",
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return. Must be between 1 and 999. Defaults to 50.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 999
             }
           }
         ],
@@ -665,7 +694,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/Event"
                 },
-                "example": "{\"moment\":{\"input_hash\":\"-2978388909754056022\",\"vtime\":22.66615231265314},\"IPT_bytes_out\":1073904,\"source\":{\"command_id\":\"BSPID1ERCnmoGEnk6WjwIZ4o3TM\",\"name\":\"setup\",\"stream\":\"info\"},\"output_text\":\"3:08:17AM:     ^ Pending: ContainerCreating\"}\n{\"moment\":{\"input_hash\":\"-2978388909754056022\",\"vtime\":22.6661523131188},\"IPT_bytes_out\":1074064,\"source\":{\"command_id\":\"BSPID1ERCnmoGEnk6WjwIZ4o3TM\",\"name\":\"setup\",\"stream\":\"info\"},\"output_text\":\"3:08:17AM:     ^ Pending: ContainerCreating\"}"
+                "example": {
+                  "moment": {
+                    "input_hash": "-2978388909754056022",
+                    "vtime": "22.66615231265314"
+                  },
+                  "IPT_bytes_out": 1073904,
+                  "source": {
+                    "command_id": "BSPID1ERCnmoGEnk6WjwIZ4o3TM",
+                    "name": "setup",
+                    "stream": "info"
+                  },
+                  "output_text": "3:08:17AM:     ^ Pending: ContainerCreating"
+                }
               }
             }
           },
@@ -701,7 +742,9 @@
         "operationId": "launchTest",
         "summary": "Launch a test",
         "description": "Kicks off a test using the specified launcher (e.g. `basic_test` or `basic_k8s_test`). Fetches the relevant container images specified in configuration files and in `antithesis.images`, builds the test environment, and runs the test for the duration set in `antithesis.duration`. Returns an HTTP status code indicating whether the test was successfully started (not the test result itself).",
-        "tags": ["Launch"],
+        "tags": [
+          "Launch"
+        ],
         "parameters": [
           {
             "name": "launcher_name",
@@ -740,35 +783,37 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/Legacy_BadRequest"
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Legacy_Unauthorized"
           },
           "403": {
-            "$ref": "#/components/responses/Forbidden"
+            "$ref": "#/components/responses/Legacy_Forbidden"
           },
           "404": {
-            "$ref": "#/components/responses/NotFound"
+            "$ref": "#/components/responses/Legacy_NotFound"
           },
           "405": {
-            "$ref": "#/components/responses/MethodNotAllowed"
+            "$ref": "#/components/responses/Legacy_MethodNotAllowed"
           },
           "406": {
-            "$ref": "#/components/responses/NotAcceptable"
+            "$ref": "#/components/responses/Legacy_NotAcceptable"
           },
           "429": {
-            "$ref": "#/components/responses/TooManyRequests"
+            "$ref": "#/components/responses/Legacy_TooManyRequests"
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/Legacy_InternalError"
           }
         }
       }
     },
     "/api/version": {
       "get": {
-        "tags": ["Version"],
+        "tags": [
+          "Version"
+        ],
         "operationId": "getVersion",
         "summary": "Get API and release version",
         "description": "Returns the latest supported API version and the current Antithesis release version for the tenant.",
@@ -786,6 +831,18 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
           }
         }
       }
@@ -796,9 +853,10 @@
         "operationId": "launchMvd",
         "summary": "Launch a debugging session",
         "description": "Kicks off a multiverse debugging session that'll be available for six hours. Returns an HTTP status code indicating whether the debugging session request was successfully accepted and the session is getting ready.\n\nThe target test run is identified by `antithesis.debugging.run_id`. For backwards compatibility, `antithesis.debugging.session_id` is also accepted — prefer `run_id` for new integrations.",
-        "tags": ["Launch"],
-        "parameters": [
+        "tags": [
+          "Launch"
         ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -849,53 +907,41 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/Legacy_BadRequest"
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Legacy_Unauthorized"
           },
           "403": {
-            "$ref": "#/components/responses/Forbidden"
+            "$ref": "#/components/responses/Legacy_Forbidden"
           },
           "404": {
-            "$ref": "#/components/responses/NotFound"
+            "$ref": "#/components/responses/Legacy_NotFound"
           },
           "405": {
-            "$ref": "#/components/responses/MethodNotAllowed"
+            "$ref": "#/components/responses/Legacy_MethodNotAllowed"
           },
           "406": {
-            "$ref": "#/components/responses/NotAcceptable"
+            "$ref": "#/components/responses/Legacy_NotAcceptable"
           },
           "429": {
-            "$ref": "#/components/responses/TooManyRequests"
+            "$ref": "#/components/responses/Legacy_TooManyRequests"
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/Legacy_InternalError"
           }
         }
       }
     }
   },
   "components": {
-    "parameters": {
-      "Version": {
-        "name": "version",
-        "in": "path",
-        "description": "API version identifier. Use `v0` for preview APIs (may change without notice) or `v1` for the stable, compatibility-committed version. See the [Versioning section](/docs/rest_api/#versioning) for the full policy.",
-        "required": true,
-        "schema": {
-          "type": "string",
-          "enum": ["v0", "v1"],
-          "default": "v1",
-          "example": "v1"
-        }
-      }
-    },
     "schemas": {
       "Error_Response": {
         "type": "object",
         "description": "Standard error envelope returned by all error responses.",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "properties": {
           "message": {
             "type": "string",
@@ -903,12 +949,14 @@
             "example": "limit must be between 1 and 100"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Run_List_Response": {
         "type": "object",
         "description": "A page of test run summaries returned by the list endpoint. Use `next_cursor` to iterate through all available results.",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -925,7 +973,12 @@
       },
       "Run_Summary": {
         "type": "object",
-        "required": ["run_id", "status", "created_at", "launcher"],
+        "required": [
+          "run_id",
+          "status",
+          "created_at",
+          "launcher"
+        ],
         "properties": {
           "run_id": {
             "type": "string",
@@ -1026,10 +1079,14 @@
       "Launch_Response": {
         "type": "object",
         "description": "Response returned when a test is successfully launched.",
-        "required": ["runId", "statusCode"],
+        "required": [
+          "runId",
+          "statusCode"
+        ],
         "properties": {
           "runId": {
             "type": "string",
+            "nullable": true,
             "description": "Unique identifier for the launched run.",
             "example": "c8d2f4a6e0b3197d5f8a2c4e6b0d3f79-49-1"
           },
@@ -1039,12 +1096,15 @@
             "example": 200
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Version_Response": {
         "type": "object",
         "description": "Version information returned by the version endpoint.",
-        "required": ["latest_api_version", "release_version"],
+        "required": [
+          "latest_api_version",
+          "release_version"
+        ],
         "properties": {
           "latest_api_version": {
             "type": "string",
@@ -1057,17 +1117,45 @@
             "example": "56.0"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Launch_MVD_Response": {
         "type": "object",
         "description": "Response returned when a debugging session request is successfully accepted.",
-        "required": ["run_id"],
+        "required": [
+          "statusCode"
+        ],
         "properties": {
-          "run_id": {
+          "runId": {
             "type": "string",
+            "nullable": true,
             "description": "Unique identifier for the launched debugging session.",
             "example": "c8d2f4a6e0b3197d5f8a2c4e6b0d3f79-49-1"
+          },
+          "statusCode": {
+            "type": "integer",
+            "description": "HTTP status code indicating whether the debugging session was accepted.",
+            "example": 202
+          }
+        },
+        "additionalProperties": true
+      },
+      "Launch_Error_Response": {
+        "type": "object",
+        "description": "Error envelope returned by the launch endpoints (`/api/v1/launch/{launcher_name}` and `/api/v1/launch/debugging`). These endpoints are fronted by the test-launch webhook and report failures with a status code rather than the `Error_Response` `message` envelope used by the other endpoints. A null `runId` is included once a request reaches the test launcher. Some gateway-level rejections (for example authentication or rate limiting) may instead return an empty body.",
+        "required": [
+          "statusCode"
+        ],
+        "properties": {
+          "statusCode": {
+            "type": "integer",
+            "description": "HTTP status code of the error. Matches the HTTP status of the response.",
+            "example": 404
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Always `null` when present. Included once the request reaches the test launcher; omitted for requests rejected before then."
           }
         },
         "additionalProperties": true
@@ -1075,7 +1163,9 @@
       "Launch_Request": {
         "type": "object",
         "description": "Request body for launching a test.",
-        "required": ["params"],
+        "required": [
+          "params"
+        ],
         "properties": {
           "params": {
             "description": "Launch parameters. All parameters are optional.",
@@ -1086,12 +1176,14 @@
             ]
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Launch_MVD_Request": {
         "type": "object",
         "description": "Request body for launching a multiverse debugging session.",
-        "required": ["params"],
+        "required": [
+          "params"
+        ],
         "properties": {
           "params": {
             "description": "Launch parameters. All parameters are optional.",
@@ -1131,7 +1223,10 @@
           "antithesis.is_ephemeral": {
             "type": "string",
             "nullable": true,
-            "enum": ["true", "false"],
+            "enum": [
+              "true",
+              "false"
+            ],
             "description": "A boolean (represented as `\"true\"` or `\"false\"`) that indicates whether or not the run's results should be reflected in future reports as a historic result. Set to `\"true\"` when kicking off one-off, exploratory runs. Defaults to `\"false\"`."
           },
           "antithesis.report.recipients": {
@@ -1169,12 +1264,12 @@
               },
               "antithesis.debugging.input_hash": {
                 "type": "string",
-                "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "description": "Obtain it from the [copy moment button](/docs/product/reports/properties/#copy-moment) in the triage report.",
                 "example": "-9067336385060865277"
               },
               "antithesis.debugging.vtime": {
                 "type": "string",
-                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/product/reports/properties/#copy-moment) in the triage report.",
                 "example": "45.334635781589895"
               },
               "antithesis.event_description": {
@@ -1205,12 +1300,12 @@
               },
               "antithesis.debugging.input_hash": {
                 "type": "string",
-                "description": "Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "description": "Obtain it from the [copy moment button](/docs/product/reports/properties/#copy-moment) in the triage report.",
                 "example": "-9067336385060865277"
               },
               "antithesis.debugging.vtime": {
                 "type": "string",
-                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/reports/properties/#copy-moment) in the triage report.",
+                "description": "The virtual time at which you want to start debugging. Obtain it from the [copy moment button](/docs/product/reports/properties/#copy-moment) in the triage report.",
                 "example": "45.334635781589895"
               },
               "antithesis.event_description": {
@@ -1230,7 +1325,9 @@
       "Event": {
         "type": "object",
         "description": "A single event. Each event includes its moment information. Fields vary by event source.",
-        "required": ["moment"],
+        "required": [
+          "moment"
+        ],
         "properties": {
           "moment": {
             "$ref": "#/components/schemas/Moment"
@@ -1241,7 +1338,10 @@
       "Moment": {
         "type": "object",
         "description": "Identifies a specific moment in the run's execution timeline.",
-        "required": ["input_hash", "vtime"],
+        "required": [
+          "input_hash",
+          "vtime"
+        ],
         "properties": {
           "input_hash": {
             "type": "string",
@@ -1254,12 +1354,15 @@
             "example": "398.4898056755774"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Build_Log_Line": {
         "type": "object",
         "description": "A single build log line.",
-        "required": ["timestamp", "text"],
+        "required": [
+          "timestamp",
+          "text"
+        ],
         "properties": {
           "timestamp": {
             "type": "string",
@@ -1269,7 +1372,10 @@
           },
           "stream": {
             "type": "string",
-            "enum": ["stdout", "stderr"],
+            "enum": [
+              "stdout",
+              "stderr"
+            ],
             "description": "Whether this line is from standard output or standard error."
           },
           "text": {
@@ -1283,7 +1389,9 @@
       "Property_List_Response": {
         "type": "object",
         "description": "A page of property results returned by the properties endpoint. Use `next_cursor` to iterate through all available results.",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -1301,7 +1409,11 @@
       "Property_Base": {
         "type": "object",
         "description": "Shared fields for all property results. A property result from a test run. Properties with `is_group` set to true represent a group property that contain other individual properties; individual properties within that group reference it via the `group` field.",
-        "required": ["name", "status", "is_event"],
+        "required": [
+          "name",
+          "status",
+          "is_event"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -1351,6 +1463,12 @@
           {
             "type": "object",
             "properties": {
+              "is_event": {
+                "description": "Always `true` for event properties. Discriminates this branch of the `oneOf`.",
+                "enum": [
+                  true
+                ]
+              },
               "examples": {
                 "type": "array",
                 "description": "A sample of example events that satisfy the property. This is not an exhaustive list.",
@@ -1378,6 +1496,12 @@
           {
             "type": "object",
             "properties": {
+              "is_event": {
+                "description": "Always `false` for non-event properties. Discriminates this branch of the `oneOf`.",
+                "enum": [
+                  false
+                ]
+              },
               "examples": {
                 "type": "array",
                 "description": "A sample of example instances that satisfy the property. This is not an exhaustive list.",
@@ -1405,12 +1529,22 @@
       },
       "Property_Status": {
         "type": "string",
-        "enum": ["Passing", "Failing"],
+        "enum": [
+          "Passing",
+          "Failing"
+        ],
         "description": "Whether the property is currently passing or failing."
       },
       "Run_Status": {
         "type": "string",
-        "enum": ["starting", "in_progress", "completed", "cancelled", "incomplete", "unknown"],
+        "enum": [
+          "starting",
+          "in_progress",
+          "completed",
+          "cancelled",
+          "incomplete",
+          "unknown"
+        ],
         "description": "Current lifecycle status of a test run. `starting`: the run is being set up. `in_progress`: the run is actively running. `completed`: the run finished successfully. `cancelled`: the run was cancelled before completion. `incomplete`: the run did not complete successfully. `unknown`: the status of the run is unknown."
       },
       "Creator_Info": {
@@ -1428,7 +1562,7 @@
             "example": "ci"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "Run_Links": {
         "type": "object",
@@ -1440,7 +1574,7 @@
             "description": "URL to the triage report for this test run."
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       }
     },
     "responses": {
@@ -1455,7 +1589,7 @@
               "message": "limit must be between 1 and 100"
             }
           }
-        }   
+        }
       },
       "Unauthorized": {
         "description": "Unauthorized — invalid or missing authentication credentials.",
@@ -1540,7 +1674,7 @@
               "$ref": "#/components/schemas/Error_Response"
             },
             "example": {
-              "message": "Too many requests. Retry after 30 seconds."
+              "message": "Too many requests."
             }
           }
         }
@@ -1554,6 +1688,122 @@
             },
             "example": {
               "message": "An unexpected error occurred. Please try again later."
+            }
+          }
+        }
+      },
+      "Legacy_BadRequest": {
+        "description": "Bad request — likely missing or invalid parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 400
+            }
+          }
+        }
+      },
+      "Legacy_Unauthorized": {
+        "description": "Unauthorized — invalid or missing authentication credentials.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 401
+            }
+          }
+        }
+      },
+      "Legacy_Forbidden": {
+        "description": "Forbidden — the authenticated user does not have permission to access this resource.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 403
+            }
+          }
+        }
+      },
+      "Legacy_NotFound": {
+        "description": "The requested resource was not found — for example, the named launcher does not exist.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 404,
+              "runId": null
+            }
+          }
+        }
+      },
+      "Legacy_MethodNotAllowed": {
+        "description": "Method not allowed — the HTTP method is not supported for this endpoint.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 405
+            }
+          }
+        }
+      },
+      "Legacy_NotAcceptable": {
+        "description": "Not acceptable — the requested content type in the Accept header is not supported by this endpoint.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 406
+            }
+          }
+        }
+      },
+      "Legacy_TooManyRequests": {
+        "description": "Rate limit exceeded. The response includes a `Retry-After` header indicating the number of seconds to wait before retrying.\n\nWe recommend implementing a retry mechanism to handle rate limiting. Follow an exponential backoff schedule to reduce request volume when necessary, and add randomness (jitter) to the backoff schedule to avoid thundering-herd retries.",
+        "headers": {
+          "Retry-After": {
+            "description": "The number of seconds to wait before retrying the request.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "example": 30
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 429
+            }
+          }
+        }
+      },
+      "Legacy_InternalError": {
+        "description": "Unknown internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Launch_Error_Response"
+            },
+            "example": {
+              "statusCode": 500,
+              "runId": null
             }
           }
         }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1360,7 +1360,7 @@ fn haystack_matches_all_needles(haystack: &str, lowered_needles: &[String]) -> b
 async fn cmd_runs_events(
     run_id: &str,
     matches: &[String],
-    limit: u16,
+    limit: usize,
     settings: &Settings,
     json: bool,
     verbose: bool,

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -149,13 +149,14 @@ pub async fn cmd_runs(
         Some(RunsCommands::Events {
             run_id,
             mut matches,
+            limit,
             query,
         }) => {
             // `-m/--match` is the documented form; the trailing positional
             // `query` is a backward-compatible alias whose terms are additional
             // needles. Merge both into a single needle list.
             matches.extend(query);
-            cmd_runs_events(&run_id, &matches, settings, json, verbose).await
+            cmd_runs_events(&run_id, &matches, limit, settings, json, verbose).await
         }
     }
 }
@@ -1359,6 +1360,7 @@ fn haystack_matches_all_needles(haystack: &str, lowered_needles: &[String]) -> b
 async fn cmd_runs_events(
     run_id: &str,
     matches: &[String],
+    limit: u16,
     settings: &Settings,
     json: bool,
     verbose: bool,
@@ -1395,12 +1397,13 @@ async fn cmd_runs_events(
         eprintln!(
             "Note: only \"{server_query}\" is matched on the server (which returns a capped \
              subset of events); the other terms filter that subset locally, so some matching \
-             events may not appear. Search a single, more specific term to be exhaustive."
+             events may not appear. Search a single, more specific term to be exhaustive, or \
+             raise the cap with --limit."
         );
     }
 
     let api = AntithesisApi::new_requiring_api_key(settings, verbose)?;
-    let stream = match api.search_run_events(run_id, &server_query).await {
+    let stream = match api.search_run_events(run_id, &server_query, limit).await {
         Ok(stream) => stream.into_inner(),
         Err(err) => return Err(explain_run_scoped_error(&api, run_id, err).await),
     };

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1360,7 +1360,7 @@ fn haystack_matches_all_needles(haystack: &str, lowered_needles: &[String]) -> b
 async fn cmd_runs_events(
     run_id: &str,
     matches: &[String],
-    limit: usize,
+    limit: Option<usize>,
     settings: &Settings,
     json: bool,
     verbose: bool,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -656,20 +656,27 @@ fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, St
     )
 }
 
-fn mock_route_search_run_events(run_id: &str, query: Option<&str>) -> (u16, String) {
+fn mock_route_search_run_events(run_id: &str, query_str: Option<&str>) -> (u16, String) {
     if !mock_run_known(run_id) {
         return mock_run_not_found(run_id);
     }
-    let Some(query) = mock_query_param(query, "q") else {
+    let Some(needle) = mock_query_param(query_str, "q") else {
         return (400, r#"{"message":"missing q"}"#.to_string());
     };
 
     let (_, logs) = mock_route_get_run_logs(run_id);
-    let query = query.to_ascii_lowercase();
-    let matches = logs
+    let needle = needle.to_ascii_lowercase();
+    let mut matches = logs
         .lines()
-        .filter(|line| line.to_ascii_lowercase().contains(&query))
+        .filter(|line| line.to_ascii_lowercase().contains(&needle))
         .collect::<Vec<_>>();
+
+    // Cap the returned events at `limit` when present, mirroring the real
+    // endpoint's `limit` query parameter (the subset is the first N matches).
+    if let Some(limit) = mock_query_param(query_str, "limit").and_then(|l| l.parse::<usize>().ok())
+    {
+        matches.truncate(limit);
+    }
 
     if matches.is_empty() {
         (200, String::new())
@@ -729,6 +736,23 @@ mod tests {
         assert!(
             body.contains("slow request"),
             "expected match for decoded query, got: {body}"
+        );
+    }
+
+    #[test]
+    fn mock_route_search_run_events_caps_at_limit() {
+        // parallel_driver_fetch matches three events; limit=1 keeps the first.
+        let (status, all) = mock_route_search_run_events("run-1", Some("q=parallel_driver_fetch"));
+        assert_eq!(status, 200);
+        assert_eq!(all.lines().count(), 3, "fixture should match three events");
+
+        let (status, capped) =
+            mock_route_search_run_events("run-1", Some("q=parallel_driver_fetch&limit=1"));
+        assert_eq!(status, 200);
+        assert_eq!(capped.lines().count(), 1);
+        assert!(
+            capped.contains(r#""vtime":"400.5""#),
+            "the first match should be retained, got: {capped}"
         );
     }
 

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -288,7 +288,10 @@ fn launch_fails_without_parameters() {
 
 #[test]
 fn launch_reports_api_errors() {
-    let mock_url = start_mock_server(r#"{"message":"bad request"}"#, 400);
+    // Launch endpoints report failures with the `Launch_Error_Response`
+    // envelope (`{ statusCode }`), not the `{ message }` shape the other
+    // endpoints use.
+    let mock_url = start_mock_server(r#"{"statusCode":400}"#, 400);
 
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "30"])

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -288,10 +288,11 @@ fn launch_fails_without_parameters() {
 
 #[test]
 fn launch_reports_api_errors() {
-    // Launch endpoints report failures with the `Launch_Error_Response`
-    // envelope (`{ statusCode }`), not the `{ message }` shape the other
-    // endpoints use.
-    let mock_url = start_mock_server(r#"{"statusCode":400}"#, 400);
+    // A launcher-reached failure carries the `Launch_Error_Response` envelope
+    // (`{ statusCode, runId: null }`), not the `{ message }` shape the other
+    // endpoints use. (Gateway rejections instead return an empty body; that
+    // path is covered in specs/debug.txt.)
+    let mock_url = start_mock_server(r#"{"statusCode":400,"runId":null}"#, 400);
 
     snouty_with_mock(&mock_url)
         .args(["launch", "-w", "basic_test", "--duration", "30"])

--- a/tests/cli_general.rs
+++ b/tests/cli_general.rs
@@ -288,17 +288,19 @@ fn launch_fails_without_parameters() {
 
 #[test]
 fn launch_reports_api_errors() {
-    // A launcher-reached failure carries the `Launch_Error_Response` envelope
-    // (`{ statusCode, runId: null }`), not the `{ message }` shape the other
-    // endpoints use. (Gateway rejections instead return an empty body; that
-    // path is covered in specs/debug.txt.)
-    let mock_url = start_mock_server(r#"{"statusCode":400,"runId":null}"#, 400);
+    // A launcher-reached failure (e.g. unknown launcher -> 404) carries the
+    // `Launch_Error_Response` envelope (`{ statusCode, runId: null }`), not the
+    // `{ message }` shape the other endpoints use. The launcher does no request
+    // validation beyond auth, so 404 — not 400 — is the reachable failure.
+    // (Gateway rejections instead return an empty body; that path is covered in
+    // specs/debug.txt.)
+    let mock_url = start_mock_server(r#"{"statusCode":404,"runId":null}"#, 404);
 
     snouty_with_mock(&mock_url)
-        .args(["launch", "-w", "basic_test", "--duration", "30"])
+        .args(["launch", "-w", "no_such_launcher", "--duration", "30"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("API error: 400"));
+        .stderr(predicate::str::contains("API error: 404"));
 }
 
 #[test]


### PR DESCRIPTION
Adopts the events search API from the latest Antithesis release (orbitinghail tenant, release 58.6). Two commits, reviewable independently.

## 1. Update OpenAPI spec to tenant 58.6 and adapt launch client

Refreshed `src/openapi.json` from the tenant. The `/api/v0` and `/api/v1` spec routes now serve one identical combined document, and the tenant ships fully lenient schemas (no `additionalProperties: false` anywhere).

Client changes the new spec forced:

- **`build.rs`** — the schema-stripping transform is now a no-op. Per the assertion's own guidance it flips to **asserting the spec is free of `additionalProperties: false`** (reporting offending JSON-pointer paths), so a future spec that reintroduces it fails the build loudly rather than silently regenerating a brittle client.
- **Launch errors** — the launch endpoints now report failures with the new `Launch_Error_Response` envelope (`{statusCode, runId?}`) instead of the `{message}` shape. Routed through a shared, body-type-generic error formatter.
- **`run_id` is now nullable** on `LaunchResponse`/`LaunchMvdResponse`, and the documented debug-launch 202 body has converged with the live webhook envelope (`{runId, statusCode}`) — parsed directly now, carrying the body's own status code through. A now-redundant test (whose "spec vs live envelope differ" premise no longer holds) was removed.

Tests and specs updated to the `{statusCode, runId: null}` launch-error envelope, validated against the live tenant (an unknown launcher 404s with exactly that shape; gateway auth rejections carry an empty body instead, also covered).

The bulk of the diff is the regenerated `openapi.json`.

## 2. Add `--limit` to `snouty runs events`

The events endpoint now takes a `limit` query param (1–999) capping how many events the server returns.

- Exposed as **`-n/--limit`**, **unset by default**: with the flag omitted the query param is left off the request entirely, so tenants that predate it never receive it and the server applies its own default (currently 50). Range checking is left to the server.
- Raising the cap makes multi-needle searches (only the longest needle is matched server-side) more exhaustive, so the capped-subset note now points at `--limit`.
- The in-process mock honors the parameter (first N matches) so the behavior is covered end to end.

## Backwards compatibility

Tracked in [this comment](https://github.com/antithesishq/snouty/pull/176#issuecomment-5047783181) and resolved as follows:

- **`snouty debug` on older tenants** — resolved, no change needed: the API team confirmed `statusCode` has always been returned and the old spec was simply misaligned, so the recovery path this depended on can't fail. A missing `runId` is tolerated end to end.
- **Always sending `limit`** — fixed: the parameter is only sent when the user asks for one.
- **Older tenants' `{message}` launch errors** — still degrades to the generic invalid-payload path (the human-readable message is lost) when a pre-58.6 tenant returns `{message}` on a launch failure. Known remaining gap.

## Testing

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` all clean. Commit 1 also builds/tests in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)