### PR TITLE
Detect podman-in-disguise with --version instead of the daemon-querying version subcommand

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -607,15 +607,31 @@ pub fn generate_image_ref(registry: &str) -> String {
 }
 
 /// Check whether a binary is genuinely docker or podman-in-disguise.
-/// `docker version` (the subcommand) prints "Podman Engine" in the Client field
-/// when docker is actually podman, while `docker --version` does not.
+///
+/// Asks with `--version` rather than the `version` subcommand: podman-docker
+/// installs `docker` as a shell script that execs podman, so `docker --version`
+/// answers `podman version 4.9.3` — enough to tell them apart. The subcommand
+/// would work too, but it queries the engine's daemon, which costs a round trip
+/// on every call and blocks indefinitely when `DOCKER_HOST` points somewhere
+/// that accepts connections but never answers (a firewalled remote, a wedged
+/// dockerd). `--version` is answered by the client alone, so it stays instant
+/// no matter what state the daemon is in.
 pub fn is_podman_in_disguise(cmd: &str) -> bool {
     Command::new(cmd)
-        .arg("version")
+        .arg("--version")
         .output()
         .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .is_some_and(|v| v.to_lowercase().contains("podman"))
+        .filter(|o| o.status.success())
+        .is_some_and(|o| version_output_is_podman(&o.stdout))
+}
+
+/// Whether a `--version` banner came from podman. Split out from
+/// [`is_podman_in_disguise`] so callers that already ran `--version` can reuse
+/// their output instead of spawning the binary a second time.
+fn version_output_is_podman(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout)
+        .to_lowercase()
+        .contains("podman")
 }
 
 /// Return the auto-detected global container runtime, preferring podman over docker.
@@ -649,7 +665,9 @@ pub fn runtime(settings: &Settings) -> Result<Box<dyn ContainerRuntime>> {
     // Fall back to docker
     match Command::new("docker").arg("--version").output() {
         Ok(output) if output.status.success() => {
-            if is_podman_in_disguise("docker") {
+            // The banner we just captured already says whether this `docker` is
+            // really podman, so decide from it rather than asking again.
+            if version_output_is_podman(&output.stdout) {
                 log::warn!("podman not found as 'podman', but 'docker' is podman");
                 return Ok(Box::new(PodmanRuntime::new("docker")));
             }
@@ -709,11 +727,14 @@ pub fn available_engines() -> Vec<Box<dyn ContainerRuntime>> {
     {
         engines.push(Box::new(PodmanRuntime::new("podman")));
     }
+    // One `docker --version` answers both questions: whether docker is here at
+    // all, and whether it is really podman wearing docker's name.
     if Command::new("docker")
         .arg("--version")
         .output()
-        .is_ok_and(|o| o.status.success())
-        && !is_podman_in_disguise("docker")
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| !version_output_is_podman(&o.stdout))
     {
         engines.push(Box::new(DockerRuntime::new("docker")));
     }
@@ -1087,6 +1108,31 @@ mod tests {
             image_ref.starts_with("registry.example.com/repo/snouty-config:"),
             "got: {image_ref}"
         );
+    }
+
+    // Real `--version` banners: podman-docker installs `docker` as a script
+    // that execs podman, so the disguise announces itself here — no need for
+    // the daemon-querying `version` subcommand.
+    #[test]
+    fn version_output_identifies_podman_in_disguise() {
+        // podman-docker 4.9.3's `docker --version`, and podman's own.
+        assert!(version_output_is_podman(b"podman version 4.9.3\n"));
+        // The subcommand banner, in case a caller ever feeds it in.
+        assert!(version_output_is_podman(
+            b"Client:       Podman Engine\nVersion:      4.9.3\n"
+        ));
+
+        // Genuine docker, standalone and Docker Desktop.
+        assert!(!version_output_is_podman(
+            b"Docker version 29.1.3, build 29.1.3-0ubuntu3~24.04.2\n"
+        ));
+        assert!(!version_output_is_podman(
+            b"Docker version 27.4.0, build bde2b89\n"
+        ));
+
+        // Nothing to read is not podman, and invalid UTF-8 must not panic.
+        assert!(!version_output_is_podman(b""));
+        assert!(!version_output_is_podman(&[0xff, 0xfe, 0xfd]));
     }
 
     #[test]


### PR DESCRIPTION
`is_podman_in_disguise` asked with the bare `version` **subcommand**, which queries the engine's daemon. snouty doesn't need the daemon to answer this question, and the call has no timeout, so it blocks for as long as the daemon takes — indefinitely when `DOCKER_HOST` points at something that accepts connections but never answers (a firewalled remote, a hung dockerd).

Measured on Ubuntu with docker 29.1.3:

| probe | healthy daemon | `DOCKER_HOST` at a dead unix socket | `DOCKER_HOST` at a blackholed TCP endpoint |
|---|---|---|---|
| `docker version` | 0.24s | 0.02s (fails fast) | **still running at 15s — no client deadline** |
| `docker --version` | 0.02s | 0.02s | **0.02s** |

This got more exposed when `warn_ambiguous_engine` landed: it calls `available_engines()` on every `launch`/`validate` when no engine was chosen explicitly, so a podman-primary machine that merely has the docker CLI installed — which previously never ran a docker command at all, because `runtime()` short-circuits on podman — now makes this daemon call on every invocation.

## The fix

podman-docker installs `docker` as a shell script that `exec`s podman, so the disguise announces itself in the client-only banner:

```
$ /usr/bin/docker --version      # podman-docker 4.9.3 shim
podman version 4.9.3
$ docker --version               # genuine docker
Docker version 29.1.3, build 29.1.3-0ubuntu3~24.04.2
```

So `--version` answers the question with no daemon involvement. The banner check is split into a small pure helper (`version_output_is_podman`) so that:

- `runtime()`'s docker fallback and `available_engines()` — both of which had *already* run `docker --version` — decide from the output they captured instead of spawning the binary a second time, halving the process spawns on that path;
- the predicate is unit-testable against real banners without mutating `PATH`.

`is_podman_in_disguise` keeps its signature for the two standalone callers (`compose.rs`'s plugin resolution and `testutils.rs`), now backed by `--version`.

No timeout was added: with the daemon out of the picture there is nothing left to hang on. The doc comment records why, so the subcommand doesn't creep back in.

## Testing

Verified against real podman (installed podman + podman-docker 4.9.3 on the test machine, then restored it):

- With only the podman-docker shim on `PATH` (podman itself hidden), `snouty doctor --offline` reports **"Container runtime: podman detected"** and the full run takes **0.05s** — the disguise branch in `runtime()` resolving correctly with no daemon contact.
- Compose plugin resolution still refuses the disguise: *"neither the `docker-compose` binary nor the `docker compose` CLI plugin is usable"*.
- With podman **and** docker both installed, `snouty validate` prints `Warning: podman and docker detected; using podman (override with SNOUTY_CONTAINER_ENGINE).`, and `SNOUTY_CONTAINER_ENGINE=docker` silences it — so `available_engines()` still classifies a genuine docker correctly under the new check.
- New unit test `version_output_identifies_podman_in_disguise` covers the real banners from podman-docker 4.9.3, podman, standalone docker, and Docker Desktop, plus empty and non-UTF-8 output.

`cargo fmt --check`, `cargo clippy --all-targets`, and the full `cargo test` (427 unit + all spec suites) are clean.

Behavior is unchanged for every engine layout, so no spec updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb
