### PR TITLE
Log keychain lookup failures other than a missing entry

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,6 +13,7 @@ use color_eyre::{
 };
 use http::HeaderValue;
 use keyring_core::Entry;
+use log::debug;
 use progenitor_client::OperationInfo;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
@@ -103,8 +104,8 @@ impl AuthenticationInfo {
             Err(other) => Err(other),
         }?;
 
-        if let Ok(persisted) = credential.get_password() {
-            match serde_json::from_str::<PersistableCredentials>(&persisted) {
+        match credential.get_password() {
+            Ok(persisted) => match serde_json::from_str::<PersistableCredentials>(&persisted) {
                 Ok(persisted) => {
                     return Ok(Some(AttributedValue::Keychain {
                         value: persisted.convert_to_authentication_info(),
@@ -116,7 +117,16 @@ impl AuthenticationInfo {
                         "Deserialization of the value in the keychain failed with error {err:#}"
                     );
                 }
-            }
+            },
+            // Nothing stored under this name is the ordinary case (no `snouty
+            // login` yet, or credentials live under another profile), so it
+            // stays quiet. Any other error means the vault is there but
+            // wouldn't answer — locked, access denied by platform ACL, or an
+            // ambiguous entry — and we fall through to the credentials file as
+            // if nothing were stored. Log it so a machine whose vault is broken
+            // can be diagnosed instead of just reporting "no credentials".
+            Err(keyring_core::Error::NoEntry) => {}
+            Err(err) => debug!("keychain lookup for entry {credential_name} failed: {err}"),
         }
 
         Ok(None)


### PR DESCRIPTION
`try_from_keychain` swallowed every `get_password` failure with `if let Ok(...)`, so a keychain that exists but won't answer was indistinguishable from never having run `snouty login`: both fall through to the credentials file and, finding nothing, report "No Antithesis credentials found".

`keyring_core::Error` distinguishes cases worth telling apart:

- `NoEntry` — nothing stored under this name. The ordinary case (no `snouty login` yet, or the credentials live under a different profile), so it stays silent.
- `NoStorageAccess` — the store couldn't be accessed, typically because it is locked or platform ACL rules denied it. On macOS this is the locked-keychain / `errSecInteractionNotAllowed` case that a non-GUI session (ssh, cron, a CI agent) hits.
- `Ambiguous` — more than one matching item in the store.
- `PlatformFailure` / `BadEncoding` / `BadDataFormat` / `BadStoreFormat` / `Invalid` / `TooLong` — malformed store or platform failure.

This keeps the fallback silent for `NoEntry` and logs everything else at debug level, so a machine whose vault is broken can be diagnosed with `RUST_LOG=debug` instead of only being told it has no credentials. Deliberately not a warning: a broken vault on a machine that never uses one shouldn't nag every invocation. If users do hit this in the field, promoting it is a one-line change.

The existing corruption `eprintln!` is untouched — that covers a different case (the read succeeded, the JSON didn't deserialize).

## Testing

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` clean. Behavior is unchanged apart from the added debug line, so no spec updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb
