### PR TITLE
Add COOKBOOK.md with the failure-moment logs recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,30 @@ Any new subcommands or flags must have a spec accompanying them. Having to chang
 an existing spec is a good sign of backwards incompatible breakage, which will
 be subject to extra review.
 
+## Cookbook
+
+`COOKBOOK.md` collects composable patterns for scripting against snouty —
+recipes that combine existing commands rather than adding new ones. Reach for it
+when a request would grow the CLI surface to serve a case that `--json` plus a
+few lines of shell already covers: a flag that special-cases one command around
+another command's concepts is harder to change later than a recipe is. PR #179
+(`runs logs --failure`) is the precedent — it was declined as a flag and became
+the first recipe instead.
+
+Recipes come from declined proposals, repeated questions, and patterns worth
+writing down once. When you add one:
+
+- Give it a header, and add a matching entry to the top-level table of contents.
+- Put a metadata block directly under the header, one italic line:
+  `*snouty <version> · <date> · source: [#N](<link>)*` — the version the recipe
+  was added in (from `Cargo.toml`), the date, and the PR or issue it came from.
+  Drop the `source:` segment when there is no link.
+- Keep examples minimal and free of error handling — no `set -euo pipefail`, no
+  null checks, no retries. A recipe is a sketch, not a program; leave room for
+  the implementation details a caller's script will need.
+- Verify every command and `jq` expression by running it before writing it down.
+  Do not guess at JSON field names.
+
 ## Tests
 
 Internal functions should be accompanied by unit tests. For small, simple

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,0 +1,36 @@
+# snouty cookbook
+
+Composable patterns for scripting against snouty. Each recipe is the smallest
+sketch that gets the job done — no error handling, no defensive checks. Fill in
+the details your script actually needs.
+
+Recipes read snouty's `--json` output, which is the stable surface for
+automation. Human output is for humans and may be reformatted at any time.
+
+## Recipes
+
+- [Stream a run's logs at its failure moment](#stream-a-runs-logs-at-its-failure-moment)
+
+## Stream a run's logs at its failure moment
+
+*snouty 0.6.1 · 2026-07-29 · source: [#179](https://github.com/antithesishq/snouty/pull/179)*
+
+`runs show --json` carries the run's failure moment; `runs logs` streams a
+timeline up to a moment. Compose the two instead of copying the moment by hand.
+
+```sh
+run=<run id>
+
+snouty runs show "$run" --json \
+  | jq -r '.failure_moment | "\(.input_hash) \(.vtime)"' \
+  | xargs snouty runs logs "$run"
+```
+
+The moment is `{"input_hash": ..., "vtime": ...}` and feeds `runs logs` in that
+order.
+
+Not every run has one. The `failure_moment` key is absent when the run has no
+moment-pinned failure, and a run that timed out or was killed reports the
+placeholder `{"input_hash": "0", "vtime": "0"}` — which streams nothing.
+`snouty runs show` treats that placeholder as "no moment"; do the same, and skip
+the log fetch rather than streaming an empty timeline.


### PR DESCRIPTION
Starts a snouty cookbook: short recipes that compose existing commands, for agents and humans writing scripts against snouty.

The first recipe is the pattern from #179. That PR proposed `runs logs --failure`, folding the failure-moment lookup into the logs command; it was declined because a flag special-casing `logs` around a `runs` concept ties two commands together for a case that `runs show --json` plus two lines of shell already covers. Writing the shell down once beats rediscovering it.

Recipe format: header, a TOC entry, and a one-line metadata block under the header giving the version and date the recipe was added plus the source PR/issue. Examples are minimal and carry no error handling — a recipe is a sketch, not a program.

`AGENTS.md` gains a Cookbook section so the next proposal that should be a recipe gets recognized as one, and the next recipe lands in this format without being told.

## Verification

Every command and `jq` expression in the recipe was run against a live tenant:

- `snouty runs show <run> --json | jq -r '.failure_moment | "\(.input_hash) \(.vtime)"'` — returns the hash and vtime in `runs logs` argument order.
- Piping that into `xargs snouty runs logs <run>` streams the failure timeline (negative input hashes pass through fine — the positionals are `allow_hyphen_values`).
- On a run without a failure, the `failure_moment` key is absent rather than null-valued. The recipe notes that case and the `0`/`0` placeholder that `RunDetail::real_failure_moment` already filters, so a script skips the fetch instead of streaming an empty timeline.

`typos` (v1.47.2, the version CI pins) reports clean. Documentation-only, so `skip-duplicate-actions` may report the build jobs as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb