### PR TITLE
Classify API failures on the HTTP status alone

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -64,12 +64,10 @@ fn generate_api_client(out_dir: &Path) {
 /// — would otherwise only surface as a status-less failure against a live
 /// tenant.
 fn assert_no_typed_error_responses(content: &str) {
-    let arms = content.matches("Error::ErrorResponse").count();
-    assert_eq!(
-        arms, 0,
-        "generated client has {arms} `Error::ErrorResponse` arm(s); every error response is \
-         supposed to be undocumented so failures keep their HTTP status (see \
-         `untype_error_responses`)"
+    assert!(
+        !content.contains("Error::ErrorResponse"),
+        "generated client has an `Error::ErrorResponse` arm; every error response is supposed \
+         to be undocumented so failures keep their HTTP status (see `untype_error_responses`)"
     );
 }
 

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn generate_api_client(out_dir: &Path) {
         offenders.len(),
         offenders.join(", ")
     );
-    relax_response_typing(&mut spec_value);
+    untype_error_responses(&mut spec_value);
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
@@ -52,12 +52,29 @@ fn generate_api_client(out_dir: &Path) {
     let ast = syn::parse2(tokens).unwrap();
     let content = prettyplease::unparse(&ast);
     let content = patch_lenient_booleans(content);
+    assert_no_typed_error_responses(&content);
 
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
 }
 
-/// Stop the generated client from typing the response bodies the server is
-/// known to answer off-schema.
+/// Hold `untype_error_responses` to its promise: with no error response
+/// documented anywhere, progenitor emits no `Error::ErrorResponse` arm, so that
+/// variant is unreachable and `classify_client_error` treats it as such. A spec
+/// refresh that slipped one back in — under a status shape the transform misses
+/// — would otherwise only surface as a status-less failure against a live
+/// tenant.
+fn assert_no_typed_error_responses(content: &str) {
+    let arms = content.matches("Error::ErrorResponse").count();
+    assert_eq!(
+        arms, 0,
+        "generated client has {arms} `Error::ErrorResponse` arm(s); every error response is \
+         supposed to be undocumented so failures keep their HTTP status (see \
+         `untype_error_responses`)"
+    );
+}
+
+/// Stop the generated client from typing error response bodies, so an HTTP
+/// failure always reaches snouty with its status attached.
 ///
 /// progenitor decodes every *documented* response into a generated type. When a
 /// documented status arrives with a body that doesn't match its schema, the
@@ -65,40 +82,22 @@ fn generate_api_client(out_dir: &Path) {
 /// serde_json::Error)` — a variant with nowhere to put the HTTP status, for
 /// which `Error::status()` is `None`. An *undocumented* status takes
 /// `Error::UnexpectedResponse(reqwest::Response)` instead, which keeps the
-/// status *and* the raw body. Two families of response are better left
-/// undocumented, so snouty always has the status:
+/// status *and* the raw body.
 ///
-/// - **Every error response, on every operation.** An error body is whatever
-///   the thing that produced it feels like sending: the API gateway rejects a
-///   bad token with an empty `text/plain` body, an intermediary answers with an
-///   HTML page. Typed, any of those masks the status — an empty-bodied 401 was
-///   reaching `snouty doctor` as "API unreachable" (#180). Untyped, every
-///   failure arrives as status + raw body and one status-first formatter
-///   renders all of them.
+/// Error bodies are exactly the ones that don't honour the schema: the API
+/// gateway rejects a bad token with an empty `text/plain` body, an intermediary
+/// answers with an HTML page. Typed, any of those masked the status — an
+/// empty-bodied 401 was reaching `snouty doctor` as "API unreachable" (#180).
+/// Untyped, every failure arrives as status + raw body and one status-first
+/// formatter renders all of them.
 ///
-/// - **The launch webhooks' success body.** The spec documents 202 while the
-///   live webhook answers 200, and the body shape varies by tenant release
-///   (`runId` vs `run_id`; `statusCode` present or not). Their success response
-///   is collapsed into a single `2XX` range carrying a free-form object, so any
-///   2xx is a success and `finish_launch` reads the body itself. Keeping a
-///   documented success — rather than dropping the response outright — is what
-///   preserves the generated `Accept: application/json` request header, which
-///   these endpoints content-negotiate on (they document a 406).
-fn relax_response_typing(spec: &mut serde_json::Value) {
-    const LAUNCH_OPERATIONS: [&str; 2] = ["launchTest", "launchMvd"];
-
-    let launch_success = serde_json::json!({
-        "2XX": {
-            "description": "Any 2xx is a successful launch. The body shape varies by tenant release, so it is left free-form and parsed by the client.",
-            "content": { "application/json": { "schema": { "type": "object" } } }
-        }
-    });
-
+/// Success responses are left alone: the spec describes them accurately, and
+/// the typed bodies are what the rest of the client is built on.
+fn untype_error_responses(spec: &mut serde_json::Value) {
     let paths = spec
         .get_mut("paths")
         .and_then(serde_json::Value::as_object_mut)
         .expect("openapi spec has a `paths` object");
-    let mut launch_operations_found = 0;
     for path_item in paths.values_mut() {
         let Some(path_item) = path_item.as_object_mut() else {
             continue;
@@ -106,36 +105,18 @@ fn relax_response_typing(spec: &mut serde_json::Value) {
         // A path item holds non-operation keys too (`parameters`, `summary`);
         // an operation is anything that documents responses.
         for operation in path_item.values_mut() {
-            let is_launch = operation
-                .get("operationId")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|id| LAUNCH_OPERATIONS.contains(&id));
             let Some(responses) = operation
                 .get_mut("responses")
                 .and_then(serde_json::Value::as_object_mut)
             else {
                 continue;
             };
-            if is_launch {
-                launch_operations_found += 1;
-                *responses = launch_success.as_object().unwrap().clone();
-            } else {
-                // Also drops any `default` response, which progenitor would
-                // otherwise turn into a typed catch-all for every error status.
-                responses.retain(|status, _| status.starts_with('2'));
-            }
+            // Retaining only 2xx also drops any `default` response, which
+            // progenitor would otherwise turn into a typed catch-all covering
+            // every error status — reintroducing the problem by another door.
+            responses.retain(|status, _| status.starts_with('2'));
         }
     }
-
-    // A spec refresh that renamed or dropped a launch operation would otherwise
-    // silently leave its responses typed, and the mismatch would only show up
-    // as a runtime "invalid API response payload" against a live tenant.
-    assert_eq!(
-        launch_operations_found,
-        LAUNCH_OPERATIONS.len(),
-        "expected the openapi spec to define {LAUNCH_OPERATIONS:?}; found {launch_operations_found} \
-         of them, so the launch response bodies may still be typed"
-    );
 }
 
 /// Recursively collect the JSON-pointer path of every `"additionalProperties":

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
 
 fn generate_api_client(out_dir: &Path) {
     let file = std::fs::File::open("src/openapi.json").unwrap();
-    let spec_value: serde_json::Value = serde_json::from_reader(file).unwrap();
+    let mut spec_value: serde_json::Value = serde_json::from_reader(file).unwrap();
 
     // A schema's `additionalProperties: false` makes progenitor/typify emit
     // `#[serde(deny_unknown_fields)]`, which turns a forwards-compatible server
@@ -41,6 +41,7 @@ fn generate_api_client(out_dir: &Path) {
         offenders.len(),
         offenders.join(", ")
     );
+    relax_response_typing(&mut spec_value);
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
@@ -53,6 +54,88 @@ fn generate_api_client(out_dir: &Path) {
     let content = patch_lenient_booleans(content);
 
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
+}
+
+/// Stop the generated client from typing the response bodies the server is
+/// known to answer off-schema.
+///
+/// progenitor decodes every *documented* response into a generated type. When a
+/// documented status arrives with a body that doesn't match its schema, the
+/// generated client returns `Error::InvalidResponsePayload(Bytes,
+/// serde_json::Error)` — a variant with nowhere to put the HTTP status, for
+/// which `Error::status()` is `None`. An *undocumented* status takes
+/// `Error::UnexpectedResponse(reqwest::Response)` instead, which keeps the
+/// status *and* the raw body. Two families of response are better left
+/// undocumented, so snouty always has the status:
+///
+/// - **Every error response, on every operation.** An error body is whatever
+///   the thing that produced it feels like sending: the API gateway rejects a
+///   bad token with an empty `text/plain` body, an intermediary answers with an
+///   HTML page. Typed, any of those masks the status — an empty-bodied 401 was
+///   reaching `snouty doctor` as "API unreachable" (#180). Untyped, every
+///   failure arrives as status + raw body and one status-first formatter
+///   renders all of them.
+///
+/// - **The launch webhooks' success body.** The spec documents 202 while the
+///   live webhook answers 200, and the body shape varies by tenant release
+///   (`runId` vs `run_id`; `statusCode` present or not). Their success response
+///   is collapsed into a single `2XX` range carrying a free-form object, so any
+///   2xx is a success and `finish_launch` reads the body itself. Keeping a
+///   documented success — rather than dropping the response outright — is what
+///   preserves the generated `Accept: application/json` request header, which
+///   these endpoints content-negotiate on (they document a 406).
+fn relax_response_typing(spec: &mut serde_json::Value) {
+    const LAUNCH_OPERATIONS: [&str; 2] = ["launchTest", "launchMvd"];
+
+    let launch_success = serde_json::json!({
+        "2XX": {
+            "description": "Any 2xx is a successful launch. The body shape varies by tenant release, so it is left free-form and parsed by the client.",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+        }
+    });
+
+    let paths = spec
+        .get_mut("paths")
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("openapi spec has a `paths` object");
+    let mut launch_operations_found = 0;
+    for path_item in paths.values_mut() {
+        let Some(path_item) = path_item.as_object_mut() else {
+            continue;
+        };
+        // A path item holds non-operation keys too (`parameters`, `summary`);
+        // an operation is anything that documents responses.
+        for operation in path_item.values_mut() {
+            let is_launch = operation
+                .get("operationId")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|id| LAUNCH_OPERATIONS.contains(&id));
+            let Some(responses) = operation
+                .get_mut("responses")
+                .and_then(serde_json::Value::as_object_mut)
+            else {
+                continue;
+            };
+            if is_launch {
+                launch_operations_found += 1;
+                *responses = launch_success.as_object().unwrap().clone();
+            } else {
+                // Also drops any `default` response, which progenitor would
+                // otherwise turn into a typed catch-all for every error status.
+                responses.retain(|status, _| status.starts_with('2'));
+            }
+        }
+    }
+
+    // A spec refresh that renamed or dropped a launch operation would otherwise
+    // silently leave its responses typed, and the mismatch would only show up
+    // as a runtime "invalid API response payload" against a live tenant.
+    assert_eq!(
+        launch_operations_found,
+        LAUNCH_OPERATIONS.len(),
+        "expected the openapi spec to define {LAUNCH_OPERATIONS:?}; found {launch_operations_found} \
+         of them, so the launch response bodies may still be typed"
+    );
 }
 
 /// Recursively collect the JSON-pointer path of every `"additionalProperties":

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -121,12 +121,10 @@ stdout '\s*"runId": "run-123".*'
 # Gateway-level rejections (auth, rate limiting) on the launch/debug endpoints
 # return an EMPTY body rather than the Launch_Error_Response envelope — verified
 # against the live API, which answers a bad token with 401/403 and no payload.
-# The HTTP status is the only thing the server said, so it is what snouty
-# reports, with a note explaining why there is no further detail.
+# The HTTP status is the only thing the server said, so it is the whole message.
 mock-server 401 ''
 ! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stderr 'API error: 401 Unauthorized.*'
-stderr '.*rejections .* with an empty body.*'
 
 # An error body snouty cannot make sense of (here an intermediary's HTML page)
 # never masks the status either: it is reported with the body shown for

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -126,7 +126,7 @@ stdout '\s*"runId": "run-123".*'
 mock-server 401 ''
 ! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stderr 'API error: 401 Unauthorized.*'
-stderr '.*return an empty body for some gateway-level rejections.*'
+stderr '.*rejections .* with an empty body.*'
 
 # An error body snouty cannot make sense of (here an intermediary's HTML page)
 # never masks the status either: it is reported with the body shown for

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -58,6 +58,13 @@ mock-server 202 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stdout 'Debugging session started: run_id run-123'
 
+# A tenant predating the documented envelope answers with a snake_case run_id
+# and no statusCode at all. That is still a successful launch: the HTTP status
+# says so, and the body only has to supply the run id.
+mock-server 202 '{"run_id":"run-123"}'
+snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
+stdout 'Debugging session started: run_id run-123'
+
 # --session-id remains supported for backwards compatibility.
 mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --session-id d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1 --vtime 1234567890
@@ -107,19 +114,32 @@ stdin moment_run_input.txt
 snouty debug --stdin
 stdout 'Debugging session started: run_id run-123'
 
-# With --json, the full response body is printed as pretty JSON.
+# With --json, the full response body is printed as pretty JSON. `statusCode`
+# is the HTTP status of the response, not the webhook's body-level copy of it
+# (the two disagree here: the mock answers HTTP 200 saying 202).
 mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty --json debug --stdin
 stdout '\s*"runId": "run-123".*'
+stdout '\s*"statusCode": 200.*'
 
 # Gateway-level rejections (auth, rate limiting) on the launch/debug endpoints
 # return an EMPTY body rather than the Launch_Error_Response envelope — verified
 # against the live API, which answers a bad token with 401/403 and no payload.
-# snouty must surface that permissively instead of choking on the empty body.
+# The HTTP status is the only thing the server said, so it is what snouty
+# reports, with a note explaining why there is no further detail.
 mock-server 401 ''
 ! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
-stderr '.*empty response body.*'
+stderr 'API error: 401 Unauthorized.*'
+stderr '.*return an empty body for some gateway-level rejections.*'
+
+# An error body snouty cannot make sense of (here an intermediary's HTML page)
+# never masks the status either: it is reported with the body shown for
+# debugging.
+mock-server 502 '<html><body>Bad Gateway</body></html>'
+! snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
+stderr 'API error: 502 Bad Gateway.*'
+stderr '.*<html><body>Bad Gateway</body></html>.*'
 
 # ANTITHESIS_EXTRA_HEADERS adds arbitrary headers to every API request (for
 #    consumption by proxies). With --verbose, the merged request headers are

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -58,13 +58,6 @@ mock-server 202 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
 stdout 'Debugging session started: run_id run-123'
 
-# A tenant predating the documented envelope answers with a snake_case run_id
-# and no statusCode at all. That is still a successful launch: the HTTP status
-# says so, and the body only has to supply the run id.
-mock-server 202 '{"run_id":"run-123"}'
-snouty debug --input-hash abc123 --run-id 9043254f65c9c65d63fe043a0abfc7fc-53-1 --vtime 1234567890
-stdout 'Debugging session started: run_id run-123'
-
 # --session-id remains supported for backwards compatibility.
 mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 snouty debug --input-hash abc123 --session-id d5d1c9cf0e64b5dd69b00e97b07fe3f4-18-1 --vtime 1234567890
@@ -114,14 +107,16 @@ stdin moment_run_input.txt
 snouty debug --stdin
 stdout 'Debugging session started: run_id run-123'
 
-# With --json, the full response body is printed as pretty JSON. `statusCode`
-# is the HTTP status of the response, not the webhook's body-level copy of it
-# (the two disagree here: the mock answers HTTP 200 saying 202).
+# With --json, snouty prints its own envelope: the run id, and nothing else.
+# The webhook's body-level statusCode is deliberately not re-exported (issue
+# #180) — it carries nothing the exit code doesn't, and here it disagrees with
+# the response anyway (the mock answers HTTP 200 saying 202). Use --verbose to
+# see the response as it arrived.
 mock-server 200 '{"statusCode":202,"runId":"run-123"}'
 stdin moment_run_input.txt
 snouty --json debug --stdin
 stdout '\s*"runId": "run-123".*'
-stdout '\s*"statusCode": 200.*'
+! stdout '.*statusCode.*'
 
 # Gateway-level rejections (auth, rate limiting) on the launch/debug endpoints
 # return an EMPTY body rather than the Launch_Error_Response envelope — verified

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -37,11 +37,13 @@ stderr '.*snouty launch.*'
 stderr '.*ANTITHESIS_PASSWORD.*'
 
 # --- API connectivity + version check (issue #146) ---
-# Cases that inject a status via mock-server are [!staging]-gated: under
+# Cases that fabricate a status via mock-server are [!staging]-gated: under
 # SNOUTY_STAGING, mock-server passes through to the real API where fabricated
-# responses don't hold. The --offline and unreachable cases use a controlled
-# local setup and run in both modes. The mock + --offline cases assume a
-# container runtime (CI provisions one); the unreachable case is robust either way.
+# responses don't hold. The 401 case is the exception — a bad key provokes the
+# same status from the real gateway, so it runs in both modes. The --offline
+# and unreachable cases use a controlled local setup and run in both modes. The
+# mock + --offline cases assume a container runtime (CI provisions one); the
+# unreachable case is robust either way.
 
 # 2xx: doctor reports the live API and tenant release versions. The check runs
 # only with an API key (the endpoint rejects basic auth), so set one on top of
@@ -67,12 +69,15 @@ stderr '.*ANTITHESIS_PASSWORD.*'
 # token (content-type: text/plain, zero length). The HTTP status is what
 # classifies the failure, so doctor names the rejected credentials instead of
 # reporting the API as unreachable because the body didn't parse (issue #180).
-[!staging] mock-server 401 ''
-[!staging] env ANTITHESIS_API_KEY=testkey
-[!staging] ! snouty doctor
-[!staging] stderr '.*Antithesis API rejected authentication.*'
-[!staging] stderr '.*returned HTTP 401.*'
-[!staging] ! stderr '.*Antithesis API unreachable.*'
+# This block runs against staging too: mock-server passes through to the real
+# gateway, and the bad key below provokes the real 401, so the issue #180
+# scenario is exercised end to end rather than only against a mock of it.
+mock-server 401 ''
+env ANTITHESIS_API_KEY=testkey
+! snouty doctor
+stderr '.*Antithesis API rejected authentication.*'
+stderr '.*returned HTTP 401.*'
+! stderr '.*Antithesis API unreachable.*'
 
 # --offline skips the network check entirely: no version line, no API contact.
 env ANTITHESIS_API_KEY=testkey

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -70,13 +70,16 @@ stderr '.*ANTITHESIS_PASSWORD.*'
 # classifies the failure, so doctor names the rejected credentials instead of
 # reporting the API as unreachable because the body didn't parse (issue #180).
 # This block runs against staging too: mock-server passes through to the real
-# gateway, and the bad key below provokes the real 401, so the issue #180
-# scenario is exercised end to end rather than only against a mock of it.
+# gateway, and the bad key below provokes a real rejection, so the issue #180
+# scenario is exercised end to end rather than only against a mock of it. The
+# mock answers 401; the live gateway answers 403 for a bad key (the probes on
+# issue #180 recorded both). Either status is an authentication rejection, so
+# the assertion accepts both.
 mock-server 401 ''
 env ANTITHESIS_API_KEY=testkey
 ! snouty doctor
 stderr '.*Antithesis API rejected authentication.*'
-stderr '.*returned HTTP 401.*'
+stderr '.*returned HTTP 40[13].*'
 ! stderr '.*Antithesis API unreachable.*'
 
 # --offline skips the network check entirely: no version line, no API contact.

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -63,6 +63,17 @@ stderr '.*ANTITHESIS_PASSWORD.*'
 [!staging] stderr '.*returned 404.*'
 [!staging] stderr '.*proxy.*'
 
+# 401 with an EMPTY body — exactly what the API gateway returns for a bad
+# token (content-type: text/plain, zero length). The HTTP status is what
+# classifies the failure, so doctor names the rejected credentials instead of
+# reporting the API as unreachable because the body didn't parse (issue #180).
+[!staging] mock-server 401 ''
+[!staging] env ANTITHESIS_API_KEY=testkey
+[!staging] ! snouty doctor
+[!staging] stderr '.*Antithesis API rejected authentication.*'
+[!staging] stderr '.*returned HTTP 401.*'
+[!staging] ! stderr '.*Antithesis API unreachable.*'
+
 # --offline skips the network check entirely: no version line, no API contact.
 env ANTITHESIS_API_KEY=testkey
 env ANTITHESIS_TENANT=testtenant

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -71,10 +71,15 @@ stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 stderr '"antithesis.source": "ci-pipeline"'
 stdout 'Test run started: run_id run-123'
 
-# With --json, the full response body is printed as pretty JSON.
+# With --json, the full response body is printed as pretty JSON. `statusCode`
+# is the HTTP status of the response, not the launch webhook's body-level copy
+# of it (the two disagree here: the mock answers HTTP 200 saying 202). The API
+# team has confirmed clients should ignore the body-level copy (issue #180), so
+# the transport status is the only one snouty trusts.
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty --json launch -w basic_test --config-image config:latest --duration 30 --source ci-pipeline
 stdout '\s*"runId": "run-123".*'
+stdout '\s*"statusCode": 200.*'
 ! stdout 'Test run started.*'
 
 # 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".
@@ -116,12 +121,13 @@ stderr '"antithesis.images": "app@sha256:abc;db:latest"'
 # On an error that reaches the test launcher (e.g. an unknown launcher name),
 # the command exits with an error showing the HTTP status. Such errors carry
 # the Launch_Error_Response envelope ({ statusCode, runId: null }), verified
-# against the live API — no message text, and runId is null. (The launcher does
+# against the live API — no message text, and runId is null. The status comes
+# from the response, and the body is echoed for debugging. (The launcher does
 # no request validation beyond auth, so it never returns a 400; 404 is the
 # canonical reachable failure.)
 mock-server 404 '{"statusCode":404,"runId":null}'
 ! snouty launch -w no_such_launcher --duration 30
-stderr 'API error: 404.*'
+stderr 'API error: 404 Not Found.*'
 
 # `snouty run` still works but prints a deprecation warning.
 mock-server 200 '{"runId":"run-123","statusCode":202}'

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -71,15 +71,15 @@ stderr '"antithesis.report.recipients": "\[REDACTED\]"'
 stderr '"antithesis.source": "ci-pipeline"'
 stdout 'Test run started: run_id run-123'
 
-# With --json, the full response body is printed as pretty JSON. `statusCode`
-# is the HTTP status of the response, not the launch webhook's body-level copy
-# of it (the two disagree here: the mock answers HTTP 200 saying 202). The API
-# team has confirmed clients should ignore the body-level copy (issue #180), so
-# the transport status is the only one snouty trusts.
+# With --json, snouty prints its own envelope: the run id, and nothing else.
+# The launch webhook's body-level statusCode is deliberately not re-exported
+# (issue #180) — the exit code is the success signal, and the field disagrees
+# with the response anyway (the mock answers HTTP 200 saying 202). Use --verbose
+# to see the response as it arrived.
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty --json launch -w basic_test --config-image config:latest --duration 30 --source ci-pipeline
 stdout '\s*"runId": "run-123".*'
-stdout '\s*"statusCode": 200.*'
+! stdout '.*statusCode.*'
 ! stdout 'Test run started.*'
 
 # 6b. --ephemeral flag sets antithesis.is_ephemeral to "true".

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -271,6 +271,18 @@ env ANTITHESIS_API_KEY=test-api-key
 stderr 'API error: 400.*'
 ! stderr 'Backtrace omitted'
 
+# A rejection with no body at all is the API gateway's shape for auth and
+# rate-limit failures (content-type: text/plain, zero length). There is nothing
+# to show beyond the status, so snouty says why instead of printing a bare
+# status line and leaving the silence unexplained (issue #180). The gateway
+# answers every endpoint that way, not just launch, so the note is not
+# endpoint-specific.
+[!staging] mock-server 429 ''
+[!staging] env ANTITHESIS_API_KEY=test-api-key
+[!staging] ! snouty runs
+[!staging] stderr 'API error: 429 Too Many Requests.*'
+[!staging] stderr '.*rejections .* with an empty body.*'
+
 # `snouty runs properties` prints a friendly empty-state message when no properties exist.
 mock-runs-server
 snouty runs properties run-empty

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -272,16 +272,13 @@ stderr 'API error: 400.*'
 ! stderr 'Backtrace omitted'
 
 # A rejection with no body at all is the API gateway's shape for auth and
-# rate-limit failures (content-type: text/plain, zero length). There is nothing
-# to show beyond the status, so snouty says why instead of printing a bare
-# status line and leaving the silence unexplained (issue #180). The gateway
-# answers every endpoint that way, not just launch, so the note is not
-# endpoint-specific.
+# rate-limit failures (content-type: text/plain, zero length). The status is all
+# the server said, so it is all snouty reports — the point of issue #180 is that
+# the status survives an unparsable body rather than being lost with it.
 [!staging] mock-server 429 ''
 [!staging] env ANTITHESIS_API_KEY=test-api-key
 [!staging] ! snouty runs
 [!staging] stderr 'API error: 429 Too Many Requests.*'
-[!staging] stderr '.*rejections .* with an empty body.*'
 
 # `snouty runs properties` prints a friendly empty-state message when no properties exist.
 mock-runs-server

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,6 +19,7 @@ use crate::auth::AuthenticationInfo;
 use crate::env;
 use crate::error::{ApiError, user_error};
 use crate::params::Params;
+use crate::render::sanitize;
 use crate::settings::Settings;
 
 #[allow(dead_code, unused_imports, private_interfaces)]
@@ -983,10 +984,7 @@ fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
 }
 
 async fn format_api_client_error(err: ClientError<()>) -> Report {
-    match classify_client_error(err).await {
-        ApiFailure::Response { status, message } => format_api_error(status, &message),
-        ApiFailure::Other(report) => report,
-    }
+    classify_client_error(err).await.into_report()
 }
 
 /// Same as [`format_api_client_error`] but adds a launch-specific suggestion
@@ -997,12 +995,11 @@ async fn format_api_client_error(err: ClientError<()>) -> Report {
 async fn format_launch_client_error(err: ClientError<()>) -> Report {
     match classify_client_error(err).await {
         ApiFailure::Response { status, message } if message.is_empty() => {
-            format_api_error(status, &message).with_suggestion(|| {
+            format_api_error(status, "").with_suggestion(|| {
                 "the launch endpoints return an empty body for some gateway-level rejections (for example authentication or rate limiting), so there is no detail to show beyond the status; if the problem persists, contact Antithesis support."
             })
         }
-        ApiFailure::Response { status, message } => format_api_error(status, &message),
-        ApiFailure::Other(report) => report,
+        failure => failure.into_report(),
     }
 }
 
@@ -1015,6 +1012,15 @@ enum ApiFailure {
     /// No usable response: a transport failure, or a success body snouty could
     /// not parse.
     Other(Report),
+}
+
+impl ApiFailure {
+    fn into_report(self) -> Report {
+        match self {
+            ApiFailure::Response { status, message } => format_api_error(status, &message),
+            ApiFailure::Other(report) => report,
+        }
+    }
 }
 
 /// Classify a client error. Anything the server answered keeps its HTTP status:
@@ -1033,16 +1039,18 @@ async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
                 .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
             ApiFailure::Response {
                 status,
-                message: error_body_message(body),
+                message: error_body_message(&body),
             }
         }
-        // Unreachable: progenitor only emits an `Error::ErrorResponse` arm for a
-        // *documented* error response, and `build.rs` documents none. It asserts
-        // as much against the generated source, so this can't rot back into
-        // reachability unnoticed.
-        ClientError::ErrorResponse(_) => {
-            unreachable!("no error response is documented; see build.rs untype_error_responses")
-        }
+        // Unreachable in practice — progenitor only emits this arm for a
+        // *documented* error response, and `build.rs` asserts the generated
+        // client has none. Kept as the same status-first outcome rather than a
+        // panic: it costs two lines, and a CLI should never abort on something a
+        // server said.
+        ClientError::ErrorResponse(response) => ApiFailure::Response {
+            status: response.status().as_u16(),
+            message: String::new(),
+        },
         ClientError::InvalidRequest(message) => {
             ApiFailure::Other(eyre!("invalid API request: {message}"))
         }
@@ -1079,21 +1087,37 @@ async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
 /// truncated if it's a whole web page) so the user still has something to debug
 /// with.
 ///
-/// The body is only ever *displayed* here, never parsed for a status: the launch
-/// envelope's `statusCode` duplicates the status line snouty already printed
-/// from the transport. Echoing the envelope anyway is still worth it, because
-/// whether `runId` is present distinguishes a rejection the test launcher
-/// produced from one an intermediary made on its behalf.
-fn error_body_message(body: String) -> String {
+/// Echoing the launch endpoints' `{statusCode, runId}` envelope is worth it even
+/// though its `statusCode` duplicates the status line: whether `runId` is present
+/// distinguishes a rejection the test launcher produced from one an intermediary
+/// made on its behalf.
+fn error_body_message(body: &str) -> String {
     const MAX_LEN: usize = 200;
 
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body)
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(body)
         && let Some(message) = value.get("message").and_then(serde_json::Value::as_str)
     {
-        return message.trim().to_owned();
+        return sanitize(message.trim());
     }
 
-    let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Collapse onto one line, stopping once there are certainly enough bytes to
+    // fill MAX_LEN chars (a char is at most 4 bytes), so a whole web page isn't
+    // rebuilt just to be cut down.
+    let mut collapsed = String::new();
+    for word in body.split_whitespace() {
+        if collapsed.len() > MAX_LEN * 4 {
+            break;
+        }
+        if !collapsed.is_empty() {
+            collapsed.push(' ');
+        }
+        collapsed.push_str(word);
+    }
+
+    // An intermediary's page can carry control characters; `sanitize` is the
+    // repo's policy for making untrusted text safe to print on one line, and it
+    // runs after collapsing so its newline escaping never has anything to do.
+    let collapsed = sanitize(&collapsed);
     match collapsed.char_indices().nth(MAX_LEN) {
         Some((offset, _)) => format!("{}…", &collapsed[..offset]),
         None => collapsed,
@@ -1289,21 +1313,21 @@ mod tests {
     #[test]
     fn error_body_message_unwraps_the_standard_envelope() {
         assert_eq!(
-            error_body_message(r#"{"message":"limit must be 1..100"}"#.to_owned()),
+            error_body_message(r#"{"message":"limit must be 1..100"}"#),
             "limit must be 1..100"
         );
         assert_eq!(
-            error_body_message(r#"{"statusCode":404,"runId":null}"#.to_owned()),
+            error_body_message(r#"{"statusCode":404,"runId":null}"#),
             r#"{"statusCode":404,"runId":null}"#
         );
-        assert_eq!(error_body_message(String::new()), "");
+        assert_eq!(error_body_message(""), "");
     }
 
     // An intermediary's error page is multi-line and can be enormous; collapse
     // it onto one line and cap it so it stays a usable one-line diagnostic.
     #[test]
     fn error_body_message_collapses_and_truncates_html() {
-        let message = error_body_message(format!(
+        let message = error_body_message(&format!(
             "<html>\n  <body>{}</body>\n</html>\n",
             "x".repeat(500)
         ));
@@ -1311,6 +1335,24 @@ mod tests {
         assert!(!message.contains('\n'), "got: {message}");
         assert!(message.ends_with('…'), "got: {message}");
         assert_eq!(message.chars().count(), 201);
+    }
+
+    // The body goes straight to the terminal, so it gets the same control-char
+    // treatment as every other piece of untrusted API text: an escape sequence
+    // in an intermediary's error page must not reach the user's terminal
+    // unescaped.
+    #[test]
+    fn error_body_message_escapes_control_characters() {
+        assert_eq!(
+            error_body_message("oops\u{1b}[31m\u{7}"),
+            r"oops\x1B[31m\x07"
+        );
+        // JSON-escaped inside the envelope, so it parses; the unwrapped message
+        // is sanitized just like an unparsed body.
+        assert_eq!(
+            error_body_message(r#"{"message":"bad\u0007request"}"#),
+            r"bad\x07request"
+        );
     }
 
     #[tokio::test]
@@ -1508,34 +1550,25 @@ mod tests {
         .unwrap()
     }
 
-    async fn mock_debug_launch(status: u16, body: &str) -> MockServer {
+    /// A mock server answering one endpoint with a fixed status and body. The
+    /// endpoint-specific wrappers below name the routes the tests care about.
+    async fn mock_endpoint(http_method: &str, route: &str, status: u16, body: &str) -> MockServer {
         let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/debugging"))
-            .respond_with(
-                ResponseTemplate::new(status)
-                    .insert_header("content-type", "application/json")
-                    .set_body_string(body),
-            )
+        Mock::given(method(http_method))
+            .and(path(route.to_owned()))
+            .respond_with(ResponseTemplate::new(status).set_body_string(body))
             .expect(1)
             .mount(&mock_server)
             .await;
         mock_server
     }
 
+    async fn mock_debug_launch(status: u16, body: &str) -> MockServer {
+        mock_endpoint("POST", "/api/v1/launch/debugging", status, body).await
+    }
+
     async fn mock_launch_test(status: u16, body: &str) -> MockServer {
-        let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/basic_test"))
-            .respond_with(
-                ResponseTemplate::new(status)
-                    .insert_header("content-type", "application/json")
-                    .set_body_string(body),
-            )
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-        mock_server
+        mock_endpoint("POST", "/api/v1/launch/basic_test", status, body).await
     }
 
     // The body's own statusCode is ignored outright (#180): snouty reads the run
@@ -1678,14 +1711,7 @@ mod tests {
     }
 
     async fn mock_version(status: u16, body: &str) -> MockServer {
-        let mock_server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/api/version"))
-            .respond_with(ResponseTemplate::new(status).set_body_string(body))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-        mock_server
+        mock_endpoint("GET", "/api/version", status, body).await
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,10 +6,13 @@ use color_eyre::eyre::{Context, Report, Result, eyre};
 use color_eyre::{Section, SectionExt};
 use futures_util::stream;
 use log::debug;
-use progenitor_client::{ClientHooks, ClientInfo, Error as ClientError, OperationInfo};
+use progenitor_client::{
+    ClientHooks, ClientInfo, Error as ClientError, OperationInfo, ResponseValue,
+};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Proxy};
 use reqwest_middleware::ClientWithMiddleware;
+use serde::de::DeserializeOwned;
 
 use crate::api_cache;
 use crate::auth::AuthenticationInfo;
@@ -33,16 +36,17 @@ pub use progenitor_client::ByteStream;
 /// The outcome of a launch or debugging-launch request, and the `--json` output
 /// of `snouty launch` / `snouty debug`.
 ///
-/// snouty owns this shape rather than re-exporting a generated type: the launch
-/// webhooks' response body varies by tenant release, so `build.rs` leaves it
-/// free-form and [`finish_launch`] reads the run id out of it directly.
-/// `status_code` is the response's HTTP status, never the body's own copy of it
-/// (#180).
+/// snouty owns this shape rather than re-exporting a generated response type,
+/// so the `--json` contract is a deliberate choice rather than whatever the
+/// vendored schema happens to say. The run id is the only thing a caller can
+/// act on: success or failure is the exit code, and the launch responses'
+/// body-level `statusCode` is a field the API team has confirmed clients should
+/// ignore (#180). The HTTP status is still visible with `--verbose`, which
+/// dumps the response as it arrived.
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LaunchResponse {
     pub run_id: Option<String>,
-    pub status_code: u16,
 }
 
 /// API and tenant release version, from `GET /api/version`.
@@ -254,13 +258,19 @@ impl AntithesisApi {
             .body(body)
             .send()
             .await;
-        finish_launch(result).await
+        let response: generated::types::LaunchResponse = finish_launch(result).await?;
+        Ok(LaunchResponse {
+            run_id: response.run_id,
+        })
     }
 
     pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
         let body = launch_mvd_request(params)?;
         let result = self.client.launch_mvd().body(body).send().await;
-        finish_launch(result).await
+        let response: generated::types::LaunchMvdResponse = finish_launch(result).await?;
+        Ok(LaunchResponse {
+            run_id: response.run_id,
+        })
     }
 
     pub async fn get_run(&self, run_id: &str) -> Result<RunDetail> {
@@ -747,36 +757,26 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
 
 /// Resolve a launch / debugging-launch webhook response.
 ///
-/// `build.rs` documents these webhooks as answering any 2xx with a free-form
-/// object, because the spec's single documented status (202) is not the one the
-/// live API uses (200) and the body's shape varies by tenant release. So any
-/// 2xx is a success, and the only thing read out of the body is the run id —
-/// under either spelling. The reported `statusCode` is the transport status:
-/// the API team has confirmed the body's own copy should be ignored (#180).
-async fn finish_launch(
-    result: std::result::Result<
-        progenitor_client::ResponseValue<serde_json::Map<String, serde_json::Value>>,
-        ClientError<()>,
-    >,
-) -> Result<LaunchResponse> {
-    let response = match result {
-        Ok(response) => response,
-        Err(err) => return Err(format_launch_client_error(err).await),
-    };
-    let status_code = response.status().as_u16();
-    Ok(LaunchResponse {
-        run_id: launch_run_id(response.into_inner()),
-        status_code,
-    })
-}
-
-/// The run id in a launch response body, under either spelling: tenants from
-/// 58.6 on answer with the documented `runId`, older ones with `run_id`. Absent
-/// on a launch that started no run, and on the debugging webhook's 200, which
-/// answers `{"statusCode": 202}` alone.
-fn launch_run_id(body: serde_json::Map<String, serde_json::Value>) -> Option<String> {
-    let run_id = body.get("runId").or_else(|| body.get("run_id"))?;
-    run_id.as_str().map(str::to_owned)
+/// These webhooks return an HTTP status the OpenAPI spec under-documents (it
+/// lists a single 2xx, while the live API has been seen to answer 200). The
+/// generated client accepts only the documented code and surfaces any other 2xx
+/// as `UnexpectedResponse`, so we treat **any** 2xx as success and decode the
+/// body ourselves on that path. Genuine failures (4xx/5xx) are formatted as
+/// errors, status first — `build.rs` leaves them undocumented, so the status is
+/// always there to lead with.
+async fn finish_launch<T: DeserializeOwned>(
+    result: std::result::Result<ResponseValue<T>, ClientError<()>>,
+) -> Result<T> {
+    match result {
+        Ok(response) => Ok(response.into_inner()),
+        Err(ClientError::UnexpectedResponse(response)) if response.status().is_success() => {
+            response
+                .json::<T>()
+                .await
+                .wrap_err("parsing launch response body")
+        }
+        Err(err) => Err(format_launch_client_error(err).await),
+    }
 }
 
 fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequest> {
@@ -1036,12 +1036,13 @@ async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
                 message: error_body_message(body),
             }
         }
-        // No operation documents an error response, so the generated client has
-        // no typed error body to construct this from.
-        ClientError::ErrorResponse(response) => ApiFailure::Response {
-            status: response.status().as_u16(),
-            message: String::new(),
-        },
+        // Unreachable: progenitor only emits an `Error::ErrorResponse` arm for a
+        // *documented* error response, and `build.rs` documents none. It asserts
+        // as much against the generated source, so this can't rot back into
+        // reachability unnoticed.
+        ClientError::ErrorResponse(_) => {
+            unreachable!("no error response is documented; see build.rs untype_error_responses")
+        }
         ClientError::InvalidRequest(message) => {
             ApiFailure::Other(eyre!("invalid API request: {message}"))
         }
@@ -1106,20 +1107,6 @@ mod tests {
     use tempfile::TempDir;
     use wiremock::matchers::{method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    // The launch body is free-form by the time it reaches snouty, so the run id
-    // is read out of it by hand: `runId` from 58.6 on, `run_id` before that, and
-    // absent on a launch that started no run.
-    #[test]
-    fn launch_run_id_reads_either_spelling() {
-        let run_id = |body: &str| launch_run_id(serde_json::from_str(body).unwrap());
-
-        assert_eq!(run_id(r#"{"runId":"abc-1"}"#).as_deref(), Some("abc-1"));
-        assert_eq!(run_id(r#"{"run_id":"abc-1"}"#).as_deref(), Some("abc-1"));
-        assert_eq!(run_id(r#"{"statusCode":202}"#), None);
-        assert_eq!(run_id(r#"{"runId":null}"#), None);
-        assert_eq!(run_id("{}"), None);
-    }
 
     fn test_api_optionally_with_cache(
         mock_server: &MockServer,
@@ -1466,7 +1453,6 @@ mod tests {
         let requests = mock_server.received_requests().await.unwrap();
 
         assert_eq!(response.run_id.as_deref(), Some("run-123"));
-        assert_eq!(response.status_code, 202);
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].url.path(), "/api/v1/launch/basic_test");
         assert_eq!(requests[0].method, reqwest::Method::POST);
@@ -1510,7 +1496,6 @@ mod tests {
 
         let response = api.launch_test("basic_test", &params).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("run-123"));
-        assert_eq!(response.status_code, 200);
     }
 
     /// Params for a debug launch against a fixed run.
@@ -1553,29 +1538,21 @@ mod tests {
         mock_server
     }
 
-    // A pre-58.6 tenant answers the documented 202 with a snake_case `run_id`
-    // and no statusCode at all. That body predates the envelope the spec now
-    // documents and must still be accepted as a successful launch.
+    // The body's own statusCode is ignored outright (#180): snouty reads the run
+    // id and nothing else, so a body claiming 202 over an HTTP 200 has no way to
+    // influence what is reported.
     #[tokio::test]
-    async fn launch_debugging_accepts_snake_case_202_body() {
-        let mock_server = mock_debug_launch(202, r#"{"run_id":"abc-1"}"#).await;
-        let api = test_api_optionally_with_cache(&mock_server, None);
-
-        let response = api.launch_debugging(&debug_params()).await.unwrap();
-        assert_eq!(response.run_id.as_deref(), Some("abc-1"));
-        assert_eq!(response.status_code, 202);
-    }
-
-    // The body's own statusCode is ignored outright: a 200 carrying `202`
-    // reports 200, the status the transport actually used.
-    #[tokio::test]
-    async fn launch_debugging_reports_the_transport_status_not_the_body() {
+    async fn launch_debugging_ignores_the_body_status_code() {
         let mock_server = mock_debug_launch(200, r#"{"runId":"x","statusCode":202}"#).await;
         let api = test_api_optionally_with_cache(&mock_server, None);
 
         let response = api.launch_debugging(&debug_params()).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("x"));
-        assert_eq!(response.status_code, 200);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            serde_json::json!({"runId": "x"}),
+            "the launch --json contract is the run id alone"
+        );
     }
 
     // …and the converse, which is the regression guard for the removed
@@ -1671,7 +1648,6 @@ mod tests {
 
         let response = api.launch_debugging(&debug_params()).await.unwrap();
         assert_eq!(response.run_id, None);
-        assert_eq!(response.status_code, 200);
     }
 
     // The documented 202 body and the live webhook envelope have converged on
@@ -1684,7 +1660,6 @@ mod tests {
 
         let response = api.launch_debugging(&debug_params()).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("debug-run-456"));
-        assert_eq!(response.status_code, 202);
     }
 
     // A documented error status carries the `Launch_Error_Response` envelope

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,10 +25,25 @@ mod generated {
 
 pub(crate) use generated::types::Params as RunParams;
 pub use generated::types::{
-    BuildLogLine, Event, EventProperty, LaunchMvdResponse, LaunchResponse, Moment,
-    NonEventProperty, Property, PropertyStatus, RunDetail, RunStatus, RunSummary,
+    BuildLogLine, Event, EventProperty, Moment, NonEventProperty, Property, PropertyStatus,
+    RunDetail, RunStatus, RunSummary,
 };
 pub use progenitor_client::ByteStream;
+
+/// The outcome of a launch or debugging-launch request, and the `--json` output
+/// of `snouty launch` / `snouty debug`.
+///
+/// snouty owns this shape rather than re-exporting a generated type: the launch
+/// webhooks' response body varies by tenant release, so `build.rs` leaves it
+/// free-form and [`finish_launch`] reads the run id out of it directly.
+/// `status_code` is the response's HTTP status, never the body's own copy of it
+/// (#180).
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchResponse {
+    pub run_id: Option<String>,
+    pub status_code: u16,
+}
 
 /// API and tenant release version, from `GET /api/version`.
 #[derive(Debug, Clone)]
@@ -239,67 +254,13 @@ impl AntithesisApi {
             .body(body)
             .send()
             .await;
-        finish_launch(result, |body| {
-            serde_json::from_value(body).wrap_err("unexpected launch response shape")
-        })
-        .await
+        finish_launch(result).await
     }
 
     pub async fn launch_debugging(&self, params: &Params) -> Result<LaunchResponse> {
         let body = launch_mvd_request(params)?;
-        match self.client.launch_mvd().body(body).send().await {
-            // Documented 202 whose body is the live `{ "runId", "statusCode" }`
-            // envelope: the spec now models exactly that shape, so the generated
-            // client parses it into `LaunchMvdResponse` for us. Carry the body's
-            // own `statusCode` through rather than assuming 202.
-            Ok(response) => {
-                let response = response.into_inner();
-                Ok(LaunchResponse {
-                    run_id: response.run_id,
-                    status_code: response.status_code,
-                })
-            }
-            // A body that fails to parse as `LaunchMvdResponse` lands here. This
-            // variant carries no HTTP status (`ClientError::status()` is `None`),
-            // so we can't gate on `is_success()`. A documented *error* whose body
-            // fails `LaunchErrorResponse` parsing also lands here, so blindly
-            // trusting it would let an error masquerade as success. Lean on this
-            // webhook reporting its real status in the body: recover only when the
-            // body itself reports a 2xx, and fall back to the standard error path
-            // otherwise.
-            Err(ClientError::InvalidResponsePayload(body, source)) => {
-                match parse_debug_launch_body(&body) {
-                    Ok((run_id, Some(status_code))) if (200..300).contains(&status_code) => {
-                        Ok(LaunchResponse {
-                            run_id,
-                            status_code,
-                        })
-                    }
-                    _ => Err(
-                        format_launch_client_error(ClientError::InvalidResponsePayload(
-                            body, source,
-                        ))
-                        .await,
-                    ),
-                }
-            }
-            // Undocumented 2xx: the live API currently answers this webhook with
-            // HTTP 200 carrying the same envelope. The transport status already
-            // confirms success here, so a body without a `statusCode` defaults to
-            // 202 Accepted.
-            Err(ClientError::UnexpectedResponse(resp)) if resp.status().is_success() => {
-                let body = resp
-                    .bytes()
-                    .await
-                    .wrap_err("reading debug launch response")?;
-                let (run_id, status_code) = parse_debug_launch_body(&body)?;
-                Ok(LaunchResponse {
-                    run_id,
-                    status_code: status_code.unwrap_or(202),
-                })
-            }
-            Err(err) => Err(format_launch_client_error(err).await),
-        }
+        let result = self.client.launch_mvd().body(body).send().await;
+        finish_launch(result).await
     }
 
     pub async fn get_run(&self, run_id: &str) -> Result<RunDetail> {
@@ -784,56 +745,38 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
     .wrap_err("failed to build launch request")
 }
 
-/// Resolve a launch / debugging-launch webhook response, tolerating spec drift
-/// on the success status code.
+/// Resolve a launch / debugging-launch webhook response.
 ///
-/// These webhooks report their real status in the response *body* and return an
-/// HTTP status the OpenAPI spec under-documents (it lists a single 2xx). The
-/// generated client only accepts the documented code and surfaces any other 2xx
-/// as `UnexpectedResponse`. We treat **any** 2xx as success: on the documented
-/// code we use the client's already-parsed value; on any other 2xx we read the
-/// body and build the response via `from_body`. Genuine failures (4xx/5xx) are
-/// still formatted as errors.
-async fn finish_launch<T>(
+/// `build.rs` documents these webhooks as answering any 2xx with a free-form
+/// object, because the spec's single documented status (202) is not the one the
+/// live API uses (200) and the body's shape varies by tenant release. So any
+/// 2xx is a success, and the only thing read out of the body is the run id —
+/// under either spelling. The reported `statusCode` is the transport status:
+/// the API team has confirmed the body's own copy should be ignored (#180).
+async fn finish_launch(
     result: std::result::Result<
-        progenitor_client::ResponseValue<T>,
-        ClientError<generated::types::LaunchErrorResponse>,
+        progenitor_client::ResponseValue<serde_json::Map<String, serde_json::Value>>,
+        ClientError<()>,
     >,
-    from_body: impl FnOnce(serde_json::Value) -> Result<T>,
-) -> Result<T> {
-    match result {
-        Ok(response) => Ok(response.into_inner()),
-        Err(ClientError::UnexpectedResponse(resp)) if resp.status().is_success() => {
-            let body = resp
-                .json::<serde_json::Value>()
-                .await
-                .wrap_err("parsing launch response body")?;
-            from_body(body)
-        }
-        Err(err) => Err(format_launch_client_error(err).await),
-    }
+) -> Result<LaunchResponse> {
+    let response = match result {
+        Ok(response) => response,
+        Err(err) => return Err(format_launch_client_error(err).await),
+    };
+    let status_code = response.status().as_u16();
+    Ok(LaunchResponse {
+        run_id: launch_run_id(response.into_inner()),
+        status_code,
+    })
 }
 
-/// Parse a debug-launch response body into `(run_id, status_code)`, tolerating
-/// either the spec's snake_case `run_id` or the live API's camelCase `runId`.
-///
-/// `status_code` is the body's own `statusCode`, if present. This webhook family
-/// reports its real status in the body rather than (only) the HTTP status line,
-/// which lets a caller that has lost the transport status still tell a success
-/// envelope from an error one. Errors only if the body isn't JSON: a missing
-/// `run_id`/`runId` yields `None`, matching the generated `LaunchMvdResponse`
-/// deserializer the documented-202 path relies on (the tenant-58.6 schema makes
-/// the field optional) so both paths agree on a run-id-less success body.
-fn parse_debug_launch_body(body: &[u8]) -> Result<(Option<String>, Option<i64>)> {
-    let value: serde_json::Value =
-        serde_json::from_slice(body).wrap_err("parsing debug launch response")?;
-    let run_id = value
-        .get("run_id")
-        .or_else(|| value.get("runId"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string);
-    let status_code = value.get("statusCode").and_then(serde_json::Value::as_i64);
-    Ok((run_id, status_code))
+/// The run id in a launch response body, under either spelling: tenants from
+/// 58.6 on answer with the documented `runId`, older ones with `run_id`. Absent
+/// on a launch that started no run, and on the debugging webhook's 200, which
+/// answers `{"statusCode": 202}` alone.
+fn launch_run_id(body: serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    let run_id = body.get("runId").or_else(|| body.get("run_id"))?;
+    run_id.as_str().map(str::to_owned)
 }
 
 fn launch_mvd_request(params: &Params) -> Result<generated::types::LaunchMvdRequest> {
@@ -1039,49 +982,10 @@ fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
     body.len()
 }
 
-async fn format_api_client_error(err: ClientError<generated::types::ErrorResponse>) -> Report {
-    format_client_error(err, |body| body.message).await
-}
-
-/// Core error formatter shared across endpoints. The only endpoint-specific bit
-/// is how a documented error body yields a human message: the standard
-/// endpoints carry it in `Error_Response.message`, while the launch webhooks use
-/// the message-less `Launch_Error_Response` envelope (status code only). Callers
-/// supply that projection via `body_message`.
-async fn format_client_error<T>(
-    err: ClientError<T>,
-    body_message: impl FnOnce(T) -> String,
-) -> Report {
-    match err {
-        ClientError::ErrorResponse(response) => {
-            let status = response.status().as_u16();
-            let body = response.into_inner();
-            format_api_error(status, &body_message(body))
-        }
-        ClientError::UnexpectedResponse(response) => {
-            let status = response.status().as_u16();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
-            format_api_error(status, &body)
-        }
-        ClientError::InvalidRequest(message) => eyre!("invalid API request: {message}"),
-        ClientError::CommunicationError(err) => eyre!(err).wrap_err("failed to contact API"),
-        ClientError::InvalidUpgrade(err) => eyre!(err).wrap_err("invalid API upgrade response"),
-        ClientError::ResponseBodyError(err) => {
-            eyre!(err).wrap_err("failed to read API response body")
-        }
-        ClientError::InvalidResponsePayload(body, err) => {
-            let body = String::from_utf8_lossy(&body);
-            if body.trim().is_empty() {
-                eyre!("API returned an empty response body where a JSON payload was expected")
-            } else {
-                let snippet = format_payload_snippet(&body, err.line(), err.column());
-                eyre!("invalid API response payload: {err}").section(snippet.header("payload:"))
-            }
-        }
-        ClientError::Custom(message) => eyre!(message),
+async fn format_api_client_error(err: ClientError<()>) -> Report {
+    match classify_client_error(err).await {
+        ApiFailure::Response { status, message } => format_api_error(status, &message),
+        ApiFailure::Other(report) => report,
     }
 }
 
@@ -1090,23 +994,108 @@ async fn format_client_error<T>(
 /// some gateway-level rejections (auth, rate limiting) with no payload at all,
 /// so the empty body is expected there. Call from launch_test / launch_debugging
 /// only — other endpoints have their own meaningful responses for empty bodies.
-async fn format_launch_client_error(
-    err: ClientError<generated::types::LaunchErrorResponse>,
-) -> Report {
-    let body_is_empty = matches!(
-        &err,
-        ClientError::InvalidResponsePayload(body, _)
-            if body.iter().all(u8::is_ascii_whitespace)
-    );
-    // Launch_Error_Response carries no message field — only a status code that
-    // already matches the HTTP status — so there is nothing to project.
-    let report = format_client_error(err, |_body| String::new()).await;
-    if body_is_empty {
-        report.with_suggestion(|| {
-            "the launch endpoints return an empty body for some gateway-level rejections (for example authentication or rate limiting). Check that your credentials are valid and have access to this tenant; if the problem persists, contact Antithesis support."
-        })
-    } else {
-        report
+async fn format_launch_client_error(err: ClientError<()>) -> Report {
+    match classify_client_error(err).await {
+        ApiFailure::Response { status, message } if message.is_empty() => {
+            format_api_error(status, &message).with_suggestion(|| {
+                "the launch endpoints return an empty body for some gateway-level rejections (for example authentication or rate limiting), so there is no detail to show beyond the status; if the problem persists, contact Antithesis support."
+            })
+        }
+        ApiFailure::Response { status, message } => format_api_error(status, &message),
+        ApiFailure::Other(report) => report,
+    }
+}
+
+/// A client error reduced to what a user-facing message is built from.
+enum ApiFailure {
+    /// The server answered. `status` is the transport status — the only
+    /// authority on success or failure, per the API team's confirmation on
+    /// #180 — and `message` the human-readable text of the body it came with.
+    Response { status: u16, message: String },
+    /// No usable response: a transport failure, or a success body snouty could
+    /// not parse.
+    Other(Report),
+}
+
+/// Classify a client error. Anything the server answered keeps its HTTP status:
+/// `build.rs` documents no error responses, so the generated client never types
+/// an error body and a failure can no longer degrade into the status-less
+/// `InvalidResponsePayload` — whatever shape the body arrives in.
+async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
+    match err {
+        // Every HTTP failure lands here, carrying both its status and its body
+        // exactly as the server sent them.
+        ClientError::UnexpectedResponse(response) => {
+            let status = response.status().as_u16();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
+            ApiFailure::Response {
+                status,
+                message: error_body_message(body),
+            }
+        }
+        // No operation documents an error response, so the generated client has
+        // no typed error body to construct this from.
+        ClientError::ErrorResponse(response) => ApiFailure::Response {
+            status: response.status().as_u16(),
+            message: String::new(),
+        },
+        ClientError::InvalidRequest(message) => {
+            ApiFailure::Other(eyre!("invalid API request: {message}"))
+        }
+        ClientError::CommunicationError(err) => {
+            ApiFailure::Other(eyre!(err).wrap_err("failed to contact API"))
+        }
+        ClientError::InvalidUpgrade(err) => {
+            ApiFailure::Other(eyre!(err).wrap_err("invalid API upgrade response"))
+        }
+        ClientError::ResponseBodyError(err) => {
+            ApiFailure::Other(eyre!(err).wrap_err("failed to read API response body"))
+        }
+        // Only a *success* body can land here: no error response is typed, so
+        // none of them is ever parsed.
+        ClientError::InvalidResponsePayload(body, err) => {
+            let body = String::from_utf8_lossy(&body);
+            ApiFailure::Other(if body.trim().is_empty() {
+                eyre!("API returned an empty response body where a JSON payload was expected")
+            } else {
+                let snippet = format_payload_snippet(&body, err.line(), err.column());
+                eyre!("invalid API response payload: {err}").section(snippet.header("payload:"))
+            })
+        }
+        ClientError::Custom(message) => ApiFailure::Other(eyre!(message)),
+    }
+}
+
+/// The human-readable text of an error response body.
+///
+/// The standard endpoints answer with `{"message": "…"}`, so unwrap that when
+/// it's there. Anything else — an empty body, an HTML error page from an
+/// intermediary, the launch endpoints' `{"statusCode", "runId"}` envelope, or a
+/// shape the spec never described — is shown verbatim (whitespace collapsed, and
+/// truncated if it's a whole web page) so the user still has something to debug
+/// with.
+///
+/// The body is only ever *displayed* here, never parsed for a status: the launch
+/// envelope's `statusCode` duplicates the status line snouty already printed
+/// from the transport. Echoing the envelope anyway is still worth it, because
+/// whether `runId` is present distinguishes a rejection the test launcher
+/// produced from one an intermediary made on its behalf.
+fn error_body_message(body: String) -> String {
+    const MAX_LEN: usize = 200;
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body)
+        && let Some(message) = value.get("message").and_then(serde_json::Value::as_str)
+    {
+        return message.trim().to_owned();
+    }
+
+    let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    match collapsed.char_indices().nth(MAX_LEN) {
+        Some((offset, _)) => format!("{}…", &collapsed[..offset]),
+        None => collapsed,
     }
 }
 
@@ -1118,33 +1107,18 @@ mod tests {
     use wiremock::matchers::{method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    // The launch body is free-form by the time it reaches snouty, so the run id
+    // is read out of it by hand: `runId` from 58.6 on, `run_id` before that, and
+    // absent on a launch that started no run.
     #[test]
-    fn parse_debug_launch_body_reads_snake_case_run_id() {
-        let (run_id, status) = parse_debug_launch_body(br#"{"run_id":"abc-1"}"#).unwrap();
-        assert_eq!(run_id.as_deref(), Some("abc-1"));
-        assert_eq!(status, None);
-    }
+    fn launch_run_id_reads_either_spelling() {
+        let run_id = |body: &str| launch_run_id(serde_json::from_str(body).unwrap());
 
-    #[test]
-    fn parse_debug_launch_body_reads_camel_case_run_id_and_status_code() {
-        let (run_id, status) =
-            parse_debug_launch_body(br#"{"runId":"xyz-2","statusCode":202}"#).unwrap();
-        assert_eq!(run_id.as_deref(), Some("xyz-2"));
-        assert_eq!(status, Some(202));
-    }
-
-    // The tenant-58.6 schema makes runId optional, so a success body may omit it.
-    // Both parsing paths must treat that as run_id: None, not a hard error.
-    #[test]
-    fn parse_debug_launch_body_tolerates_missing_run_id() {
-        let (run_id, status) = parse_debug_launch_body(br#"{"statusCode":202}"#).unwrap();
-        assert_eq!(run_id, None);
-        assert_eq!(status, Some(202));
-    }
-
-    #[test]
-    fn parse_debug_launch_body_errors_on_non_json() {
-        assert!(parse_debug_launch_body(b"not json").is_err());
+        assert_eq!(run_id(r#"{"runId":"abc-1"}"#).as_deref(), Some("abc-1"));
+        assert_eq!(run_id(r#"{"run_id":"abc-1"}"#).as_deref(), Some("abc-1"));
+        assert_eq!(run_id(r#"{"statusCode":202}"#), None);
+        assert_eq!(run_id(r#"{"runId":null}"#), None);
+        assert_eq!(run_id("{}"), None);
     }
 
     fn test_api_optionally_with_cache(
@@ -1261,10 +1235,7 @@ mod tests {
     #[tokio::test]
     async fn format_api_client_error_describes_empty_invalid_payload() {
         let parse_err = serde_json::from_slice::<serde_json::Value>(b"").unwrap_err();
-        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
-            Default::default(),
-            parse_err,
-        );
+        let err = ClientError::<()>::InvalidResponsePayload(Default::default(), parse_err);
 
         let report = format_api_client_error(err).await;
         let message = format!("{report}");
@@ -1282,17 +1253,27 @@ mod tests {
         );
     }
 
+    /// A served error, in the shape the generated client hands every HTTP
+    /// failure to the formatters: no error response is documented, so the
+    /// status and the raw body both survive.
+    fn served_error(status: u16, body: &str) -> ClientError<()> {
+        let response = http::Response::builder()
+            .status(status)
+            .body(body.to_owned())
+            .map(reqwest::Response::from)
+            .unwrap();
+        ClientError::UnexpectedResponse(response)
+    }
+
     #[tokio::test]
     async fn format_launch_client_error_attaches_suggestion_for_empty_body() {
-        let parse_err = serde_json::from_slice::<serde_json::Value>(b"").unwrap_err();
-        let err = ClientError::<generated::types::LaunchErrorResponse>::InvalidResponsePayload(
-            Default::default(),
-            parse_err,
-        );
-
-        let report = format_launch_client_error(err).await;
+        let report = format_launch_client_error(served_error(401, "")).await;
         let debug = format!("{report:?}");
 
+        assert!(
+            debug.contains("API error: 401"),
+            "the transport status must survive an empty body, got: {debug}"
+        );
         assert!(
             debug.contains("Antithesis support"),
             "expected launch-specific suggestion, got: {debug}"
@@ -1305,30 +1286,51 @@ mod tests {
 
     #[tokio::test]
     async fn format_launch_client_error_skips_suggestion_for_non_empty_body() {
-        let body: &[u8] = b"not json";
-        let parse_err = serde_json::from_slice::<serde_json::Value>(body).unwrap_err();
-        let err = ClientError::<generated::types::LaunchErrorResponse>::InvalidResponsePayload(
-            body.to_vec().into(),
-            parse_err,
-        );
-
-        let report = format_launch_client_error(err).await;
+        let report = format_launch_client_error(served_error(400, "not json")).await;
         let debug = format!("{report:?}");
 
+        assert!(debug.contains("API error: 400"), "got: {debug}");
+        assert!(debug.contains("not json"), "got: {debug}");
         assert!(
             !debug.contains("Antithesis support"),
             "non-empty body must not attach the launch suggestion, got: {debug}"
         );
     }
 
+    // The standard `{"message": …}` envelope is unwrapped; anything else is
+    // shown verbatim so the user can still see what the server said.
+    #[test]
+    fn error_body_message_unwraps_the_standard_envelope() {
+        assert_eq!(
+            error_body_message(r#"{"message":"limit must be 1..100"}"#.to_owned()),
+            "limit must be 1..100"
+        );
+        assert_eq!(
+            error_body_message(r#"{"statusCode":404,"runId":null}"#.to_owned()),
+            r#"{"statusCode":404,"runId":null}"#
+        );
+        assert_eq!(error_body_message(String::new()), "");
+    }
+
+    // An intermediary's error page is multi-line and can be enormous; collapse
+    // it onto one line and cap it so it stays a usable one-line diagnostic.
+    #[test]
+    fn error_body_message_collapses_and_truncates_html() {
+        let message = error_body_message(format!(
+            "<html>\n  <body>{}</body>\n</html>\n",
+            "x".repeat(500)
+        ));
+        assert!(message.starts_with("<html> <body>xxx"), "got: {message}");
+        assert!(!message.contains('\n'), "got: {message}");
+        assert!(message.ends_with('…'), "got: {message}");
+        assert_eq!(message.chars().count(), 201);
+    }
+
     #[tokio::test]
     async fn format_api_client_error_keeps_snippet_for_non_empty_invalid_payload() {
         let body: &[u8] = b"not json";
         let parse_err = serde_json::from_slice::<serde_json::Value>(body).unwrap_err();
-        let err = ClientError::<generated::types::ErrorResponse>::InvalidResponsePayload(
-            body.to_vec().into(),
-            parse_err,
-        );
+        let err = ClientError::<()>::InvalidResponsePayload(body.to_vec().into(), parse_err);
 
         let report = format_api_client_error(err).await;
         // The message is the bare statement …
@@ -1487,8 +1489,8 @@ mod tests {
         );
     }
 
-    // The launch webhooks return HTTP 200 with the real status in the body,
-    // even though the spec documents 202. snouty accepts any 2xx as success.
+    // The launch webhooks answer an undocumented HTTP 200 whose body claims 202.
+    // snouty accepts any 2xx as success and reports the transport status.
     #[tokio::test]
     async fn launch_test_accepts_200_webhook_envelope() {
         let mock_server = MockServer::start().await;
@@ -1508,7 +1510,128 @@ mod tests {
 
         let response = api.launch_test("basic_test", &params).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("run-123"));
+        assert_eq!(response.status_code, 200);
+    }
+
+    /// Params for a debug launch against a fixed run.
+    fn debug_params() -> Params {
+        Params::from_key_value_pairs([
+            "antithesis.debugging.run_id=a2a4-53-1",
+            "antithesis.debugging.input_hash=-1",
+            "antithesis.debugging.vtime=1.0",
+        ])
+        .unwrap()
+    }
+
+    async fn mock_debug_launch(status: u16, body: &str) -> MockServer {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/debugging"))
+            .respond_with(
+                ResponseTemplate::new(status)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(body),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        mock_server
+    }
+
+    async fn mock_launch_test(status: u16, body: &str) -> MockServer {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/launch/basic_test"))
+            .respond_with(
+                ResponseTemplate::new(status)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(body),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        mock_server
+    }
+
+    // A pre-58.6 tenant answers the documented 202 with a snake_case `run_id`
+    // and no statusCode at all. That body predates the envelope the spec now
+    // documents and must still be accepted as a successful launch.
+    #[tokio::test]
+    async fn launch_debugging_accepts_snake_case_202_body() {
+        let mock_server = mock_debug_launch(202, r#"{"run_id":"abc-1"}"#).await;
+        let api = test_api_optionally_with_cache(&mock_server, None);
+
+        let response = api.launch_debugging(&debug_params()).await.unwrap();
+        assert_eq!(response.run_id.as_deref(), Some("abc-1"));
         assert_eq!(response.status_code, 202);
+    }
+
+    // The body's own statusCode is ignored outright: a 200 carrying `202`
+    // reports 200, the status the transport actually used.
+    #[tokio::test]
+    async fn launch_debugging_reports_the_transport_status_not_the_body() {
+        let mock_server = mock_debug_launch(200, r#"{"runId":"x","statusCode":202}"#).await;
+        let api = test_api_optionally_with_cache(&mock_server, None);
+
+        let response = api.launch_debugging(&debug_params()).await.unwrap();
+        assert_eq!(response.run_id.as_deref(), Some("x"));
+        assert_eq!(response.status_code, 200);
+    }
+
+    // …and the converse, which is the regression guard for the removed
+    // "recover when the body self-reports a 2xx" gate: a body claiming success
+    // can never turn an error status into a launch.
+    #[tokio::test]
+    async fn launch_debugging_rejects_success_body_on_error_status() {
+        for status in [400, 403, 500] {
+            let mock_server = mock_debug_launch(status, r#"{"statusCode":202}"#).await;
+            let api = test_api_optionally_with_cache(&mock_server, None);
+
+            let report = api.launch_debugging(&debug_params()).await.unwrap_err();
+            assert_eq!(crate::error::api_error_status(&report), Some(status));
+        }
+    }
+
+    // Error bodies are taken as they come — empty, HTML, the live envelope, or
+    // the pre-58.6 `{message}` shape — and every one keeps the HTTP status.
+    #[tokio::test]
+    async fn launch_test_reports_the_status_for_any_error_body() {
+        for body in [
+            "",
+            "<html><body>404 Not Found</body></html>",
+            r#"{"statusCode":404,"runId":null}"#,
+        ] {
+            let mock_server = mock_launch_test(404, body).await;
+            let api = test_api_optionally_with_cache(&mock_server, None);
+            let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
+
+            let report = api.launch_test("basic_test", &params).await.unwrap_err();
+            assert_eq!(
+                crate::error::api_error_status(&report),
+                Some(404),
+                "body {body:?} lost its status"
+            );
+            assert!(
+                format!("{report:#}").contains("API error: 404 Not Found"),
+                "body {body:?} produced: {report:#}"
+            );
+        }
+    }
+
+    // The pre-58.6 launch endpoints answered with the standard `{message}`
+    // envelope, which `Launch_Error_Response` cannot represent. Surface the text
+    // anyway rather than reducing the failure to a bare status line.
+    #[tokio::test]
+    async fn launch_test_surfaces_the_error_message_body() {
+        let mock_server = mock_launch_test(404, r#"{"message":"bad request"}"#).await;
+        let api = test_api_optionally_with_cache(&mock_server, None);
+        let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
+
+        let report = api.launch_test("basic_test", &params).await.unwrap_err();
+        assert_eq!(
+            format!("{report:#}"),
+            "API error: 404 Not Found — bad request"
+        );
     }
 
     #[tokio::test]
@@ -1543,56 +1666,23 @@ mod tests {
     // than hard-erroring on the missing field.
     #[tokio::test]
     async fn launch_debugging_accepts_200_without_run_id() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/debugging"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "statusCode": 202 })),
-            )
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
+        let mock_server = mock_debug_launch(200, r#"{"statusCode":202}"#).await;
         let api = test_api_optionally_with_cache(&mock_server, None);
-        let params = Params::from_key_value_pairs([
-            "antithesis.debugging.run_id=a2a4-53-1",
-            "antithesis.debugging.input_hash=-1",
-            "antithesis.debugging.vtime=1.0",
-        ])
-        .unwrap();
 
-        let response = api.launch_debugging(&params).await.unwrap();
+        let response = api.launch_debugging(&debug_params()).await.unwrap();
         assert_eq!(response.run_id, None);
-        assert_eq!(response.status_code, 202);
+        assert_eq!(response.status_code, 200);
     }
 
     // The documented 202 body and the live webhook envelope have converged on
-    // `{ statusCode, runId }`, which the generated client parses directly. We
-    // carry the body's own status code through rather than assuming 202.
+    // `{ statusCode, runId }`, which the generated client parses directly.
     #[tokio::test]
     async fn launch_debugging_accepts_202_documented() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/debugging"))
-            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
-                "statusCode": 202,
-                "runId": "debug-run-456"
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
+        let mock_server =
+            mock_debug_launch(202, r#"{"statusCode":202,"runId":"debug-run-456"}"#).await;
         let api = test_api_optionally_with_cache(&mock_server, None);
-        let params = Params::from_key_value_pairs([
-            "antithesis.debugging.run_id=a2a4-53-1",
-            "antithesis.debugging.input_hash=-1",
-            "antithesis.debugging.vtime=1.0",
-        ])
-        .unwrap();
 
-        let response = api.launch_debugging(&params).await.unwrap();
+        let response = api.launch_debugging(&debug_params()).await.unwrap();
         assert_eq!(response.run_id.as_deref(), Some("debug-run-456"));
         assert_eq!(response.status_code, 202);
     }
@@ -1600,34 +1690,80 @@ mod tests {
     // A documented error status carries the `Launch_Error_Response` envelope
     // (`{ statusCode, runId }`). Its `runId` is informational only and must never
     // be mistaken for a successful launch: the non-2xx HTTP status keeps this an
-    // error even though the body parses cleanly.
+    // error even though the body parses cleanly. The body is still echoed for
+    // debugging, so assert on the outcome rather than on the absent run id.
     #[tokio::test]
     async fn launch_debugging_rejects_error_body_carrying_run_id() {
-        let mock_server = MockServer::start().await;
+        let mock_server =
+            mock_debug_launch(403, r#"{"statusCode":403,"runId":"not-a-launch"}"#).await;
+        let api = test_api_optionally_with_cache(&mock_server, None);
 
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/debugging"))
-            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
-                "statusCode": 403,
-                "runId": "should-not-be-reported"
-            })))
+        let report = api.launch_debugging(&debug_params()).await.unwrap_err();
+        assert_eq!(crate::error::api_error_status(&report), Some(403));
+    }
+
+    async fn mock_version(status: u16, body: &str) -> MockServer {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(status).set_body_string(body))
             .expect(1)
             .mount(&mock_server)
             .await;
+        mock_server
+    }
 
+    #[tokio::test]
+    async fn get_version_reads_the_documented_body() {
+        let mock_server = mock_version(
+            200,
+            r#"{"latest_api_version":"v1","release_version":"58.6"}"#,
+        )
+        .await;
         let api = test_api_optionally_with_cache(&mock_server, None);
-        let params = Params::from_key_value_pairs([
-            "antithesis.debugging.run_id=a2a4-53-1",
-            "antithesis.debugging.input_hash=-1",
-            "antithesis.debugging.vtime=1.0",
-        ])
-        .unwrap();
 
-        let err = api.launch_debugging(&params).await.unwrap_err().to_string();
-        assert!(
-            !err.contains("should-not-be-reported"),
-            "a 403 error body must not be reported as a successful launch: {err}"
-        );
+        let version = api.get_version().await.unwrap();
+        assert_eq!(version.latest_api_version, "v1");
+        assert_eq!(version.release_version, "58.6");
+    }
+
+    // The gateway rejects a bad token with a documented status and an *empty*
+    // body (content-type: text/plain). Before the transport-level normalization
+    // that body failed `Error_Response` parsing, which cost the status and left
+    // `snouty doctor` reporting the API as unreachable instead of as rejecting
+    // authentication. Every non-conforming error body must keep its status:
+    // empty, an intermediary's HTML page, or an unexpected JSON shape.
+    #[tokio::test]
+    async fn get_version_keeps_the_status_for_non_conforming_error_bodies() {
+        let cases = [
+            (401, ""),
+            (401, "<html><body>Unauthorized</body></html>"),
+            (406, r#"{"statusCode":406}"#),
+            (429, ""),
+            (500, "<html><body>502 upstream</body></html>"),
+        ];
+        for (status, body) in cases {
+            let mock_server = mock_version(status, body).await;
+            let api = test_api_optionally_with_cache(&mock_server, None);
+
+            match api.get_version().await {
+                Err(VersionError::Http(code)) => assert_eq!(code, status),
+                other => panic!("expected Http({status}) for body {body:?}, got {other:?}"),
+            }
+        }
+    }
+
+    // A 404 is undocumented for this operation, so it never went through the
+    // typed-body path; keep it covered so the normalization can't regress it.
+    #[tokio::test]
+    async fn get_version_keeps_the_status_for_an_undocumented_404() {
+        let mock_server = mock_version(404, "").await;
+        let api = test_api_optionally_with_cache(&mock_server, None);
+
+        match api.get_version().await {
+            Err(VersionError::Http(404)) => {}
+            other => panic!("expected Http(404), got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -984,22 +984,10 @@ fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
 }
 
 /// Render a failed API call for the user, status first.
-///
-/// A status with no body at all gets a note explaining the silence. That is the
-/// gateway's shape for some rejections — a bad token comes back 401/403 with
-/// `content-type: text/plain` and zero length — and it is not specific to any
-/// endpoint: `GET /api/version` answers exactly the same way, which is what
-/// `snouty doctor` trips over in #180. The note deliberately says nothing about
-/// credentials, because [`format_api_error`] already attaches that on a 401/403
-/// and this fires for 429 and 5xx too.
 async fn format_api_client_error(err: ClientError<()>) -> Report {
     match classify_client_error(err).await {
-        ApiFailure::Response { status, message } if message.is_empty() => {
-            format_api_error(status, "").with_suggestion(|| {
-                "the API answers some gateway-level rejections (for example authentication or rate limiting) with an empty body, so there is no detail to show beyond the status; if the problem persists, contact Antithesis support."
-            })
-        }
-        failure => failure.into_report(),
+        ApiFailure::Response { status, message } => format_api_error(status, &message),
+        ApiFailure::Other(report) => report,
     }
 }
 
@@ -1014,15 +1002,6 @@ enum ApiFailure {
     Other(Report),
 }
 
-impl ApiFailure {
-    fn into_report(self) -> Report {
-        match self {
-            ApiFailure::Response { status, message } => format_api_error(status, &message),
-            ApiFailure::Other(report) => report,
-        }
-    }
-}
-
 /// Classify a client error. Anything the server answered keeps its HTTP status:
 /// `build.rs` documents no error responses, so the generated client never types
 /// an error body and a failure can no longer degrade into the status-less
@@ -1033,24 +1012,16 @@ async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
         // exactly as the server sent them.
         ClientError::UnexpectedResponse(response) => {
             let status = response.status().as_u16();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
             ApiFailure::Response {
                 status,
-                message: error_body_message(&body),
+                message: error_body_message(&read_error_body(response).await),
             }
         }
-        // Unreachable in practice — progenitor only emits this arm for a
-        // *documented* error response, and `build.rs` asserts the generated
-        // client has none. Kept as the same status-first outcome rather than a
-        // panic: it costs two lines, and a CLI should never abort on something a
-        // server said.
-        ClientError::ErrorResponse(response) => ApiFailure::Response {
-            status: response.status().as_u16(),
-            message: String::new(),
-        },
+        // Unreachable: progenitor only emits this arm for a *documented* error
+        // response, and `build.rs` asserts the generated client has none.
+        ClientError::ErrorResponse(_) => {
+            unreachable!("no error response is documented; see build.rs untype_error_responses")
+        }
         ClientError::InvalidRequest(message) => {
             ApiFailure::Other(eyre!("invalid API request: {message}"))
         }
@@ -1078,49 +1049,64 @@ async fn classify_client_error(err: ClientError<()>) -> ApiFailure {
     }
 }
 
-/// The human-readable text of an error response body.
+/// How much of an error response body to read. Error bodies are meant to be a
+/// sentence; anything far past that is an intermediary's web page, and only the
+/// first line of it will ever be shown. Bounding the read keeps a misbehaving
+/// proxy from making snouty buffer an arbitrarily large body to print 200
+/// characters of it.
+const MAX_ERROR_BODY: usize = 4 * 1024;
+
+/// Read up to [`MAX_ERROR_BODY`] of an error response, chunk by chunk, and drop
+/// the rest. Truncating mid-character is fine — the result is only ever
+/// displayed, and `from_utf8_lossy` renders a split character as `U+FFFD`.
+async fn read_error_body(mut response: reqwest::Response) -> String {
+    let mut body = Vec::new();
+    while body.len() < MAX_ERROR_BODY {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let remaining = MAX_ERROR_BODY - body.len();
+                body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+            }
+            Ok(None) => break,
+            Err(err) => return format!("<failed to read response body: {err}>"),
+        }
+    }
+    String::from_utf8_lossy(&body).into_owned()
+}
+
+/// The human-readable text of an error response body, as one terminal line.
 ///
 /// The standard endpoints answer with `{"message": "…"}`, so unwrap that when
 /// it's there. Anything else — an empty body, an HTML error page from an
 /// intermediary, the launch endpoints' `{"statusCode", "runId"}` envelope, or a
-/// shape the spec never described — is shown verbatim (whitespace collapsed, and
-/// truncated if it's a whole web page) so the user still has something to debug
-/// with.
-///
-/// Echoing the launch endpoints' `{statusCode, runId}` envelope is worth it even
-/// though its `statusCode` duplicates the status line: whether `runId` is present
+/// shape the spec never described — is shown as it came, so the user still has
+/// something to debug with. Echoing the launch envelope is worth it even though
+/// its `statusCode` duplicates the status line: whether `runId` is present
 /// distinguishes a rejection the test launcher produced from one an intermediary
 /// made on its behalf.
+///
+/// Runs of whitespace collapse to a single space before the cut, so that an
+/// indented error page spends the 200 characters on its text rather than on its
+/// margins. [`sanitize`] is the repo's policy for untrusted text on one line; it
+/// runs after the collapse, which leaves it nothing to do about newlines and
+/// only control characters to escape.
 fn error_body_message(body: &str) -> String {
     const MAX_LEN: usize = 200;
 
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(body)
-        && let Some(message) = value.get("message").and_then(serde_json::Value::as_str)
-    {
-        return sanitize(message.trim());
-    }
+    let text = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| body.split_whitespace().collect::<Vec<_>>().join(" "));
 
-    // Collapse onto one line, stopping once there are certainly enough bytes to
-    // fill MAX_LEN chars (a char is at most 4 bytes), so a whole web page isn't
-    // rebuilt just to be cut down.
-    let mut collapsed = String::new();
-    for word in body.split_whitespace() {
-        if collapsed.len() > MAX_LEN * 4 {
-            break;
-        }
-        if !collapsed.is_empty() {
-            collapsed.push(' ');
-        }
-        collapsed.push_str(word);
-    }
-
-    // An intermediary's page can carry control characters; `sanitize` is the
-    // repo's policy for making untrusted text safe to print on one line, and it
-    // runs after collapsing so its newline escaping never has anything to do.
-    let collapsed = sanitize(&collapsed);
-    match collapsed.char_indices().nth(MAX_LEN) {
-        Some((offset, _)) => format!("{}…", &collapsed[..offset]),
-        None => collapsed,
+    let text = sanitize(text.trim());
+    match text.char_indices().nth(MAX_LEN) {
+        Some((offset, _)) => format!("{}…", &text[..offset]),
+        None => text,
     }
 }
 
@@ -1276,11 +1262,11 @@ mod tests {
         ClientError::UnexpectedResponse(response)
     }
 
-    // Every endpoint gets the empty-body note, not just launch: the gateway
-    // answers the same way whichever one you hit, so 429 on `runs list` explains
-    // its silence the way a 401 on `launch` does.
+    // The status is the whole message when the server sent no body — which is
+    // what the gateway does for some rejections, on any endpoint. The point of
+    // #180 is that the status survives that; nothing further is added.
     #[tokio::test]
-    async fn format_api_client_error_attaches_suggestion_for_empty_body() {
+    async fn format_api_client_error_reports_the_status_for_an_empty_body() {
         for status in [401, 429, 502] {
             let report = format_api_client_error(served_error(status, "")).await;
             let debug = format!("{report:?}");
@@ -1289,28 +1275,41 @@ mod tests {
                 debug.contains(&format!("API error: {status}")),
                 "the transport status must survive an empty body, got: {debug}"
             );
-            assert!(
-                debug.contains("Antithesis support"),
-                "expected the empty-body suggestion, got: {debug}"
-            );
-            assert!(
-                debug.contains("authentication or rate limiting"),
-                "expected gateway-rejection wording in suggestion, got: {debug}"
-            );
         }
     }
 
     #[tokio::test]
-    async fn format_api_client_error_skips_suggestion_for_non_empty_body() {
+    async fn format_api_client_error_shows_a_non_empty_body() {
         let report = format_api_client_error(served_error(400, "not json")).await;
         let debug = format!("{report:?}");
 
         assert!(debug.contains("API error: 400"), "got: {debug}");
         assert!(debug.contains("not json"), "got: {debug}");
-        assert!(
-            !debug.contains("Antithesis support"),
-            "non-empty body must not attach the empty-body suggestion, got: {debug}"
-        );
+    }
+
+    // The read is bounded, so a proxy answering an error with a huge page cannot
+    // make snouty buffer all of it just to print 200 characters.
+    #[tokio::test]
+    async fn read_error_body_stops_at_the_cap() {
+        let mock_server =
+            mock_endpoint("GET", "/api/version", 500, &"x".repeat(MAX_ERROR_BODY * 3)).await;
+        let response = reqwest::get(format!("{}/api/version", mock_server.uri()))
+            .await
+            .unwrap();
+
+        assert_eq!(read_error_body(response).await.len(), MAX_ERROR_BODY);
+    }
+
+    // A body under the cap is returned whole, so the bound never truncates a
+    // real error message.
+    #[tokio::test]
+    async fn read_error_body_keeps_a_short_body_intact() {
+        let mock_server = mock_endpoint("GET", "/api/version", 500, "upstream is down").await;
+        let response = reqwest::get(format!("{}/api/version", mock_server.uri()))
+            .await
+            .unwrap();
+
+        assert_eq!(read_error_body(response).await, "upstream is down");
     }
 
     // The standard `{"message": …}` envelope is unwrapped; anything else is

--- a/src/api.rs
+++ b/src/api.rs
@@ -776,7 +776,7 @@ async fn finish_launch<T: DeserializeOwned>(
                 .await
                 .wrap_err("parsing launch response body")
         }
-        Err(err) => Err(format_launch_client_error(err).await),
+        Err(err) => Err(format_api_client_error(err).await),
     }
 }
 
@@ -983,20 +983,20 @@ fn char_pos_to_byte_offset(body: &str, line: usize, column: usize) -> usize {
     body.len()
 }
 
+/// Render a failed API call for the user, status first.
+///
+/// A status with no body at all gets a note explaining the silence. That is the
+/// gateway's shape for some rejections — a bad token comes back 401/403 with
+/// `content-type: text/plain` and zero length — and it is not specific to any
+/// endpoint: `GET /api/version` answers exactly the same way, which is what
+/// `snouty doctor` trips over in #180. The note deliberately says nothing about
+/// credentials, because [`format_api_error`] already attaches that on a 401/403
+/// and this fires for 429 and 5xx too.
 async fn format_api_client_error(err: ClientError<()>) -> Report {
-    classify_client_error(err).await.into_report()
-}
-
-/// Same as [`format_api_client_error`] but adds a launch-specific suggestion
-/// when the server returned an empty body. The launch/debug endpoints answer
-/// some gateway-level rejections (auth, rate limiting) with no payload at all,
-/// so the empty body is expected there. Call from launch_test / launch_debugging
-/// only — other endpoints have their own meaningful responses for empty bodies.
-async fn format_launch_client_error(err: ClientError<()>) -> Report {
     match classify_client_error(err).await {
         ApiFailure::Response { status, message } if message.is_empty() => {
             format_api_error(status, "").with_suggestion(|| {
-                "the launch endpoints return an empty body for some gateway-level rejections (for example authentication or rate limiting), so there is no detail to show beyond the status; if the problem persists, contact Antithesis support."
+                "the API answers some gateway-level rejections (for example authentication or rate limiting) with an empty body, so there is no detail to show beyond the status; if the problem persists, contact Antithesis support."
             })
         }
         failure => failure.into_report(),
@@ -1276,35 +1276,40 @@ mod tests {
         ClientError::UnexpectedResponse(response)
     }
 
+    // Every endpoint gets the empty-body note, not just launch: the gateway
+    // answers the same way whichever one you hit, so 429 on `runs list` explains
+    // its silence the way a 401 on `launch` does.
     #[tokio::test]
-    async fn format_launch_client_error_attaches_suggestion_for_empty_body() {
-        let report = format_launch_client_error(served_error(401, "")).await;
-        let debug = format!("{report:?}");
+    async fn format_api_client_error_attaches_suggestion_for_empty_body() {
+        for status in [401, 429, 502] {
+            let report = format_api_client_error(served_error(status, "")).await;
+            let debug = format!("{report:?}");
 
-        assert!(
-            debug.contains("API error: 401"),
-            "the transport status must survive an empty body, got: {debug}"
-        );
-        assert!(
-            debug.contains("Antithesis support"),
-            "expected launch-specific suggestion, got: {debug}"
-        );
-        assert!(
-            debug.contains("authentication or rate limiting"),
-            "expected gateway-rejection wording in suggestion, got: {debug}"
-        );
+            assert!(
+                debug.contains(&format!("API error: {status}")),
+                "the transport status must survive an empty body, got: {debug}"
+            );
+            assert!(
+                debug.contains("Antithesis support"),
+                "expected the empty-body suggestion, got: {debug}"
+            );
+            assert!(
+                debug.contains("authentication or rate limiting"),
+                "expected gateway-rejection wording in suggestion, got: {debug}"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn format_launch_client_error_skips_suggestion_for_non_empty_body() {
-        let report = format_launch_client_error(served_error(400, "not json")).await;
+    async fn format_api_client_error_skips_suggestion_for_non_empty_body() {
+        let report = format_api_client_error(served_error(400, "not json")).await;
         let debug = format!("{report:?}");
 
         assert!(debug.contains("API error: 400"), "got: {debug}");
         assert!(debug.contains("not json"), "got: {debug}");
         assert!(
             !debug.contains("Antithesis support"),
-            "non-empty body must not attach the launch suggestion, got: {debug}"
+            "non-empty body must not attach the empty-body suggestion, got: {debug}"
         );
     }
 
@@ -1447,17 +1452,7 @@ mod tests {
 
     #[tokio::test]
     async fn launch_test_sends_snouty_user_agent() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/basic_test"))
-            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
-                "runId": "run-123",
-                "statusCode": 202
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
+        let mock_server = mock_launch_test(202, LAUNCH_OK_BODY).await;
 
         let api = test_api_optionally_with_cache(&mock_server, None);
         let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
@@ -1476,17 +1471,7 @@ mod tests {
 
     #[tokio::test]
     async fn launch_test_uses_basic_auth() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/basic_test"))
-            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
-                "runId": "run-123",
-                "statusCode": 202
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
+        let mock_server = mock_launch_test(202, LAUNCH_OK_BODY).await;
 
         let api = test_api_optionally_with_cache(&mock_server, None);
         let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
@@ -1521,17 +1506,7 @@ mod tests {
     // snouty accepts any 2xx as success and reports the transport status.
     #[tokio::test]
     async fn launch_test_accepts_200_webhook_envelope() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/api/v1/launch/basic_test"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "runId": "run-123",
-                "statusCode": 202
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
+        let mock_server = mock_launch_test(200, LAUNCH_OK_BODY).await;
 
         let api = test_api_optionally_with_cache(&mock_server, None);
         let params = Params::from_key_value_pairs(["antithesis.duration=30"]).unwrap();
@@ -1570,6 +1545,11 @@ mod tests {
     async fn mock_launch_test(status: u16, body: &str) -> MockServer {
         mock_endpoint("POST", "/api/v1/launch/basic_test", status, body).await
     }
+
+    /// The launch envelope the live webhook returns on success. Its body-level
+    /// `statusCode` deliberately disagrees with the HTTP status the mocks pair
+    /// it with, since snouty must ignore the body's copy (#180).
+    const LAUNCH_OK_BODY: &str = r#"{"runId":"run-123","statusCode":202}"#;
 
     // The body's own statusCode is ignored outright (#180): snouty reads the run
     // id and nothing else, so a body claiming 202 over an HTTP 200 has no way to


### PR DESCRIPTION
Closes #180: make the HTTP status the only authority on whether an API call succeeded, and stop letting a non-conforming error body destroy it.

## What was broken

`progenitor_client::Error::InvalidResponsePayload(Bytes, serde_json::Error)` structurally has nowhere to put the HTTP status, and `Error::status()` returns `None` for that variant ([progenitor-client 0.14, `progenitor_client.rs:364`](https://docs.rs/progenitor-client/0.14.0/src/progenitor_client/progenitor_client.rs.html)). The generated client hits it whenever a **documented** status arrives with a body that doesn't match its schema — which is exactly the case we care about, because gateways and intermediaries answer with whatever they like:

- **`GET /api/version` → 401 with an empty body** — precisely what the API gateway returns for a bad token (`content-type: text/plain`, zero length) — was classified as `VersionError::Unreachable`, so `snouty doctor` printed *"Antithesis API unreachable / could not connect to \<host\>"* instead of *"Antithesis API rejected authentication / verify ANTITHESIS_API_KEY"*. Same for 406/429/500 behind an intermediary's HTML error page. This regressed when the 58.6 spec refresh (#176) gave `getVersion` typed error responses; v0.6.1 classified it correctly.
- **`launch_debugging`** recovered an unparsable body *only when the body itself self-reported a 2xx `statusCode`*, because with the transport status gone the body was the only status left. That gate also did `status_code.unwrap_or(202)`.
- Error-envelope churn was load-bearing: because error bodies are *typed*, an unparseable one downgraded a precise "HTTP 404 — \<message\>" into "invalid API response payload".

## The one detail the fix turns on

An **undocumented** status doesn't take that variant. It takes `Error::UnexpectedResponse(reqwest::Response)`, which keeps the status *and* the raw body. That is why a 404 on `getVersion` always worked correctly — it simply isn't documented for that operation.

So this bug is entirely a function of **which responses the spec tells progenitor to type**. `build.rs` already preprocesses the vendored spec, so that is where the fix goes.

## Approach: stop documenting error responses

One new transform, `untype_error_responses`, applied to the spec before generation: drop every non-2xx response from every operation.

Error bodies are precisely the ones that don't honour the schema — the gateway's empty `text/plain`, an intermediary's HTML page, an envelope the spec never described. Typing them let any of those shapes mask the status. Untyped, every failure reaches snouty as status + raw body, and one status-first formatter renders all of them. Dropping `default` responses along with the explicit 4xx/5xx matters too: progenitor turns a `default` into a typed catch-all covering every error status, which would reintroduce the problem by another door.

**Success responses are left alone.** The spec describes them accurately and the typed bodies are what the rest of the client is built on.

`src/openapi.json` is unmodified, and `build.rs`'s `additionalProperties: false` assertion is untouched.

### What that buys in `src/api.rs`

Every operation's error type becomes `Error<()>` — the generated client went from 64 `Error::ErrorResponse` arms to zero. `classify_client_error` collapses onto a single arm that always has both the status and the body exactly as the server sent it, and the `Error_Response` / `Launch_Error_Response` split disappears from the error path. There is now exactly one formatter (`format_api_client_error`) for every endpoint, and one `ApiFailure::into_report` stating how a failure renders.

`ClientError::ErrorResponse` is unreachable — progenitor only emits that arm for a documented error response — and `build.rs` asserts zero such arms in the generated source, in the same spirit as the existing `patch_lenient_booleans` and `additionalProperties` assertions. A spec refresh that reintroduces one fails the build. (Verified by disabling the transform: the build panics.) The runtime arm still reports the status rather than panicking, because progenitor *does* generate it for a documented error response with **no content** while leaving the error type `()` — so the type system alone doesn't rule it out, and a CLI shouldn't abort with a backtrace on something a server said.

Body text reaches the user through the existing status-first `format_api_error(status, body)`: unwrapped from `{"message": …}` when that's the shape, otherwise verbatim with whitespace collapsed and anything over 200 chars truncated, then run through `render::sanitize` — the repo's control-character policy — so an intermediary's error page stays a usable one-line diagnostic and can't smuggle escape sequences into the terminal.

`launch_debugging` loses its three-arm match, its body-status gate, its `unwrap_or(202)`, and `parse_debug_launch_body`; both launch entry points now share one `finish_launch` that treats any 2xx as success.

Authentication (the `pre` hook), verbose `format_request`/`format_response` logging, and the HTTP cache path in `send_request` are all untouched. Nothing buffers a response body, so the streaming NDJSON endpoints (`get_run_logs`, `get_run_build_logs`, `search_run_events`) are unaffected by construction. `specs/runs.txt` exercises all three and passes.

## Error bodies are bounded and sanitized

`read_error_body` reads at most 4 KiB of a failed response, chunk by chunk, and drops the rest — a misbehaving proxy shouldn't get snouty to buffer an arbitrarily large page to print 200 characters of it. What's shown is then collapsed to one line, run through `render::sanitize` (the repo's policy for untrusted text on a terminal line, so an error page can't emit escape sequences), and cut at 200 characters.

## `--json` no longer emits `statusCode` ⚠️ breaking

`snouty launch --json` and `snouty debug --json` now print `{ "runId": … }` and nothing else.

The field duplicated the HTTP status of a response the caller never sees, the exit code has always been the success signal, and [the API team has confirmed](https://github.com/antithesishq/snouty/issues/180#issuecomment-5110568006) that clients should ignore the body-level `statusCode` entirely. `LaunchResponse` is now a snouty-owned struct rather than a re-exported generated type, so the `--json` contract is a deliberate choice rather than whatever the vendored schema happens to say. Both specs assert the field's absence to pin that down.

**The break to watch for:** anything using `test $(snouty launch --json | jq .statusCode) -lt 300` as a success check now reads `null` rather than failing loudly. The exit code was always the correct signal, but this is a real backwards-incompatible output change.

The HTTP status remains available with `--verbose`, which dumps the response exactly as it arrived.

## User-visible changes

| Situation | Before | After |
|---|---|---|
| `doctor`, empty-body 401 from the gateway | "Antithesis API unreachable / could not connect to \<host\>" | "Antithesis API rejected authentication / the API returned HTTP 401" |
| any command, empty error body | "API returned an empty response body where a JSON payload was expected" | "API error: 401 Unauthorized" — the status is the whole message |
| `debug`/`launch`, HTML or unexpected-shape error body | "invalid API response payload: …" | "API error: 502 Bad Gateway — \<body\>" |
| launch error carrying `{"message": …}` | status line only (the field has no home in `Launch_Error_Response`) | message text surfaced |
| error body containing control characters | printed raw to the terminal | escaped as `\xNN`, like every other API-derived text |
| `launch --json` / `debug --json` | `{ runId, statusCode }` | `{ runId }` |

## Test matrix

New unit tests in `src/api.rs`:

- `get_version_keeps_the_status_for_non_conforming_error_bodies` — 401 empty, 401 HTML, 406 unexpected-shape JSON, 429 empty, 500 HTML all yield `VersionError::Http(<status>)`, not `Unreachable`.
- `get_version_keeps_the_status_for_an_undocumented_404` / `get_version_reads_the_documented_body` — regression guards on the paths that already worked.
- `launch_test_reports_the_status_for_any_error_body` — 404 with an empty body, an HTML page, and the live `{"statusCode":404,"runId":null}` envelope all report 404 (asserted structurally via `api_error_status`, not by string-sniffing).
- `launch_test_surfaces_the_error_message_body` — 404 + `{"message":"bad request"}` renders "API error: 404 Not Found — bad request".
- `launch_debugging_ignores_the_body_status_code` — HTTP 200 + `{"runId":"x","statusCode":202}` succeeds, and the serialized `--json` envelope is `{"runId":"x"}` alone.
- `launch_debugging_rejects_success_body_on_error_status` — 400/403/500 carrying `{"statusCode":202}` all error. Regression guard for the removed "body self-reports a 2xx" gate.
- `format_api_client_error_reports_the_status_for_an_empty_body` — 401, 429 and 502 with no body each keep their status.
- `read_error_body_*` (2) — an oversized body reads exactly the 4 KiB cap; a short one comes back intact.
- `error_body_message_*` (3) — envelope unwrapping, HTML collapsing/truncation, control-character escaping.

Specs: `specs/debug.txt` (empty-body 401 now names the status; new HTML-body 502 case; `--json` asserts `statusCode` is gone), `specs/launch.txt` (same `--json` assertion, 404 wording), `specs/doctor.txt` (new empty-body 401 → "rejected authentication" case; it runs in both modes — against staging, a bad key provokes the real gateway 401), `specs/runs.txt` (new `[!staging]` empty-body 429 → the status survives a body carrying nothing).

`cargo fmt --check`, `cargo clippy --all-targets`, the full `cargo test` suite (433 lib + all integration and spec targets), and `typos` are clean.

## Revision history

**`7f9d1ba` — review round.** Dropped the empty-body suggestion (the status line already says everything the server said), bounded the error body read to 4 KiB, simplified `error_body_message` now that the bound makes a hand-rolled bounded collapse unnecessary, and put `ClientError::ErrorResponse` back to `unreachable!`.

**`2695223`** — collapsed the launch-specific formatter into the shared one (the note it carried was removed a round later), and converted the last hand-rolled launch mocks in the test module to the shared helper.

**`6697749` — quality pass.** Routed error body text through `render::sanitize`, which is the repo's control-character policy; `error_body_message` had grown a weaker private copy that only collapsed Unicode whitespace, so ESC/BEL from a proxy's error page reached the terminal unescaped. Also bounded the collapse (it used to rebuild an entire error page into a `Vec` and a `String` before discarding all but 200 chars), gave `ApiFailure` an `into_report` so the rendering rule is stated once, and folded three near-identical wiremock helpers into one.

**`e34986a` — review round.** Reverted the launch-success half of the spec transform, dropped `statusCode` from `--json`, and simplified `finish_launch`'s signature.

The reverted piece deserves calling out, because its justification was wrong. It claimed the launch body shape "varies by tenant release (`runId` vs `run_id`)". Backwards: the **pre-58.6 spec** declared `Launch_MVD_Response` with a required *snake_case* `run_id`, while the live webhook has always sent camelCase `runId`. That mismatch is what 9ec1f37 worked around and what #176 fixed at the source. No tenant emits `run_id`, so nothing needs to tolerate it — and `statusCode` is `required` in the 58.6 schema and always sent. The spec is accurate for launch success; the transform was inventing a compatibility requirement.

**`ac9352f` — approach change.** The first revision fixed this at runtime, in the progenitor `exec` hook: it buffered every error body, synthesized an envelope engineered to satisfy `Error_Response` and `Launch_Error_Response` simultaneously so the failure would land in `Error::ErrorResponse` with its status intact, and smuggled the real body past progenitor base64-encoded on a private `x-snouty-original-body` response header. Every one of those steps existed to *feed* a typed error path we don't want; documenting fewer responses removes the path instead.

That removed `normalize_response`, `normalized_launch_body`, `rebuild_response`, `original_body`, `is_launch_operation`, `ORIGINAL_BODY_HEADER`, and the `base64` use in `api.rs`.

Measured against `main`:

| | `src/api.rs` | `build.rs` | net new |
|---|---|---|---|
| `7ea9ea9` (`exec` hook) | +559 / −242 | — | **+317** |
| `7f9d1ba` (this) | +428 / −312 | +63 | **+179** |

Also considered and rejected:

- **Editing `src/openapi.json` directly.** It's vendored and refreshed wholesale (#176); the edit would vanish on the next refresh. `build.rs` is the established place, with precedent in both directions (`patch_lenient_booleans` today, the `additionalProperties` strip in git history).
- **A different generator.** openapi-generator's Rust target models errors as `ResponseContent<E>`, which does keep the status, so it would fix the bug — but it adds a Java toolchain to the build, rewrites every call site and every generated type name, and snouty's auth `pre` hook and cache-aware `exec` hook are progenitor-specific. Wildly disproportionate to one variant's missing field.
- **Configuring progenitor.** `GenerationSettings` in 0.14 has no error-handling knob; `with_patch` / `with_replacement` / `with_conversion` are typify type-level controls (derives, renames, substitute types). The only lever progenitor gives you here is what the spec documents.
- **Filing upstream** so `InvalidResponsePayload` carries the response status (issue proposal item 5) is still worth doing, but snouty no longer depends on it.

### Known trade-off

Untyping error responses gives up typed access to `Error_Response.message`. In practice `error_body_message`'s generic `{"message": …}` unwrap covers it, and the premise of #180 is that error bodies come from intermediaries that don't honour the schema anyway — but if the API later adds structured error fields (an error code, say), they'd be hand-parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb

Rebased onto `main` after #190 merged, so the specs run on the forked testscript engine. Every pattern this PR adds carries a regex trigger character, so the engine change does not alter their meaning. All checks re-verified after the rebase, including staging against a live tenant.

