### PR TITLE
runs logs: add --failure to stream logs at the run's failure moment

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -556,19 +556,31 @@ INPUT_HASH and VTIME identify the moment and its timeline; logs are streamed up
 to that moment. Without --begin-vtime, streaming starts at the timeline's
 earliest log entry.
 
+Pass --failure instead of HASH/VTIME to stream up to the run's own failure
+moment (the one `runs show` reports) — a shortcut for the common case of
+"show me the logs at the failure" without copying the moment by hand.
+
 Output: `[vtime] [source] [stream] message`. A moment (HASH/VTIME) comes from
 `runs properties --detail` or `runs events`."#)]
     Logs {
         /// Run ID
         run_id: String,
 
-        /// Input hash of the moment to stream up to (with VTIME, picks the timeline)
-        #[arg(allow_hyphen_values = true)]
-        input_hash: String,
+        /// Input hash of the moment to stream up to (with VTIME, picks the
+        /// timeline). Optional when --failure is given.
+        #[arg(allow_hyphen_values = true, required_unless_present = "failure")]
+        input_hash: Option<String>,
 
-        /// Virtual time of the moment to stream up to
-        #[arg(allow_hyphen_values = true)]
-        vtime: String,
+        /// Virtual time of the moment to stream up to. Optional when --failure
+        /// is given.
+        #[arg(allow_hyphen_values = true, required_unless_present = "failure")]
+        vtime: Option<String>,
+
+        /// Stream logs up to the run's own failure moment instead of an
+        /// explicit HASH/VTIME (the same moment `runs show` reports). Conflicts
+        /// with passing HASH/VTIME.
+        #[arg(long, conflicts_with_all = ["input_hash", "vtime"])]
+        failure: bool,
 
         /// Start from this virtual time instead of the timeline's earliest log entry
         #[arg(long, allow_hyphen_values = true)]
@@ -719,10 +731,31 @@ mod tests {
         else {
             panic!("expected `runs logs`");
         };
-        assert_eq!(input_hash, "-123");
-        assert_eq!(vtime, "-2.0");
+        assert_eq!(input_hash.as_deref(), Some("-123"));
+        assert_eq!(vtime.as_deref(), Some("-2.0"));
         assert_eq!(begin_vtime.as_deref(), Some("-2.0"));
         assert_eq!(begin_input_hash.as_deref(), Some("0"));
+    }
+
+    // `--failure` resolves the moment from the run, so HASH/VTIME are omitted.
+    #[test]
+    fn logs_failure_needs_no_moment() {
+        let cli = parse(&["snouty", "runs", "logs", "RUN", "--failure"]);
+        let Commands::Runs {
+            command:
+                Some(RunsCommands::Logs {
+                    input_hash,
+                    vtime,
+                    failure,
+                    ..
+                }),
+        } = cli.command
+        else {
+            panic!("expected `runs logs`");
+        };
+        assert!(failure);
+        assert_eq!(input_hash, None);
+        assert_eq!(vtime, None);
     }
 
     // `-r` is the short form of `--raw`; note `-r` must not swallow the
@@ -737,7 +770,7 @@ mod tests {
             panic!("expected `runs logs`");
         };
         assert!(raw);
-        assert_eq!(vtime, "-2.0");
+        assert_eq!(vtime.as_deref(), Some("-2.0"));
 
         let cli = parse(&["snouty", "runs", "logs", "RUN", "-123", "-2.0"]);
         let Commands::Runs {

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -131,14 +131,16 @@ pub async fn cmd_runs(
             run_id,
             input_hash,
             vtime,
+            failure,
             begin_vtime,
             begin_input_hash,
             raw,
         }) => {
             cmd_runs_logs(
                 &run_id,
-                &input_hash,
-                &vtime,
+                input_hash.as_deref(),
+                vtime.as_deref(),
+                failure,
                 begin_input_hash.as_deref(),
                 begin_vtime.as_deref(),
                 settings,
@@ -1482,10 +1484,12 @@ async fn cmd_runs_events(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn cmd_runs_logs(
     run_id: &str,
-    input_hash: &str,
-    vtime: &str,
+    input_hash: Option<&str>,
+    vtime: Option<&str>,
+    failure: bool,
     begin_input_hash: Option<&str>,
     begin_vtime: Option<&str>,
     settings: &Settings,
@@ -1494,8 +1498,31 @@ async fn cmd_runs_logs(
     debug!("streaming logs for run: {}", run_id);
 
     let api = AntithesisApi::new_requiring_api_key(settings, verbose)?;
+
+    // --failure resolves the moment from the run itself (same one `runs show`
+    // reports), so the caller doesn't have to copy HASH/VTIME by hand. clap
+    // guarantees HASH/VTIME are present when --failure is absent.
+    let (input_hash, vtime) = if failure {
+        let run = api.get_run(run_id).await?;
+        match run.real_failure_moment() {
+            Some(moment) => (moment.input_hash.clone(), moment.vtime.clone()),
+            None => {
+                return Err(user_error(format!(
+                    "run {run_id} has no failure moment to stream logs from"
+                ))
+                .note("only runs that failed a property expose one")
+                .note(format!("inspect the run with `snouty runs show {run_id}`")));
+            }
+        }
+    } else {
+        (
+            input_hash.expect("clap requires input_hash without --failure").to_string(),
+            vtime.expect("clap requires vtime without --failure").to_string(),
+        )
+    };
+
     let stream = match api
-        .get_run_logs(run_id, input_hash, vtime, begin_input_hash, begin_vtime)
+        .get_run_logs(run_id, &input_hash, &vtime, begin_input_hash, begin_vtime)
         .await
     {
         Ok(stream) => stream.into_inner(),


### PR DESCRIPTION
`runs show` already resolves a run's failure moment and prints it as a ready-to-run `runs logs <run> <hash> <vtime>` command. This folds that into one step: `runs logs <run> --failure` fetches the run, resolves `real_failure_moment()`, and streams up to it — so the common "show me the logs at the failure" case needs no copy-paste of the moment.

- `INPUT_HASH`/`VTIME` become optional (`required_unless_present = "failure"`) and conflict with `--failure`.
- A run with no real failure moment gets a clear error pointing at `runs show`.
- Reuses the existing `real_failure_moment()` (so the placeholder 0/0 moment is treated as "none", same as `runs show`).

Tests: added a parse test for `--failure`, updated the two existing `logs` parse tests for the now-`Option` positionals; `cargo test --lib` green (427 passed). Left as a draft for your CI/clippy/formatting to confirm — my local run was in a container without your full toolchain.