### PR TITLE
Let CI provide the test registry and pre-fetch test images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,13 @@ jobs:
             podman save docker.io/antithesishq/k8s-validator:1.0.0 -o ~/k8s-validator.tar
           fi
 
+      # Pre-fetch every remote image and start the registry tests push to, so a
+      # slow or rate-limited pull fails here rather than inside a test.
+      - name: Set up test images and registry
+        shell: bash
+        timeout-minutes: 10
+        run: scripts/setup-test-images.sh "${{ matrix.runtime }}"
+
       - name: Test
         run: cargo nextest run
   tests-passed:
@@ -248,6 +255,13 @@ jobs:
       - name: Start Podman socket # required for docker-compose
         run: |
           systemctl --user start podman.socket
+
+      # This leg sets no SNOUTY_TEST_RUNTIME, so the suite exercises both
+      # engines and both need the images.
+      - name: Set up test images and registry
+        shell: bash
+        timeout-minutes: 10
+        run: scripts/setup-test-images.sh podman docker
 
       - name: Test
         run: nix-shell --run "cargo nextest run"

--- a/scripts/setup-test-images.sh
+++ b/scripts/setup-test-images.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fetch the images the test suite needs and start a registry for it to push to.
+#
+# The suite pulls these implicitly otherwise — `registry:2` when a test starts
+# its own registry, the fixture base images when a spec builds one, and
+# k8s-validator when a k8s validate spec runs. Doing it here means a slow or
+# rate-limited registry fails setup, with the engine's own error, instead of
+# failing a test minutes later for reasons that look like a bug in snouty.
+#
+# Starting the registry here is also what keeps CI off the per-test container
+# path: tests use $SNOUTY_TEST_REGISTRY when it is set and only start their own
+# when it isn't, so local runs are unaffected.
+#
+# Usage:
+#   scripts/setup-test-images.sh <engine> [<engine>...]
+#
+# Pass every engine the suite will exercise; each needs its own copy of the
+# images. Under GitHub Actions the registry address is exported to later steps.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <engine> [<engine>...]" >&2
+  exit 2
+fi
+
+# Floating tags, matching what the tests and fixtures ask for.
+IMAGES=(
+  registry:2
+  busybox
+  debian:bookworm-slim
+  docker.io/antithesishq/k8s-validator:1.0.0
+)
+
+REGISTRY_CONTAINER=snouty-test-registry
+# Fixed because tests read it from the environment, and 127.0.0.1 because snouty
+# only skips TLS verification for localhost addresses.
+REGISTRY_ADDR=127.0.0.1:5000
+
+for engine in "$@"; do
+  for image in "${IMAGES[@]}"; do
+    # Already present is the common case on macOS, where k8s-validator is
+    # restored from a cache tarball before this runs.
+    if "$engine" image inspect "$image" >/dev/null 2>&1; then
+      echo "$engine: $image already present"
+      continue
+    fi
+    echo "$engine: pulling $image"
+    "$engine" pull "$image"
+  done
+done
+
+# The first engine hosts the registry; any of them can, since tests reach it
+# over TCP rather than through the engine that runs it.
+host_engine=$1
+"$host_engine" rm -f "$REGISTRY_CONTAINER" >/dev/null 2>&1 || true
+"$host_engine" run -d --name "$REGISTRY_CONTAINER" -p "$REGISTRY_ADDR:5000" registry:2
+
+# Fail here, not in the first test that tries to push.
+for _ in $(seq 1 60); do
+  if curl -fsS "http://$REGISTRY_ADDR/v2/" >/dev/null 2>&1; then
+    echo "registry ready at $REGISTRY_ADDR"
+    if [ -n "${GITHUB_ENV:-}" ]; then
+      echo "SNOUTY_TEST_REGISTRY=$REGISTRY_ADDR" >> "$GITHUB_ENV"
+    fi
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "registry at $REGISTRY_ADDR never answered /v2/; container logs:" >&2
+"$host_engine" logs "$REGISTRY_CONTAINER" >&2 || true
+exit 1

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1515,7 +1515,16 @@ services:
             )
             .unwrap();
             std::fs::write(img_dir.path().join("file"), "x").unwrap();
-            let local = "snouty-pin-test:latest";
+            // Unique per runtime: every iteration builds byte-identical content,
+            // so a shared name would make the second push a no-op (the registry
+            // already serves that digest) and stop testing the push path. The
+            // pushed repo is `{registry}/{local name}`, so this covers both the
+            // local image store and the registry.
+            let local = format!(
+                "{}:latest",
+                crate::testutils::unique_image_prefix(&format!("pin-{}", rt.name()))
+            );
+            let local = local.as_str();
             rt.build_image(img_dir.path(), local, None, Some("linux/amd64"))
                 .unwrap_or_else(|e| panic!("{}: build: {e:?}", rt.name()));
 
@@ -1539,7 +1548,7 @@ services:
                     .unwrap()
                     .to_string())
             };
-            let pushed_prefix = format!("{addr}/snouty-pin-test:latest@sha256:");
+            let pushed_prefix = format!("{addr}/{local}@sha256:");
 
             // Case 1 — build stanza: the local build is pushed and pinned.
             let built = pinned_app(&format!(

--- a/src/container.rs
+++ b/src/container.rs
@@ -1040,7 +1040,9 @@ mod tests {
             )
             .unwrap();
 
-            let image_ref = format!("{addr}/test/snouty-config:test");
+            // Unique per runtime so iterations sharing a registry don't collide.
+            let repo = crate::testutils::unique_image_prefix(&format!("cfg-{}", rt.name()));
+            let image_ref = format!("{addr}/{repo}/snouty-config:test");
             rt.build_and_push_config_image(dir.path(), &image_ref)
                 .unwrap_or_else(|e| panic!("{}: {e:?}", rt.name()));
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -989,28 +989,6 @@ mod tests {
         );
     }
 
-    // A registry from TEST_REGISTRY_VAR belongs to whoever started it: dropping
-    // the handle must not stop the container out from under the rest of the run.
-    #[cfg(unix)]
-    #[test]
-    fn oci_registry_drop_leaves_an_external_registry_alone() {
-        let dir = tempfile::tempdir().unwrap();
-        let log_path = dir.path().join("runtime.log");
-
-        {
-            let registry = OCIRegistry {
-                host_port: "127.0.0.1:5000".to_string(),
-                owned: None,
-            };
-            assert_eq!(registry.host_port(), "127.0.0.1:5000");
-        }
-
-        assert!(
-            !log_path.exists(),
-            "dropping an external registry handle must not run any engine command"
-        );
-    }
-
     #[cfg(unix)]
     #[test]
     fn ensure_registry_image_available_pulls_registry_image() {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -36,17 +36,52 @@ pub fn available_runtimes() -> Vec<Box<dyn ContainerRuntime>> {
     runtimes
 }
 
+/// Points tests at a registry the environment already runs, instead of each one
+/// starting its own (see `scripts/setup-test-images.sh`, which CI runs).
+///
+/// The value is a `host:port`, and the host has to be `127.0.0.1` or
+/// `localhost`: snouty only disables TLS verification for those, so a registry
+/// reached any other way fails the push (see `ContainerRuntime::image_push`).
+pub const TEST_REGISTRY_VAR: &str = "SNOUTY_TEST_REGISTRY";
+
 pub struct OCIRegistry {
+    host_port: String,
+    /// The container this handle started, or `None` when the registry came from
+    /// [`TEST_REGISTRY_VAR`] — someone else's to stop.
+    owned: Option<OwnedRegistry>,
+}
+
+struct OwnedRegistry {
     child: Child,
     runtime: String,
     container_name: String,
-    port: u16,
+    /// The container's stderr, kept so a start failure can say why.
+    log: tempfile::NamedTempFile,
 }
 
 impl OCIRegistry {
-    /// Try to start a local OCI registry container.  Returns `None` when the
-    /// container cannot be launched.
+    /// A registry to push test images to: the one [`TEST_REGISTRY_VAR`] names,
+    /// or a fresh container. Returns `None` when neither is usable.
     pub fn start(runtime: &dyn ContainerRuntime) -> Option<Self> {
+        if let Some(host_port) = std::env::var(TEST_REGISTRY_VAR)
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            // A configured-but-dead registry is a broken environment, not a
+            // reason to quietly start a second one: fall through to skip_or_fail
+            // so CI fails loudly on its own setup.
+            if registry_v2_ping_addr(&host_port) {
+                return Some(Self {
+                    host_port,
+                    owned: None,
+                });
+            }
+            skip_or_fail(&format!(
+                "{TEST_REGISTRY_VAR} is set to {host_port} but nothing answers /v2/ there"
+            ));
+            return None;
+        }
+
         if !runtime_supports_linux_registry_image(runtime.name()) {
             eprintln!(
                 "skipping: OCI registry image requires Linux containers for {}",
@@ -62,72 +97,109 @@ impl OCIRegistry {
             return None;
         }
 
-        let port = reserve_local_port();
-        let container_name = format!("snouty-test-registry-{}-{}", std::process::id(), port);
-        let publish = format!("127.0.0.1:{port}:5000");
+        let container_name = format!(
+            "snouty-test-registry-{}-{}",
+            std::process::id(),
+            next_registry_nonce()
+        );
         let runtime_name = runtime.name().to_owned();
+        let log = tempfile::NamedTempFile::new().expect("create OCI registry log file");
 
+        // Let the engine pick the host port. Asking the kernel for a free port
+        // first and publishing it by number leaves a window where another test
+        // takes it before the engine binds.
         let child = Command::new(&runtime_name)
             .args([
                 "run",
                 "--rm",
                 "-p",
-                &publish,
+                "127.0.0.1:0:5000",
                 "--name",
                 &container_name,
                 "registry:2",
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(
+                log.reopen().expect("reopen OCI registry log file"),
+            ))
             .spawn()
             .unwrap_or_else(|e| {
                 panic!("failed to start OCI registry with {}: {e}", runtime.name())
             });
 
         let mut registry = Self {
-            child,
-            runtime: runtime_name,
-            container_name,
-            port,
+            host_port: String::new(),
+            owned: Some(OwnedRegistry {
+                child,
+                runtime: runtime_name,
+                container_name,
+                log,
+            }),
         };
-        if !registry.wait_until_ready() {
-            registry.cleanup_container();
-            skip_or_fail(&format!(
-                "OCI registry could not start with {}",
-                runtime.name()
-            ));
-            return None;
+        match registry.wait_until_ready() {
+            Ok(host_port) => {
+                registry.host_port = host_port;
+                Some(registry)
+            }
+            Err(reason) => {
+                registry.cleanup_container();
+                skip_or_fail(&format!(
+                    "OCI registry could not start with {}: {reason}",
+                    runtime.name()
+                ));
+                None
+            }
         }
-        Some(registry)
     }
 
     pub fn host_port(&self) -> String {
-        format!("127.0.0.1:{}", self.port)
+        self.host_port.clone()
     }
 
-    /// Returns `true` when the registry is ready, `false` when it exited or
-    /// timed out.
-    fn wait_until_ready(&mut self) -> bool {
+    /// Wait for the container to publish its port and answer `/v2/`, returning
+    /// the `host:port` it landed on. `Err` carries what the container said, so a
+    /// failure to start explains itself.
+    fn wait_until_ready(&mut self) -> Result<String, String> {
+        let owned = self
+            .owned
+            .as_mut()
+            .expect("wait_until_ready is only for a container this handle started");
+        let mut host_port = None;
         for _ in 0..200 {
-            if registry_v2_ping(self.port) {
-                return true;
+            if host_port.is_none() {
+                host_port = published_host_port(&owned.runtime, &owned.container_name);
             }
-            if let Some(_status) = self
+            if let Some(addr) = &host_port
+                && registry_v2_ping_addr(addr)
+            {
+                return Ok(addr.clone());
+            }
+            if owned
                 .child
                 .try_wait()
                 .expect("failed to poll OCI registry child process")
+                .is_some()
             {
-                return false;
+                return Err(container_log_tail(&owned.log));
             }
             thread::sleep(Duration::from_millis(100));
         }
-        false
+        Err(format!(
+            "timed out waiting for the registry to answer{}: {}",
+            host_port
+                .map(|a| format!(" on {a}"))
+                .unwrap_or_else(|| " (it never published a port)".to_string()),
+            container_log_tail(&owned.log)
+        ))
     }
 
     fn cleanup_container(&self) {
-        let _ = Command::new(&self.runtime)
-            .args(["rm", "-f", &self.container_name])
+        let Some(owned) = &self.owned else {
+            return;
+        };
+        let _ = Command::new(&owned.runtime)
+            .args(["rm", "-f", &owned.container_name])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -137,12 +209,75 @@ impl OCIRegistry {
 
 impl Drop for OCIRegistry {
     fn drop(&mut self) {
-        if self.child.try_wait().ok().flatten().is_none() {
-            let _ = self.child.kill();
+        // A registry from TEST_REGISTRY_VAR outlives every test that used it.
+        let Some(owned) = &mut self.owned else {
+            return;
+        };
+        if owned.child.try_wait().ok().flatten().is_none() {
+            let _ = owned.child.kill();
         }
-        let _ = self.child.wait();
+        let _ = owned.child.wait();
         self.cleanup_container();
     }
+}
+
+/// Distinguishes registries started by the same process, since one test can
+/// start several (one per container runtime).
+fn next_registry_nonce() -> u32 {
+    static NONCE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// The `host:port` the engine published the registry's port 5000 on, once the
+/// container is running.
+fn published_host_port(runtime: &str, container_name: &str) -> Option<String> {
+    let output = Command::new(runtime)
+        .args(["port", container_name, "5000/tcp"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // Both engines answer `127.0.0.1:49154`, one mapping per line.
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("127.0.0.1:"))
+        .map(str::to_string)
+}
+
+/// The last thing the registry container wrote, for a start-failure message.
+fn container_log_tail(log: &tempfile::NamedTempFile) -> String {
+    const MAX_TAIL: usize = 400;
+    let Ok(contents) = std::fs::read_to_string(log.path()) else {
+        return "no container output".to_string();
+    };
+    let tail: String = contents
+        .lines()
+        .rev()
+        .take(3)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("; ");
+    if tail.trim().is_empty() {
+        return "no container output".to_string();
+    }
+    tail.chars().take(MAX_TAIL).collect()
+}
+
+/// A repo prefix unique to this call, so tests that share one registry — every
+/// test does when [`TEST_REGISTRY_VAR`] is set — never push to the same repo.
+/// That matters beyond hygiene: `pin_images` skips the push when the registry
+/// already serves the digest, so a shared repo would silently stop exercising
+/// the push path. Include the runtime in `label` when a test loops over engines.
+pub fn unique_image_prefix(label: &str) -> String {
+    format!(
+        "snouty-test-{label}-{}-{}",
+        std::process::id(),
+        next_registry_nonce()
+    )
 }
 
 /// Returns `true` when running inside GitHub Actions (or any CI that sets `CI=true`).
@@ -187,21 +322,13 @@ pub fn require_runtimes_with_compose() -> Vec<Box<dyn ContainerRuntime>> {
     runtimes
 }
 
-fn reserve_local_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
-fn registry_v2_ping(port: u16) -> bool {
-    let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
+/// Whether an OCI registry answers `/v2/` at `addr` (a `host:port`).
+fn registry_v2_ping_addr(addr: &str) -> bool {
+    let Ok(mut stream) = TcpStream::connect(addr) else {
         return false;
     };
 
-    let request =
-        format!("GET /v2/ HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n");
+    let request = format!("GET /v2/ HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
     if std::io::Write::write_all(&mut stream, request.as_bytes()).is_err() {
         return false;
     }
@@ -844,10 +971,13 @@ mod tests {
 
         {
             let _registry = OCIRegistry {
-                child,
-                runtime: runtime_path.display().to_string(),
-                container_name: container_name.clone(),
-                port: 5000,
+                host_port: "127.0.0.1:5000".to_string(),
+                owned: Some(OwnedRegistry {
+                    child,
+                    runtime: runtime_path.display().to_string(),
+                    container_name: container_name.clone(),
+                    log: tempfile::NamedTempFile::new().unwrap(),
+                }),
             };
         }
 
@@ -856,6 +986,28 @@ mod tests {
             log.lines()
                 .any(|line| line == format!("rm -f {container_name}")),
             "expected cleanup command in log, got: {log}"
+        );
+    }
+
+    // A registry from TEST_REGISTRY_VAR belongs to whoever started it: dropping
+    // the handle must not stop the container out from under the rest of the run.
+    #[cfg(unix)]
+    #[test]
+    fn oci_registry_drop_leaves_an_external_registry_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("runtime.log");
+
+        {
+            let registry = OCIRegistry {
+                host_port: "127.0.0.1:5000".to_string(),
+                owned: None,
+            };
+            assert_eq!(registry.host_port(), "127.0.0.1:5000");
+        }
+
+        assert!(
+            !log_path.exists(),
+            "dropping an external registry handle must not run any engine command"
         );
     }
 


### PR DESCRIPTION
Every registry-backed test started its own `registry:2` container — pulling the image, binding a port, waiting for it to come up. Under nextest that's one container per test *process*, and it's the failure we keep chasing: `OCI registry could not start with podman` took down `main` and `jeskew/oauth` yesterday, and `OCI registry image could not be pulled with podman` took down #181's macOS leg the day before. Neither had anything to do with the code under test.

CI now does that work once, up front.

## What changed

**`scripts/setup-test-images.sh`** pre-fetches the remote images the suite uses (`registry:2`, `busybox`, `debian:bookworm-slim`, `k8s-validator:1.0.0`), starts one `registry:2` on `127.0.0.1:5000`, and exports `SNOUTY_TEST_REGISTRY`. It skips images already present, so the macOS k8s-validator cache tarball still short-circuits its pull. Wired into all three legs — including `build-nix`, which sets no `SNOUTY_TEST_RUNTIME` and so exercises both engines and needs the images in both.

Two consequences worth naming: a rate-limited or slow pull now fails **in setup**, with the engine's own error, instead of failing a test ten minutes later; and starting the registry there doubles as a preflight that the engine can actually run a port-mapped container.

**`OCIRegistry::start`** uses `SNOUTY_TEST_REGISTRY` when set and starts its own container when not, so local development is unchanged. Details that matter:

- A registry from the variable is **never stopped on drop** — it belongs to whoever started it and outlives every test that used it.
- A variable pointing at a dead registry **fails loudly** instead of quietly starting a second one, because that means CI's setup is broken. `skip_or_fail` keeps that a panic in CI and a skip locally.
- The address must be `127.0.0.1`/`localhost`: snouty only passes `--tls-verify=false` for those (`container.rs:513`), so a registry reached by any other name would fail the push. That's why the script publishes on `127.0.0.1` and not, say, a service-container alias.

**Unique image names** in both registry tests. This isn't hygiene — it's load-bearing. Both tests loop over available engines and push byte-identical content, so with a shared registry the second iteration would find the digest already served, take `pin_images`' "Image already in a registry, skipping push" branch, and silently stop testing the push path. Since `pin_images` derives its push target as `{registry}/{local image name}`, nonce-ing the local name fixes the registry *and* the fixed local tag that was shared state in the engine's image store.

**Two fixes to the path that stays in use locally:**

- The container's stderr is captured to a temp file and reported when it fails to come up. That failure has been arriving with no explanation at all, which is why yesterday's investigation ended in a hypothesis rather than a cause.
- The port comes from the engine (`-p 127.0.0.1:0:5000`, read back with `<engine> port`) instead of `reserve_local_port`'s bind-read-close-rebind, which left a window for another test to take the port first.

## Testing

Both paths, locally, with docker:

| | result |
|---|---|
| Fallback (no env var) — engine allocated port 32769 | 2/2 pass |
| CI path (`SNOUTY_TEST_REGISTRY=127.0.0.1:5000`) | 2/2 pass, 8.2s → 4.6s |
| Env var set, nothing listening, `CI=true` | panics: `SNOUTY_TEST_REGISTRY is set to 127.0.0.1:9 but nothing answers /v2/ there` |
| Same, locally | skips |

The CI path pushed to `snouty-test-cfg-docker-…/snouty-config` and `snouty-test-pin-docker-…` — confirmed unique in `/v2/_catalog` — started no containers, and left the shared registry running afterwards.

Full suite green four ways: `cargo test` with and without the variable, and `cargo nextest run` (534/534) with it, which is the runner CI actually uses. `scripts/setup-test-images.sh docker` was run for real, not just syntax-checked. `fmt`, `clippy --all-targets`, and `typos` clean.

## Notes

- Digest-pinning the floating tags (`registry:2`, `busybox`) is deliberately out of scope.
- Unrelated observation from watching the output: case 2 of `pin_images_pushes_every_local_image` ("local without a build stanza") already takes the skip-push branch today, because case 1 pushed the same digest to the same repo moments earlier. Its assertion passes either way, so it isn't verifying what its comment claims. Pre-existing, left alone.
- `build-nix` remains the heaviest leg — no `SNOUTY_TEST_RUNTIME`, so every engine test runs twice. Setting it to one engine would halve the container work there, at the cost of the docker coverage that leg currently provides; the matrix covers docker on Ubuntu separately. Your call, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb
