### PR TITLE
Add a VTime type and show vtime as an exact JSON number

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -27,10 +27,13 @@ snouty runs show "$run" --json \
 ```
 
 The moment is `{"input_hash": ..., "vtime": ...}` and feeds `runs logs` in that
-order.
+order. The `vtime` is a JSON number carrying the moment's exact value: pass it
+through unchanged, and compare it numerically — never as text, where
+`"1000.0" < "9.0"`.
 
 Not every run has one. The `failure_moment` key is absent when the run has no
 moment-pinned failure, and a run that timed out or was killed reports the
-placeholder `{"input_hash": "0", "vtime": "0"}` — which streams nothing.
-`snouty runs show` treats that placeholder as "no moment"; do the same, and skip
-the log fetch rather than streaming an empty timeline.
+placeholder `{"input_hash": "0", "vtime": 0}` — which streams nothing.
+`snouty runs show` treats that placeholder as "no moment"; do the same with a
+numeric check (`.vtime != 0`), and skip the log fetch rather than streaming an
+empty timeline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,8 @@ dependencies = [
  "reqwest-middleware",
  "rpassword",
  "rusqlite",
+ "ryu",
+ "schemars",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,6 @@ dependencies = [
  "reqwest-middleware",
  "rpassword",
  "rusqlite",
- "ryu",
  "schemars",
  "semver",
  "serde",
@@ -2755,6 +2754,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "which",
  "wiremock",
+ "zmij",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,8 @@ serde = { version = "1", features = ["derive"] }
 # float_roundtrip makes serde_json's f64 parsing correctly-rounded, so a vtime
 # read out of a JSON number is never off by one ULP (see src/vtime.rs).
 serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-# The float printer serde_json itself uses; VTime::Display takes its digits
-# (expanding exponent notation to plain decimal — see src/vtime.rs), so the
-# human text matches the JSON number wherever both are plain decimal.
+# The float printer serde_json itself uses; VTime::Display goes through it so
+# the human text matches the JSON number byte-for-byte (see src/vtime.rs).
 zmij = "1"
 indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ serde = { version = "1", features = ["derive"] }
 # float_roundtrip makes serde_json's f64 parsing correctly-rounded, so a vtime
 # read out of a JSON number is never off by one ULP (see src/vtime.rs).
 serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-# The shortest-round-trip float printer serde_json itself uses; VTime's
-# Display goes through it so human output matches the JSON number exactly.
+# Shortest-round-trip float printing for VTime::Display (see src/vtime.rs).
 ryu = "1"
 indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ serde = { version = "1", features = ["derive"] }
 # float_roundtrip makes serde_json's f64 parsing correctly-rounded, so a vtime
 # read out of a JSON number is never off by one ULP (see src/vtime.rs).
 serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-# The float printer serde_json itself uses; VTime::Display goes through it so
-# the human text matches the JSON number byte-for-byte (see src/vtime.rs).
+# The float printer serde_json itself uses; VTime::Display takes its digits
+# (expanding exponent notation to plain decimal — see src/vtime.rs), so the
+# human text matches the JSON number wherever both are plain decimal.
 zmij = "1"
 indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,12 @@ color-eyre = { version = "0.6", default-features = false }
 futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util", "io-std", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+# float_roundtrip makes serde_json's f64 parsing correctly-rounded, so a vtime
+# read out of a JSON number is never off by one ULP (see src/vtime.rs).
+serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
+# The shortest-round-trip float printer serde_json itself uses; VTime's
+# Display goes through it so human output matches the JSON number exactly.
+ryu = "1"
 indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }
 console = "0.15"
@@ -60,6 +65,9 @@ openapiv3 = "2"
 prettyplease = "0.2"
 progenitor = "0.14.0"
 quote = "1"
+# Same schemars version progenitor/typify resolve; build.rs hands
+# with_conversion a schemars SchemaObject to map vtime onto crate::vtime::VTime.
+schemars = "0.8"
 serde_json = "1"
 syn = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ serde = { version = "1", features = ["derive"] }
 # float_roundtrip makes serde_json's f64 parsing correctly-rounded, so a vtime
 # read out of a JSON number is never off by one ULP (see src/vtime.rs).
 serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-# Shortest-round-trip float printing for VTime::Display (see src/vtime.rs).
-ryu = "1"
+# The float printer serde_json itself uses; VTime::Display goes through it so
+# the human text matches the JSON number byte-for-byte (see src/vtime.rs).
+zmij = "1"
 indexmap = { version = "2.10.0" }
 rusqlite = { version = "0.34", features = ["bundled"] }
 console = "0.15"

--- a/build.rs
+++ b/build.rs
@@ -143,9 +143,7 @@ fn untype_error_responses(spec: &mut serde_json::Value) {
 /// `with_conversion` mapping registered above. The marker is injected here
 /// rather than edited into `src/openapi.json`, because that file is a
 /// vendored upstream artifact — the next spec refresh would silently drop the
-/// edit. Panics when the spec no longer carries the expected string-typed
-/// property, so an upstream schema change fails the build with a clear
-/// message instead of silently regenerating a stringly-typed client.
+/// edit.
 fn mark_vtime_schema(spec: &mut serde_json::Value) {
     let vtime = spec
         .pointer_mut("/components/schemas/Moment/properties/vtime")

--- a/build.rs
+++ b/build.rs
@@ -42,17 +42,39 @@ fn generate_api_client(out_dir: &Path) {
         offenders.join(", ")
     );
     untype_error_responses(&mut spec_value);
+    mark_vtime_schema(&mut spec_value);
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_interface(progenitor::InterfaceStyle::Builder);
     settings.with_inner_type(quote::quote!(crate::api::ClientState));
+    // Map the marked vtime schema onto the handwritten VTime type, which
+    // enforces the exact string<->f64 conversion a vtime needs (the
+    // conversion lookup ignores schema metadata such as description/example,
+    // so `type` + `format` is the whole match key).
+    let vtime_schema: schemars::schema::SchemaObject =
+        serde_json::from_value(serde_json::json!({"type": "string", "format": "vtime"})).unwrap();
+    settings.with_conversion(
+        vtime_schema,
+        "crate::vtime::VTime",
+        std::iter::empty::<progenitor::TypeImpl>(),
+    );
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(&spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();
     let content = prettyplease::unparse(&ast);
     let content = patch_lenient_booleans(content);
     assert_no_typed_error_responses(&content);
+
+    // The conversion fails open: an unmatched schema silently falls back to a
+    // plain String field. Assert it took, so a progenitor/typify change that
+    // breaks the match fails the build instead of quietly shipping a client
+    // without the vtime precision guarantees.
+    assert!(
+        content.contains("pub vtime: crate::vtime::VTime"),
+        "generated client does not use crate::vtime::VTime for Moment.vtime; \
+         the with_conversion schema match no longer applies"
+    );
 
     fs::write(out_dir.join("antithesis_api.rs"), content).unwrap();
 }
@@ -115,6 +137,25 @@ fn untype_error_responses(spec: &mut serde_json::Value) {
             responses.retain(|status, _| status.starts_with('2'));
         }
     }
+}
+
+/// Tag `Moment.vtime` with a private `format: vtime` marker for the
+/// `with_conversion` mapping registered above. The marker is injected here
+/// rather than edited into `src/openapi.json`, because that file is a
+/// vendored upstream artifact — the next spec refresh would silently drop the
+/// edit. Panics when the spec no longer carries the expected string-typed
+/// property, so an upstream schema change fails the build with a clear
+/// message instead of silently regenerating a stringly-typed client.
+fn mark_vtime_schema(spec: &mut serde_json::Value) {
+    let vtime = spec
+        .pointer_mut("/components/schemas/Moment/properties/vtime")
+        .expect("openapi spec has no Moment.properties.vtime; update the VTime wiring in build.rs");
+    assert_eq!(
+        vtime["type"],
+        serde_json::json!("string"),
+        "Moment.vtime is no longer a string in the openapi spec; revisit the VTime wiring in build.rs"
+    );
+    vtime["format"] = serde_json::json!("vtime");
 }
 
 /// Recursively collect the JSON-pointer path of every `"additionalProperties":

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -215,10 +215,9 @@ class Discovery:
     event_keyword: str = ""
     event_kw2: str = ""
     event_hash: str = ""
-    # Held as the exact text of the JSON number so positional moment arguments
-    # reach the API byte-identically (Python's float repr agrees with snouty's
-    # print, but text-in text-out never has to rely on that).
-    event_vtime: str = ""
+    # The exact text of the JSON number, so positional moment arguments reach
+    # the API byte-identically.
+    event_vtime: str = "0"
     fail_prop: str = ""  # failing event property whose detail shows counter-examples
     pass_event_prop: str = ""  # passing event property whose detail shows examples
     nonevent_prop: str = ""  # non-event property whose detail shows a real value
@@ -1023,7 +1022,7 @@ def build_stories(d: Discovery) -> list[Story]:
     kw, kw2 = d.event_keyword, d.event_kw2
     # `--begin-vtime` for the logs skip-ahead story: just before the sampled
     # moment. A lower bound, so the float round-trip is harmless here.
-    vmin = f"{max(0.0, float(d.event_vtime or 0.0) - 0.5):.3f}"
+    vmin = f"{max(0.0, float(d.event_vtime) - 0.5):.3f}"
     stories = [
         # -- listing --------------------------------------------------------
         Story(
@@ -2321,7 +2320,7 @@ def main() -> int:
 
     if args.list:
         # An all-default Discovery is enough to enumerate slugs (build_stories
-        # only reads a few fields; an empty event_vtime is fine for listing).
+        # only reads a few fields, and event_vtime defaults to a real vtime).
         for s in build_stories(Discovery()):
             print(s.slug)
         for s in build_validate_stories(None):

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -215,7 +215,10 @@ class Discovery:
     event_keyword: str = ""
     event_kw2: str = ""
     event_hash: str = ""
-    event_vtime: float = 0.0
+    # Held as the exact text of the JSON number so positional moment arguments
+    # reach the API byte-identically (Python's float repr agrees with snouty's
+    # print, but text-in text-out never has to rely on that).
+    event_vtime: str = ""
     fail_prop: str = ""  # failing event property whose detail shows counter-examples
     pass_event_prop: str = ""  # passing event property whose detail shows examples
     nonevent_prop: str = ""  # non-event property whose detail shows a real value
@@ -318,13 +321,14 @@ def _pick_completed_run(sn: Snouty, scan: int) -> CompletedPick:
 
 def _real_failure_moment(moment: dict) -> bool:
     """Whether a run's failure moment is a real, streamable coordinate. The API
-    returns the sentinel `input_hash="0", vtime="0"` for an incomplete run with no
+    reports the sentinel `input_hash "0"`, `vtime 0` for an incomplete run with no
     specific failure point (a timeout or kill, not a moment-pinned failure) and
-    omits the fields for some runs; neither yields any logs."""
+    omits the fields for some runs; neither yields any logs. snouty emits vtime
+    as a JSON number, so the zero check is numeric."""
     h, v = moment.get("input_hash"), moment.get("vtime")
-    if not h or not v:
+    if not h or v is None:
         return False
-    return not (str(h) == "0" and str(v) == "0")
+    return not (str(h) == "0" and float(v) == 0.0)
 
 
 def _pick_incomplete_run(sn: Snouty, scan: int) -> tuple[str, dict, str]:
@@ -553,7 +557,7 @@ def discover(sn: Snouty, scan: int) -> Discovery:
         event_keyword=keyword,
         event_kw2=event["_second_needle"],
         event_hash=moment["input_hash"],
-        event_vtime=float(moment["vtime"]),
+        event_vtime=str(moment["vtime"]),
         # Property-story selections were derived against `success` during the
         # holistic run pick, so reuse them rather than re-probing the API.
         fail_prop=pick.fail_prop,
@@ -1017,8 +1021,9 @@ def _reachable_doctor_env() -> dict[str, str | None]:
 
 def build_stories(d: Discovery) -> list[Story]:
     kw, kw2 = d.event_keyword, d.event_kw2
-    # `--begin-vtime` for the logs skip-ahead story: just before the sampled moment.
-    vmin = f"{max(0.0, d.event_vtime - 0.5):.3f}"
+    # `--begin-vtime` for the logs skip-ahead story: just before the sampled
+    # moment. A lower bound, so the float round-trip is harmless here.
+    vmin = f"{max(0.0, float(d.event_vtime or 0.0) - 0.5):.3f}"
     stories = [
         # -- listing --------------------------------------------------------
         Story(
@@ -1281,7 +1286,7 @@ def build_stories(d: Discovery) -> list[Story]:
             "Stream logs at a specific moment",
             "I want the log lines at a particular moment of the run.",
             "At least one log line is streamed at/around the moment.",
-            ["runs", "logs", d.success, d.event_hash, f"{d.event_vtime}"],
+            ["runs", "logs", d.success, d.event_hash, d.event_vtime],
             logs_non_empty,
         ),
         Story(
@@ -1294,7 +1299,7 @@ def build_stories(d: Discovery) -> list[Story]:
                 "logs",
                 d.success,
                 d.event_hash,
-                f"{d.event_vtime}",
+                d.event_vtime,
                 "--begin-vtime",
                 vmin,
                 "--begin-input-hash",
@@ -1607,7 +1612,7 @@ def build_help_stories(d: Discovery) -> list[Story]:
             "I want the help to make clear that the positional moment streams logs up to "
             "it and --begin-vtime sets the start, and to describe the line format.",
             ["runs", "logs"],
-            ["runs", "logs", s, d.event_hash, f"{d.event_vtime}"],
+            ["runs", "logs", s, d.event_hash, d.event_vtime],
         ),
         _help_story(
             "help-runs-build-logs",
@@ -2316,7 +2321,7 @@ def main() -> int:
 
     if args.list:
         # An all-default Discovery is enough to enumerate slugs (build_stories
-        # only reads a few fields, and event_vtime defaults to a real float).
+        # only reads a few fields; an empty event_vtime is fine for listing).
         for s in build_stories(Discovery()):
             print(s.slug)
         for s in build_validate_stories(None):

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -140,8 +140,8 @@ snouty runs properties --passing $R_run_id
 stderr '.*cannot be used with.*'
 
 # `snouty --json runs properties` outputs JSON. A moment's vtime is an exact
-# JSON number (a vtime is ticks / 2^32, which an f64 holds exactly, so the
-# full-precision value round-trips byte-identically).
+# JSON number — the full-precision value survives byte-identically (see
+# src/vtime.rs for why an f64 holds it exactly).
 mock-runs-server
 snouty --json runs properties $R_run_id
 [!staging] stdout '"name".*"Counter value stays below limit"'
@@ -242,8 +242,7 @@ mock-runs-server
 [staging] snouty --json runs events $R_run_id --match fault --limit 3
 [!staging] stdout '"antithesis_assert".*"Counter'\''s value retrieved"'
 [!staging] stdout '.*"moment".*"input_hash":"-4735081784258020614".*'
-# The vtime is converted from the server's seconds string to an exact JSON
-# number; the full-precision value survives byte-identically.
+# The vtime is an exact JSON number, full precision intact.
 [!staging] stdout '.*"moment".*"vtime":311\.8487535319291.*'
 
 [staging] skip
@@ -383,10 +382,9 @@ stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
 # moment.vtime is converted in place from the server's seconds string to an
-# exact JSON number: a vtime is ticks / 2^32, which an f64 holds exactly, so
-# the full-precision value round-trips byte-identically. active_faults is
-# appended by the annotator. The clog window (start 401.5, max_duration 0.267)
-# is active at 401.5 and 401.75, then expired by 402.
+# exact JSON number, full precision intact. active_faults is appended by the
+# annotator. The clog window (start 401.5, max_duration 0.267) is active at
+# 401.5 and 401.75, then expired by 402.
 stdout '"vtime":73\.94233945617452'
 stdout '"vtime":401.5.*"active_faults":\{"network_clog":\{"vtime":401.5\}\}'
 stdout '"vtime":401.75.*"active_faults":\{"network_clog":\{"vtime":401.5\}\}'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -139,19 +139,23 @@ snouty runs properties --passing $R_run_id
 ! snouty runs properties --passing --failing $R_run_id
 stderr '.*cannot be used with.*'
 
-# `snouty --json runs properties` outputs JSON.
+# `snouty --json runs properties` outputs JSON. A moment's vtime is an exact
+# JSON number (a vtime is ticks / 2^32, which an f64 holds exactly, so the
+# full-precision value round-trips byte-identically).
 mock-runs-server
 snouty --json runs properties $R_run_id
 [!staging] stdout '"name".*"Counter value stays below limit"'
 [!staging] stdout '"status".*"Failing"'
+[!staging] stdout '"vtime":45\.334635781589895'
 
 # `--name <substr> --detail` expands the matching property into its examples.
 # For the Counter event property that's a STATUS/HASH/VTIME table, sorted
-# numerically by vtime (5.0 before 10.0), failing before passing.
+# numerically by vtime (45.3… before 313.1…, where an alphanumeric sort would
+# put "313…" first), failing before passing.
 mock-runs-server
 snouty runs properties $R_run_id --name 'Counter value' --detail
 [!staging] stdout 'STATUS.*HASH.*VTIME'
-[!staging] stdout '(?s)failing.*-100.*5\.0.*failing.*-200.*10\.0.*passing.*-300.*15\.0'
+[!staging] stdout '(?s)failing.*-100.*45\.334635781589895.*failing.*-200.*313\.15126806590706.*passing.*-300.*398\.4898056755774'
 
 # --name is a case-insensitive substring filter over property names; without
 # --detail it just narrows the (grouped) table.
@@ -238,7 +242,9 @@ mock-runs-server
 [staging] snouty --json runs events $R_run_id --match fault --limit 3
 [!staging] stdout '"antithesis_assert".*"Counter'\''s value retrieved"'
 [!staging] stdout '.*"moment".*"input_hash":"-4735081784258020614".*'
-[!staging] stdout '.*"moment".*"vtime":"311\.8487535319291".*'
+# The vtime is converted from the server's seconds string to an exact JSON
+# number; the full-precision value survives byte-identically.
+[!staging] stdout '.*"moment".*"vtime":311\.8487535319291.*'
 
 [staging] skip
 
@@ -264,6 +270,8 @@ snouty --json runs show $R_run_id
 stdout '"failure_moment".*'
 stdout '"input_hash".*'
 stdout '"vtime".*'
+# failure_moment.vtime is an exact JSON number, full precision intact.
+[!staging] stdout '"vtime": 398\.4898056755774'
 
 # If no runs are returned, the command prints a friendly empty-state message.
 mock-runs-server empty
@@ -375,8 +383,11 @@ stdout 'output_text.*starting'
 stdout 'output_text.*slow request'
 stdout '"antithesis_assert".*"display_type":"AlwaysOrUnreachable"'
 # moment.vtime is converted in place from the server's seconds string to an
-# f64; active_faults is appended by the annotator. The clog window (start 401.5,
-# max_duration 0.267) is active at 401.5 and 401.75, then expired by 402.
+# exact JSON number: a vtime is ticks / 2^32, which an f64 holds exactly, so
+# the full-precision value round-trips byte-identically. active_faults is
+# appended by the annotator. The clog window (start 401.5, max_duration 0.267)
+# is active at 401.5 and 401.75, then expired by 402.
+stdout '"vtime":73\.94233945617452'
 stdout '"vtime":401.5.*"active_faults":\{"network_clog":\{"vtime":401.5\}\}'
 stdout '"vtime":401.75.*"active_faults":\{"network_clog":\{"vtime":401.5\}\}'
 stdout '"vtime":402.0.*"active_faults":\{\}'
@@ -432,10 +443,10 @@ snouty runs events $R_run_id request
 # parallel_driver_fetch; --limit 1 keeps only the first (vtime 400.5).
 mock-runs-server
 snouty --json runs events $R_run_id --match parallel_driver_fetch --limit 1
-[!staging] stdout '"vtime":"400\.5"'
-[!staging] ! stdout '"vtime":"401\.75"'
+[!staging] stdout '"vtime":400\.5'
+[!staging] ! stdout '"vtime":401\.75'
 
 # Without --limit no cap is sent at all, so all three matches come back.
 mock-runs-server
 snouty --json runs events $R_run_id --match parallel_driver_fetch
-[!staging] stdout '"vtime":"401\.75"'
+[!staging] stdout '"vtime":401\.75'

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,6 +21,7 @@ use crate::error::{ApiError, user_error};
 use crate::params::Params;
 use crate::render::sanitize;
 use crate::settings::Settings;
+use crate::vtime::VTime;
 
 #[allow(dead_code, unused_imports, private_interfaces)]
 mod generated {
@@ -122,7 +123,7 @@ impl RunDetail {
     pub(crate) fn real_failure_moment(&self) -> Option<&Moment> {
         self.failure_moment
             .as_ref()
-            .filter(|m| m.input_hash != "0" || m.vtime != "0")
+            .filter(|m| m.input_hash != "0" || m.vtime != VTime::ZERO)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod testutils;
 pub mod time;
 pub mod util;
 pub mod validate;
+pub mod vtime;
 
 /// User-Agent string sent with every HTTP request snouty makes.
 pub fn user_agent() -> String {

--- a/src/moment.rs
+++ b/src/moment.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 
 use crate::error::user_error;
 use crate::params::Params;
+use crate::vtime::VTime;
 use color_eyre::Section;
 use color_eyre::eyre::Result;
 
@@ -14,9 +15,10 @@ use color_eyre::eyre::Result;
 /// (older triage reports use `session_id` in place of `run_id`).
 ///
 /// This is JSON5 object syntax with unquoted keys. The keys are converted
-/// to `antithesis.debugging.*` format and numeric values are converted to strings.
-/// The parser is identifier-agnostic: whichever of `run_id` / `session_id` the
-/// moment carries is passed through unchanged.
+/// to `antithesis.debugging.*` format and numeric values are converted to
+/// strings — the vtime through [`VTime`], whose print is exact by
+/// construction. The parser is identifier-agnostic: whichever of `run_id` /
+/// `session_id` the moment carries is passed through unchanged.
 pub fn parse(input: &str) -> Result<Params> {
     let input = input.trim();
 
@@ -42,8 +44,18 @@ pub fn parse(input: &str) -> Result<Params> {
     for (key, val) in obj {
         let new_key = format!("antithesis.debugging.{}", key);
         debug!("converting key {} -> {}", key, new_key);
-        // Convert numbers to strings
+        // Convert numbers to strings. The vtime goes through VTime so its
+        // number->text print carries the same exactness guarantee as every
+        // other vtime path (an integer vtime normalizes to e.g. "402.0", the
+        // text the API prints for that moment).
         let string_val = match val {
+            Value::Number(n) if key == "vtime" => {
+                let vtime = n
+                    .as_f64()
+                    .and_then(VTime::from_seconds)
+                    .ok_or_else(|| user_error("invalid arguments: vtime is not a finite number"))?;
+                Value::String(vtime.to_string())
+            }
             Value::Number(n) => Value::String(n.to_string()),
             other => other.clone(),
         };
@@ -129,6 +141,19 @@ mod tests {
         assert_eq!(
             params.as_map().get("antithesis.debugging.vtime"),
             Some(&Value::String("329.8037810830865".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_whole_number_vtime_normalizes_to_json_number_text() {
+        // json5 keeps `402` as an integer; the vtime routes through VTime, so
+        // it prints as "402.0" — the same text every JSON number path emits.
+        let input = r#"Moment.from({ run_id: "r-1", input_hash: "42", vtime: 402 })"#;
+        let params = parse(input).unwrap();
+
+        assert_eq!(
+            params.as_map().get("antithesis.debugging.vtime"),
+            Some(&Value::String("402.0".to_string()))
         );
     }
 

--- a/src/moment.rs
+++ b/src/moment.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 
 use crate::error::user_error;
 use crate::params::Params;
-use crate::vtime::VTime;
+use crate::vtime::{ParseVTimeError, VTime};
 use color_eyre::Section;
 use color_eyre::eyre::Result;
 
@@ -15,10 +15,9 @@ use color_eyre::eyre::Result;
 /// (older triage reports use `session_id` in place of `run_id`).
 ///
 /// This is JSON5 object syntax with unquoted keys. The keys are converted
-/// to `antithesis.debugging.*` format and numeric values are converted to
-/// strings — the vtime through [`VTime`], whose print is exact by
-/// construction. The parser is identifier-agnostic: whichever of `run_id` /
-/// `session_id` the moment carries is passed through unchanged.
+/// to `antithesis.debugging.*` format and numeric values are converted to strings.
+/// The parser is identifier-agnostic: whichever of `run_id` / `session_id` the
+/// moment carries is passed through unchanged.
 pub fn parse(input: &str) -> Result<Params> {
     let input = input.trim();
 
@@ -44,20 +43,18 @@ pub fn parse(input: &str) -> Result<Params> {
     for (key, val) in obj {
         let new_key = format!("antithesis.debugging.{}", key);
         debug!("converting key {} -> {}", key, new_key);
-        // Convert numbers to strings. The vtime goes through VTime so its
-        // number->text print carries the same exactness guarantee as every
-        // other vtime path (an integer vtime normalizes to e.g. "402.0", the
-        // text the API prints for that moment).
-        let string_val = match val {
-            Value::Number(n) if key == "vtime" => {
-                let vtime = n
-                    .as_f64()
-                    .and_then(VTime::from_seconds)
-                    .ok_or_else(|| user_error("invalid arguments: vtime is not a finite number"))?;
-                Value::String(vtime.to_string())
+        // Convert numbers to strings. The vtime — number or string — routes
+        // through VTime, so the text sent to the API is its exact print
+        // (an integer vtime normalizes to e.g. "402.0").
+        let string_val = if key == "vtime" {
+            let vtime = VTime::from_json(val)
+                .ok_or_else(|| user_error(format!("invalid arguments: {ParseVTimeError}")))?;
+            Value::String(vtime.to_string())
+        } else {
+            match val {
+                Value::Number(n) => Value::String(n.to_string()),
+                other => other.clone(),
             }
-            Value::Number(n) => Value::String(n.to_string()),
-            other => other.clone(),
         };
         map.insert(new_key, string_val);
     }
@@ -145,16 +142,20 @@ mod tests {
     }
 
     #[test]
-    fn parse_whole_number_vtime_normalizes_to_json_number_text() {
-        // json5 keeps `402` as an integer; the vtime routes through VTime, so
-        // it prints as "402.0" — the same text every JSON number path emits.
-        let input = r#"Moment.from({ run_id: "r-1", input_hash: "42", vtime: 402 })"#;
-        let params = parse(input).unwrap();
-
-        assert_eq!(
-            params.as_map().get("antithesis.debugging.vtime"),
-            Some(&Value::String("402.0".to_string()))
-        );
+    fn parse_normalizes_vtime_to_its_exact_print() {
+        // Both shapes normalize: integer 402 and string "402" print as "402.0".
+        for moment in [
+            r#"Moment.from({ run_id: "r-1", input_hash: "42", vtime: 402 })"#,
+            r#"Moment.from({ run_id: "r-1", input_hash: "42", vtime: "402" })"#,
+        ] {
+            let params = parse(moment).unwrap();
+            assert_eq!(
+                params.as_map().get("antithesis.debugging.vtime"),
+                Some(&Value::String("402.0".to_string()))
+            );
+        }
+        // A vtime that isn't a finite number is rejected.
+        assert!(parse(r#"Moment.from({ run_id: "r-1", vtime: "oops" })"#).is_err());
     }
 
     #[test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1627,8 +1627,8 @@ fn format_log_vtime(entry: &Value) -> String {
         // The API sends vtime as a seconds string; truncate it directly so f64
         // round-trips can't nudge the displayed value.
         Some(s) => truncate_decimals(s, 3),
-        // A JSON-number vtime: VTime's Display is the exact text the number
-        // was printed from, so truncating it cuts — never rounds.
+        // A JSON-number vtime: VTime's Display is plain decimal and
+        // value-exact, so truncating it cuts — never rounds.
         None => match VTime::from_json(raw) {
             Some(v) => truncate_decimals(&v.to_string(), 3),
             None => String::new(),
@@ -4551,10 +4551,15 @@ mod tests {
         let NdjsonLine::Entry(entry) = classify_line(&line) else {
             panic!("an object line should classify as Entry");
         };
+        // The expected number text comes from the JSON writer, not Display:
+        // below ~10µs the writer uses exponent notation where Display stays
+        // plain decimal. Both carry the identical value.
+        let number_text = serde_json::to_string(&vtime).unwrap();
         assert_eq!(
             entry.to_string(),
-            format!(r#"{{"moment":{{"vtime":{vtime}}},"output_text":"x"}}"#)
+            format!(r#"{{"moment":{{"vtime":{number_text}}},"output_text":"x"}}"#)
         );
+        assert_eq!(VTime::from_json(&entry["moment"]["vtime"]), Some(vtime));
     }
 
     /// classify_line never panics, whatever the server sends; anything that

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -25,6 +25,7 @@ use crate::error::{api_error_status, user_error};
 use crate::render::{render_kv, sanitize, sanitize_multiline};
 use crate::settings::Settings;
 use crate::time::ReportDuration;
+use crate::vtime::VTime;
 
 /// `print!`/`println!`, but routed through `write!`/`writeln!` to stdout so a
 /// closed pipe (e.g. `snouty runs list | head`) surfaces as an `io::Error` the
@@ -834,14 +835,14 @@ fn render_moments_table(p: &EventProperty) -> String {
         rows.push(vec![
             "failing".to_string(),
             sanitize(&event.moment.input_hash),
-            sanitize(&event.moment.vtime),
+            event.moment.vtime.to_string(),
         ]);
     }
     for event in sorted_by_vtime(&p.examples) {
         rows.push(vec![
             "passing".to_string(),
             sanitize(&event.moment.input_hash),
-            sanitize(&event.moment.vtime),
+            event.moment.vtime.to_string(),
         ]);
     }
     if rows.is_empty() {
@@ -971,23 +972,11 @@ fn trim_blank_edges(lines: &[String]) -> &[String] {
     lines.get(start..end).unwrap_or(&[])
 }
 
-/// Return references to `events` ordered ascending by `moment.vtime` parsed as
-/// f64. Entries whose vtime doesn't parse as a number sort last, preserving
-/// their original relative order. The sort is stable, so events with equal
-/// vtimes keep their incoming order.
+/// Return references to `events` ordered ascending by `moment.vtime`. The
+/// sort is stable, so events with equal vtimes keep their incoming order.
 fn sorted_by_vtime(events: &[Event]) -> Vec<&Event> {
     let mut sorted: Vec<&Event> = events.iter().collect();
-    sorted.sort_by(|a, b| {
-        let av = a.moment.vtime.parse::<f64>().ok();
-        let bv = b.moment.vtime.parse::<f64>().ok();
-        match (av, bv) {
-            (Some(a), Some(b)) => a.total_cmp(&b),
-            // Numeric vtimes sort ahead of non-numeric/unparseable ones.
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => std::cmp::Ordering::Equal,
-        }
-    });
+    sorted.sort_by_key(|e| e.moment.vtime);
     sorted
 }
 
@@ -1160,7 +1149,7 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
         // Hash before VTime to match the `runs logs <hash> <vtime>` argument
         // order, so the values read top-to-bottom in the order you paste them.
         rows.push(("Failure Hash", moment.input_hash.clone()));
-        rows.push(("Failure VTime", moment.vtime.clone()));
+        rows.push(("Failure VTime", moment.vtime.to_string()));
     }
 
     if let Some(ref creator) = run.creator
@@ -1433,17 +1422,18 @@ async fn cmd_runs_events(
 
     let mut stdout = BufWriter::new(std::io::stdout().lock());
 
-    // JSON mode emits the raw matching line, but matching itself runs against the
-    // DECODED fields (see `event_haystack`) so it agrees with what the table
-    // shows. Parse each line once to build the haystack, then stream the raw
-    // matching line as it arrives.
+    // JSON mode emits the matching line with moment.vtime converted to an
+    // exact JSON number, but matching itself runs against the DECODED fields
+    // (see `event_haystack`) so it agrees with what the table shows. Parse
+    // each line once to build the haystack, then stream the matching line as
+    // it arrives.
     if json {
         let result = stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
             let (haystack, _) = prepare_event_line(line);
             if !haystack_matches_all_needles(&haystack, &lowered_matches) {
                 return Ok(());
             }
-            writeln!(stdout, "{line}")?;
+            writeln!(stdout, "{}", numeric_vtime_line(line))?;
             Ok(())
         })
         .await;
@@ -1616,15 +1606,31 @@ fn format_log_entry(entry: &Value, raw: bool) -> String {
     )
 }
 
-/// Parse a `moment`'s vtime to f64 seconds. The API sends `moment.vtime` as a
-/// seconds string (e.g. "398.4898"); accept a JSON number too, since the schema
-/// doesn't forbid one. Returns `None` when there's no parseable vtime.
-fn moment_vtime_seconds(entry: &Value) -> Option<f64> {
+/// Parse a `moment`'s vtime out of an NDJSON entry. The API sends
+/// `moment.vtime` as a seconds string (e.g. "398.4898"); accept a JSON number
+/// too, since the schema doesn't forbid one (and snouty's own `--json` output
+/// uses a number). Returns `None` when there's no parseable vtime.
+fn moment_vtime(entry: &Value) -> Option<VTime> {
     let vtime = &entry["moment"]["vtime"];
-    vtime
-        .as_str()
-        .and_then(|s| s.parse::<f64>().ok())
-        .or_else(|| vtime.as_f64())
+    match vtime.as_str() {
+        Some(s) => s.parse().ok(),
+        None => vtime.as_f64().and_then(VTime::from_seconds),
+    }
+}
+
+/// Rewrite an NDJSON event line's `moment.vtime` from the server's seconds
+/// string to an exact JSON number, matching every other `--json` surface (the
+/// value survives byte-identically; see [`VTime`]). A line that doesn't parse,
+/// or has no parseable vtime, passes through unchanged.
+fn numeric_vtime_line(line: &str) -> std::borrow::Cow<'_, str> {
+    let Ok(mut entry) = serde_json::from_str::<Value>(line) else {
+        return std::borrow::Cow::Borrowed(line);
+    };
+    let Some(vtime) = moment_vtime(&entry) else {
+        return std::borrow::Cow::Borrowed(line);
+    };
+    entry["moment"]["vtime"] = json!(vtime);
+    std::borrow::Cow::Owned(entry.to_string())
 }
 
 /// Render a log line's vtime in seconds with exactly 3 decimal places,
@@ -1639,10 +1645,10 @@ fn format_log_vtime(entry: &Value) -> String {
         // The API sends vtime as a seconds string; truncate it directly so f64
         // round-trips can't nudge the displayed value.
         Some(s) => truncate_decimals(s, 3),
-        // A JSON-number vtime: format with surplus precision, then truncate the
-        // string, so the kept 3 decimals are never perturbed by rounding.
-        None => match raw.as_f64() {
-            Some(v) => truncate_decimals(&format!("{v:.9}"), 3),
+        // A JSON-number vtime: VTime's Display is the exact text the number
+        // was printed from, so truncating it cuts — never rounds.
+        None => match raw.as_f64().and_then(VTime::from_seconds) {
+            Some(v) => truncate_decimals(&v.to_string(), 3),
             None => String::new(),
         },
     }
@@ -1793,10 +1799,10 @@ impl LineTransformer for FaultAnnotator {
             let mut update_faults = false;
 
             // The API sends moment.vtime as seconds, so the fault-window math
-            // runs directly in seconds. Lines without a vtime fall back to 0.0,
-            // which never expires a window (expiry is strict less-than).
-            let event_vtime = moment_vtime_seconds(&entry);
-            let latest_vtime = event_vtime.unwrap_or(0.0);
+            // runs directly in seconds. Lines without a vtime fall back to
+            // zero, which never expires a window (expiry is strict less-than).
+            let event_vtime = moment_vtime(&entry);
+            let latest_vtime = event_vtime.unwrap_or(VTime::ZERO);
             let fault_name = entry["fault"]["name"].as_str();
             let is_fault_injector = entry["source"]["name"]
                 .as_str()
@@ -1828,7 +1834,7 @@ impl LineTransformer for FaultAnnotator {
 
             if is_fault_injector && let Some(fault_name) = fault_name {
                 let max_duration = entry["fault"]["max_duration"].as_f64().filter(|d| *d > 0.0);
-                let end_vtime = max_duration.map(|duration| duration + latest_vtime);
+                let end_vtime = max_duration.map(|duration| latest_vtime.plus_seconds(duration));
                 let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
 
                 if let Some(target) = entry["fault"]["affected_nodes"]
@@ -1881,8 +1887,9 @@ impl LineTransformer for FaultAnnotator {
             if let Some(output_text) = entry["output_text"].as_str() {
                 entry["output_text"] = Value::String(strip_ansi(output_text));
             }
-            // Replace the seconds string with its f64 form in place — the only
-            // processing snouty does to vtime.
+            // Replace the seconds string with an exact JSON number in place —
+            // the only processing snouty does to vtime (VTime guarantees the
+            // value survives byte-identically).
             if let Some(vtime) = event_vtime {
                 entry["moment"]["vtime"] = json!(vtime);
             }
@@ -1922,14 +1929,14 @@ fn strip_ansi(text: &str) -> String {
 }
 
 struct FaultWindowBounds {
-    start_vtime: f64,
-    end_vtime: Option<f64>,
+    start_vtime: VTime,
+    end_vtime: Option<VTime>,
 }
 
 impl FaultWindowBounds {
-    fn is_expired(&self, latest_vtime: &f64) -> bool {
+    fn is_expired(&self, latest_vtime: VTime) -> bool {
         self.end_vtime
-            .map(|expiry| expiry.lt(latest_vtime))
+            .map(|expiry| expiry < latest_vtime)
             .unwrap_or(false)
     }
 }
@@ -1937,6 +1944,7 @@ impl FaultWindowBounds {
 struct ActiveFaultWindows {
     network: IndexMap<String, FaultWindowBounds>,
     node: IndexMap<String, IndexMap<String, FaultWindowBounds>>,
+    // The offset is a duration (seconds added to the clock), not a vtime.
     clock: Vec<(f64, FaultWindowBounds)>,
 }
 
@@ -1961,17 +1969,16 @@ impl ActiveFaultWindows {
         did_something
     }
 
-    fn clear_expired_faults(&mut self, latest_vtime: f64) -> bool {
+    fn clear_expired_faults(&mut self, latest_vtime: VTime) -> bool {
         let mut did_something;
 
         let clock_faults_length = self.clock.len();
-        self.clock
-            .retain(|fault| !fault.1.is_expired(&latest_vtime));
+        self.clock.retain(|fault| !fault.1.is_expired(latest_vtime));
         did_something = self.clock.len() != clock_faults_length;
 
         for _ in self
             .network
-            .extract_if(.., |_k, window| window.is_expired(&latest_vtime))
+            .extract_if(.., |_k, window| window.is_expired(latest_vtime))
         {
             did_something = true;
         }
@@ -1979,7 +1986,7 @@ impl ActiveFaultWindows {
         let mut dropped_categories_of_node_faults = false;
         for _ in self.node.extract_if(.., |_k, windows_by_container| {
             for _ in
-                windows_by_container.extract_if(.., |_c, window| window.is_expired(&latest_vtime))
+                windows_by_container.extract_if(.., |_c, window| window.is_expired(latest_vtime))
             {
                 did_something = true;
             }
@@ -2072,7 +2079,7 @@ impl ActiveFaultWindows {
 
         if !&self.clock.is_empty() {
             let mut offset_sum = 0f64;
-            let mut max_clock_fault_start = 0f64;
+            let mut max_clock_fault_start = VTime::ZERO;
 
             for entry in &self.clock {
                 offset_sum += entry.0;
@@ -2093,7 +2100,7 @@ fn merge_fault_windows(
     incumbent: &FaultWindowBounds,
     new: FaultWindowBounds,
 ) -> Option<FaultWindowBounds> {
-    if new.start_vtime.lt(&incumbent.start_vtime) {
+    if new.start_vtime < incumbent.start_vtime {
         return Some(FaultWindowBounds {
             start_vtime: new.start_vtime,
             end_vtime: incumbent.end_vtime.and_then(|prev_expiry| {
@@ -2110,7 +2117,7 @@ fn merge_fault_windows(
                 end_vtime: None,
             }),
             Some(new_expiry) => {
-                if new_expiry.gt(&prev_expiry) {
+                if new_expiry > prev_expiry {
                     return Some(FaultWindowBounds {
                         start_vtime: incumbent.start_vtime,
                         end_vtime: Some(new_expiry),
@@ -3159,7 +3166,7 @@ mod tests {
         Event {
             moment: Moment {
                 input_hash: input_hash.to_string(),
-                vtime: vtime.to_string(),
+                vtime: vtime.parse().unwrap(),
             },
         }
     }
@@ -3600,6 +3607,26 @@ mod tests {
         // non-number is passed through untouched.
         assert_eq!(truncate_decimals("1e3", 3), "1000.000");
         assert_eq!(truncate_decimals("n/a", 3), "n/a");
+    }
+
+    #[test]
+    fn format_log_vtime_agrees_between_string_and_number_forms() {
+        // A vtime rendered from the JSON-number form (snouty's own --json
+        // output) must land on the same truncated — never rounded — text as
+        // the server's string form, so a value copied off the screen and fed
+        // back as --begin-vtime lands on the line you saw, never past it.
+        for s in ["398.4898056755774", "311.8487535319291", "402.0", "1.9995"] {
+            let vtime: VTime = s.parse().unwrap();
+            let from_string = format_log_vtime(&json!({"moment": {"vtime": s}}));
+            let from_number = format_log_vtime(&json!({"moment": {"vtime": vtime}}));
+            assert_eq!(from_string, from_number, "for {s}");
+            assert_eq!(from_string, truncate_decimals(s, 3), "for {s}");
+        }
+        // Spot-check the truncation: .4898… cuts to .489 (rounding gives .490).
+        assert_eq!(
+            format_log_vtime(&json!({"moment": {"vtime": "398.4898056755774"}})),
+            "398.489"
+        );
     }
 
     #[test]
@@ -4454,6 +4481,47 @@ mod tests {
                 .to_string()
             )
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // vtime precision through the NDJSON paths
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fault_annotator_emits_full_precision_vtime_byte_identically() {
+        let mut transformer = FaultAnnotator {
+            active_fault_windows: ActiveFaultWindows::new(),
+            active_faults: json!({}),
+        };
+
+        // The seconds string becomes a JSON number carrying the exact value:
+        // the full-precision text survives the string -> f64 -> text round
+        // trip byte-for-byte (a vtime is ticks / 2^32, exact in an f64).
+        assert_eq!(
+            transformer
+                .try_transform(r#"{"moment":{"vtime":"398.4898056755774"},"output_text":"hi"}"#),
+            Some(
+                concat!(
+                    r#"{"moment":{"vtime":398.4898056755774},"output_text":"hi","#,
+                    r#""active_faults":{}}"#
+                )
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn numeric_vtime_line_converts_string_vtime_to_exact_number() {
+        assert_eq!(
+            numeric_vtime_line(r#"{"a":1,"moment":{"vtime":"313.15126806590706"},"z":2}"#),
+            r#"{"a":1,"moment":{"vtime":313.15126806590706},"z":2}"#
+        );
+        // No parseable vtime: the line passes through unchanged.
+        assert_eq!(
+            numeric_vtime_line(r#"{"moment":{"vtime":"n/a"}}"#),
+            r#"{"moment":{"vtime":"n/a"}}"#
+        );
+        assert_eq!(numeric_vtime_line("not json"), "not json");
     }
 
     // -----------------------------------------------------------------------

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1288,22 +1288,24 @@ async fn cmd_runs_build_logs(
 
     let mut wrote_any = false;
     let result = if json {
-        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+        // The --json contract is raw NDJSON passthrough.
+        stream_raw_lines(stream, |line| {
             wrote_any = true;
             writeln!(stdout, "{line}")?;
             Ok(())
         })
         .await
     } else {
-        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+        stream_ndjson_lines(stream, |line| {
             wrote_any = true;
-            if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
-                let ts = format_local_str(entry["timestamp"].as_str().unwrap_or(""));
-                let stream = entry["stream"].as_str().unwrap_or("out");
-                let text = sanitize(entry["text"].as_str().unwrap_or(""));
-                writeln!(stdout, "{ts} [{stream}] {text}")?;
-            } else {
-                writeln!(stdout, "{line}")?;
+            match line {
+                NdjsonLine::Entry(entry) => {
+                    let ts = format_local_str(entry["timestamp"].as_str().unwrap_or(""));
+                    let stream = entry["stream"].as_str().unwrap_or("out");
+                    let text = sanitize(entry["text"].as_str().unwrap_or(""));
+                    writeln!(stdout, "{ts} [{stream}] {text}")?;
+                }
+                NdjsonLine::Raw(line) => writeln!(stdout, "{line}")?,
             }
             Ok(())
         })
@@ -1331,32 +1333,6 @@ fn event_haystack(rendered: &RenderedEventEntry) -> String {
         "{} {} {} {}",
         rendered.input_hash, rendered.vtime, rendered.source, rendered.output
     )
-}
-
-/// Parse one NDJSON event line a single time and derive both its search haystack
-/// and (for the human table) its rendered row. A line that doesn't parse as JSON
-/// falls back to raw-line matching and a sanitized raw OUTPUT row.
-fn prepare_event_line(line: &str) -> (String, [String; 4]) {
-    match serde_json::from_str::<Value>(line) {
-        Ok(entry) => {
-            let rendered = render_event_entry(&entry);
-            let haystack = event_haystack(&rendered);
-            let row = [
-                rendered.input_hash,
-                rendered.vtime,
-                rendered.source,
-                rendered.output,
-            ];
-            (haystack, row)
-        }
-        // The line isn't valid JSON (a truncated final chunk, a proxy-injected
-        // error blob, …). Match against the raw line and surface it sanitized in
-        // the OUTPUT column rather than dropping it silently.
-        Err(_) => (
-            line.to_string(),
-            [String::new(), String::new(), String::new(), sanitize(line)],
-        ),
-    }
 }
 
 /// True when every needle (already lowercased) appears in `haystack`. Both sides
@@ -1422,27 +1398,22 @@ async fn cmd_runs_events(
 
     let mut stdout = BufWriter::new(std::io::stdout().lock());
 
-    // JSON mode emits the matching line with moment.vtime converted to an
-    // exact JSON number, but matching itself runs against the DECODED fields
-    // (see `event_haystack`) so it agrees with what the table shows. Parse
-    // each line once: the haystack and the vtime rewrite share the `Value`.
-    // A line that isn't JSON matches against the raw text and streams raw,
-    // like the human path.
+    // Matching runs against the DECODED fields (see `event_haystack`) so it
+    // agrees with what the table shows; a raw line matches on its text.
     if json {
-        let result = stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            let Ok(mut entry) = serde_json::from_str::<Value>(line) else {
-                if haystack_matches_all_needles(line, &lowered_matches) {
-                    writeln!(stdout, "{line}")?;
+        let result = stream_ndjson_lines(stream, |line| {
+            match line {
+                NdjsonLine::Entry(entry) => {
+                    let haystack = event_haystack(&render_event_entry(&entry));
+                    if haystack_matches_all_needles(&haystack, &lowered_matches) {
+                        writeln!(stdout, "{entry}")?;
+                    }
                 }
-                return Ok(());
-            };
-            let haystack = event_haystack(&render_event_entry(&entry));
-            if !haystack_matches_all_needles(&haystack, &lowered_matches) {
-                return Ok(());
-            }
-            match normalize_moment_vtime(&mut entry) {
-                Some(_) => writeln!(stdout, "{entry}")?,
-                None => writeln!(stdout, "{line}")?,
+                NdjsonLine::Raw(line) => {
+                    if haystack_matches_all_needles(line, &lowered_matches) {
+                        writeln!(stdout, "{line}")?;
+                    }
+                }
             }
             Ok(())
         })
@@ -1453,15 +1424,31 @@ async fn cmd_runs_events(
 
     // Human table: the event stream is small (the server already substring-
     // filters), so buffer the matching rows and size the HASH/VTIME/SOURCE
-    // columns to the actual content rather than guessing fixed widths. Each line
-    // is parsed once into both its haystack and its row.
+    // columns to the actual content rather than guessing fixed widths. A raw
+    // line surfaces sanitized in the OUTPUT column rather than being dropped.
     let mut rows: Vec<Vec<String>> = Vec::new();
-    let result = stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-        let (haystack, row) = prepare_event_line(line);
+    let result = stream_ndjson_lines(stream, |line| {
+        let (haystack, row) = match line {
+            NdjsonLine::Entry(entry) => {
+                let rendered = render_event_entry(&entry);
+                let haystack = event_haystack(&rendered);
+                let row = vec![
+                    rendered.input_hash,
+                    rendered.vtime,
+                    rendered.source,
+                    rendered.output,
+                ];
+                (haystack, row)
+            }
+            NdjsonLine::Raw(line) => (
+                line.to_string(),
+                vec![String::new(), String::new(), String::new(), sanitize(line)],
+            ),
+        };
         if !haystack_matches_all_needles(&haystack, &lowered_matches) {
             return Ok(());
         }
-        rows.push(row.to_vec());
+        rows.push(row);
         Ok(())
     })
     .await;
@@ -1529,34 +1516,36 @@ async fn cmd_runs_logs(
         // Fault annotation is the default; `--raw` opts out into a verbatim
         // NDJSON passthrough.
         if raw {
-            stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+            stream_raw_lines(stream, |line| {
                 wrote_any = true;
                 writeln!(stdout, "{line}")?;
                 Ok(())
             })
             .await
         } else {
-            stream_ndjson_lines(
-                stream,
-                FaultAnnotator {
-                    active_fault_windows: ActiveFaultWindows::new(),
-                    active_faults: json!({}),
-                },
-                |line| {
-                    wrote_any = true;
-                    writeln!(stdout, "{line}")?;
-                    Ok(())
-                },
-            )
+            let mut annotator = FaultAnnotator {
+                active_fault_windows: ActiveFaultWindows::new(),
+                active_faults: json!({}),
+            };
+            stream_ndjson_lines(stream, |line| {
+                wrote_any = true;
+                match line {
+                    NdjsonLine::Entry(mut entry) => {
+                        annotator.annotate(&mut entry);
+                        writeln!(stdout, "{entry}")?;
+                    }
+                    NdjsonLine::Raw(line) => writeln!(stdout, "{line}")?,
+                }
+                Ok(())
+            })
             .await
         }
     } else {
-        stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
+        stream_ndjson_lines(stream, |line| {
             wrote_any = true;
-            if let Ok(entry) = serde_json::from_str::<Value>(line) {
-                writeln!(stdout, "{}", format_log_entry(&entry, raw))?;
-            } else {
-                writeln!(stdout, "{line}")?;
+            match line {
+                NdjsonLine::Entry(entry) => writeln!(stdout, "{}", format_log_entry(&entry, raw))?,
+                NdjsonLine::Raw(line) => writeln!(stdout, "{line}")?,
             }
             Ok(())
         })
@@ -1724,9 +1713,49 @@ fn strip_log_envelope(entry: &Value) -> String {
     }
 }
 
+/// One line of an NDJSON stream, classified once at the stream boundary.
+enum NdjsonLine<'a> {
+    /// The happy case: the line parsed as a JSON *object* — the shape every
+    /// log/event record has — with `moment.vtime` already normalized to an
+    /// exact JSON number.
+    Entry(Value),
+    /// Everything else: a line that isn't valid JSON (a truncated final
+    /// chunk, a proxy-injected error blob, …) or valid JSON that isn't an
+    /// object. Carries the original text so callers surface it verbatim
+    /// rather than dropping it silently.
+    Raw(&'a str),
+}
+
+/// Classify one NDJSON line: see [`NdjsonLine`].
+fn classify_line(line: &str) -> NdjsonLine<'_> {
+    if let Ok(mut entry) = serde_json::from_str::<Value>(line)
+        && entry.is_object()
+    {
+        normalize_moment_vtime(&mut entry);
+        return NdjsonLine::Entry(entry);
+    }
+    NdjsonLine::Raw(line)
+}
+
+/// Stream an NDJSON response, handing each line to the callback parsed and
+/// normalized (see [`NdjsonLine`]). Commands whose contract is *raw*
+/// passthrough (`runs logs --json --raw`, `runs build-logs --json`) use
+/// [`stream_raw_lines`] instead — parsing is not their happy case.
 async fn stream_ndjson_lines<S, C>(
+    stream: S,
+    mut process_line: impl FnMut(NdjsonLine<'_>) -> Result<()>,
+) -> Result<()>
+where
+    S: futures_util::Stream<Item = reqwest::Result<C>> + Unpin,
+    C: AsRef<[u8]>,
+{
+    stream_raw_lines(stream, |line| process_line(classify_line(line))).await
+}
+
+/// Split a byte stream into newline-delimited lines and hand each to the
+/// callback verbatim.
+async fn stream_raw_lines<S, C>(
     mut stream: S,
-    mut line_transformer: impl LineTransformer,
     mut process_line: impl FnMut(&str) -> Result<()>,
 ) -> Result<()>
 where
@@ -1746,11 +1775,7 @@ where
             if !line_bytes.is_empty() {
                 let line = std::str::from_utf8(line_bytes)
                     .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-                if let Some(transformed) = line_transformer.try_transform(line) {
-                    process_line(&transformed)?;
-                } else {
-                    process_line(line)?;
-                }
+                process_line(line)?;
             }
             buf.drain(..=pos);
         }
@@ -1759,26 +1784,10 @@ where
     if !buf.is_empty() {
         let line = std::str::from_utf8(&buf)
             .map_err(|e| eyre!("invalid UTF-8 in response stream: {e}"))?;
-        if let Some(transformed) = line_transformer.try_transform(line) {
-            process_line(&transformed)?;
-        } else {
-            process_line(line)?;
-        }
+        process_line(line)?;
     }
 
     Ok(())
-}
-
-trait LineTransformer {
-    fn try_transform(&mut self, line: &str) -> Option<String>;
-}
-
-struct NoOpTransformer {}
-
-impl LineTransformer for NoOpTransformer {
-    fn try_transform(&mut self, _: &str) -> Option<String> {
-        None
-    }
 }
 
 struct FaultAnnotator {
@@ -1786,85 +1795,70 @@ struct FaultAnnotator {
     active_faults: Value,
 }
 
-impl LineTransformer for FaultAnnotator {
-    fn try_transform(&mut self, line: &str) -> Option<String> {
-        if let Ok(mut entry) = serde_json::from_str::<Value>(line) {
-            let mut update_faults = false;
+impl FaultAnnotator {
+    /// Annotate one parsed log entry in place: advance the fault windows
+    /// using the entry's vtime, strip ANSI from `output_text`, and attach the
+    /// current `active_faults`.
+    fn annotate(&mut self, entry: &mut Value) {
+        let mut update_faults = false;
 
-            // The API sends moment.vtime as seconds, so the fault-window math
-            // runs directly in seconds. Lines without a vtime fall back to
-            // zero, which never expires a window (expiry is strict less-than).
-            let event_vtime = normalize_moment_vtime(&mut entry);
-            let latest_vtime = event_vtime.unwrap_or(VTime::ZERO);
-            let fault_name = entry["fault"]["name"].as_str();
-            let is_fault_injector = entry["source"]["name"]
+        // The fault-window math runs directly in seconds. Entries without a
+        // vtime fall back to zero, which never expires a window (expiry is
+        // strict less-than).
+        let latest_vtime = VTime::from_json(&entry["moment"]["vtime"]).unwrap_or(VTime::ZERO);
+        let fault_name = entry["fault"]["name"].as_str();
+        let is_fault_injector = entry["source"]["name"]
+            .as_str()
+            .map(|source| source.eq("fault_injector"))
+            .unwrap_or(false);
+
+        // Clear network and node faults if the fault injector was paused
+        if is_fault_injector
+            && entry["info"]["message"]
                 .as_str()
-                .map(|source| source.eq("fault_injector"))
-                .unwrap_or(false);
+                .map(|message| message.eq("status"))
+                .unwrap_or(false)
+            && entry["info"]["details"]["paused"]
+                .as_bool()
+                .unwrap_or(false)
+        {
+            update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
+            update_faults = self.active_fault_windows.clear_node_faults() || update_faults;
+        }
 
-            // Clear network and node faults if the fault injector was paused
-            if is_fault_injector
-                && entry["info"]["message"]
-                    .as_str()
-                    .map(|message| message.eq("status"))
-                    .unwrap_or(false)
-                && entry["info"]["details"]["paused"]
-                    .as_bool()
-                    .unwrap_or(false)
+        // Clear network faults if the network was restored
+        if is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false) {
+            update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
+        }
+
+        // Clear any expired faults
+        update_faults =
+            self.active_fault_windows.clear_expired_faults(latest_vtime) || update_faults;
+
+        if is_fault_injector && let Some(fault_name) = fault_name {
+            let max_duration = entry["fault"]["max_duration"].as_f64().filter(|d| *d > 0.0);
+            let end_vtime = max_duration.map(|duration| latest_vtime.plus_seconds(duration));
+            let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
+
+            if let Some(target) = entry["fault"]["affected_nodes"]
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|first| first.as_str())
             {
-                update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
-                update_faults = self.active_fault_windows.clear_node_faults() || update_faults;
-            }
-
-            // Clear network faults if the network was restored
-            if is_fault_injector && fault_name.map(|n| n.eq("restore")).unwrap_or(false) {
-                update_faults = self.active_fault_windows.clear_network_faults() || update_faults;
-            }
-
-            // Clear any expired faults
-            update_faults =
-                self.active_fault_windows.clear_expired_faults(latest_vtime) || update_faults;
-
-            if is_fault_injector && let Some(fault_name) = fault_name {
-                let max_duration = entry["fault"]["max_duration"].as_f64().filter(|d| *d > 0.0);
-                let end_vtime = max_duration.map(|duration| latest_vtime.plus_seconds(duration));
-                let fault_type = entry["fault"]["type"].as_str().unwrap_or("");
-
-                if let Some(target) = entry["fault"]["affected_nodes"]
-                    .as_array()
-                    .and_then(|arr| arr.first())
-                    .and_then(|first| first.as_str())
-                {
-                    if fault_name.eq("partition") || fault_name.eq("clog") {
-                        update_faults = self.active_fault_windows.add_network_fault(
-                            fault_name.to_string(),
-                            FaultWindowBounds {
-                                start_vtime: latest_vtime,
-                                end_vtime,
-                            },
-                        ) || update_faults;
-                    }
-
-                    if fault_type.eq("node")
-                        && (fault_name.eq("pause") || fault_name.eq("throttle"))
-                    {
-                        update_faults = self.active_fault_windows.add_node_fault(
-                            fault_name.to_string(),
-                            target.to_string(),
-                            FaultWindowBounds {
-                                start_vtime: latest_vtime,
-                                end_vtime,
-                            },
-                        ) || update_faults;
-                    }
+                if fault_name.eq("partition") || fault_name.eq("clog") {
+                    update_faults = self.active_fault_windows.add_network_fault(
+                        fault_name.to_string(),
+                        FaultWindowBounds {
+                            start_vtime: latest_vtime,
+                            end_vtime,
+                        },
+                    ) || update_faults;
                 }
 
-                if fault_name.eq("skip")
-                    && fault_type.eq("clock")
-                    && let Some(offset) = entry["fault"]["details"]["offset"].as_f64()
-                {
-                    update_faults = self.active_fault_windows.add_clock_fault(
-                        offset,
+                if fault_type.eq("node") && (fault_name.eq("pause") || fault_name.eq("throttle")) {
+                    update_faults = self.active_fault_windows.add_node_fault(
+                        fault_name.to_string(),
+                        target.to_string(),
                         FaultWindowBounds {
                             start_vtime: latest_vtime,
                             end_vtime,
@@ -1873,21 +1867,29 @@ impl LineTransformer for FaultAnnotator {
                 }
             }
 
-            if update_faults {
-                self.active_faults = self.active_fault_windows.to_json();
-            }
-
-            if let Some(output_text) = entry["output_text"].as_str() {
-                entry["output_text"] = Value::String(strip_ansi(output_text));
-            }
-
-            if entry.is_object() {
-                entry["active_faults"] = self.active_faults.clone();
-                return Some(format!("{}", entry));
+            if fault_name.eq("skip")
+                && fault_type.eq("clock")
+                && let Some(offset) = entry["fault"]["details"]["offset"].as_f64()
+            {
+                update_faults = self.active_fault_windows.add_clock_fault(
+                    offset,
+                    FaultWindowBounds {
+                        start_vtime: latest_vtime,
+                        end_vtime,
+                    },
+                ) || update_faults;
             }
         }
 
-        None
+        if update_faults {
+            self.active_faults = self.active_fault_windows.to_json();
+        }
+
+        if let Some(output_text) = entry["output_text"].as_str() {
+            entry["output_text"] = Value::String(strip_ansi(output_text));
+        }
+
+        entry["active_faults"] = self.active_faults.clone();
     }
 }
 
@@ -2209,7 +2211,11 @@ fn render_event_entry(entry: &Value) -> RenderedEventEntry {
         .as_str()
         .unwrap_or("")
         .to_string();
-    let vtime = entry["moment"]["vtime"].as_str().unwrap_or("").to_string();
+    // The stream normalizes vtime to a JSON number; VTime's Display prints
+    // the same text the server sent, so the column stays copy-paste exact.
+    let vtime = VTime::from_json(&entry["moment"]["vtime"])
+        .map(|v| v.to_string())
+        .unwrap_or_default();
     let container = entry["source"]["container"].as_str().unwrap_or("");
     let name = entry["source"]["name"].as_str().unwrap_or("");
     let stream = entry["source"]["stream"].as_str().unwrap_or("");
@@ -2769,6 +2775,25 @@ mod tests {
     use super::*;
     use hegel::generators;
     use serde_json::json;
+
+    /// Test surface for the annotated-logs pipeline: classify the line
+    /// exactly as the stream does, annotate entries, and return the emitted
+    /// text. `None` means the stream would pass the line through raw.
+    trait TryTransform {
+        fn try_transform(&mut self, line: &str) -> Option<String>;
+    }
+
+    impl TryTransform for FaultAnnotator {
+        fn try_transform(&mut self, line: &str) -> Option<String> {
+            match classify_line(line) {
+                NdjsonLine::Entry(mut entry) => {
+                    self.annotate(&mut entry);
+                    Some(entry.to_string())
+                }
+                NdjsonLine::Raw(_) => None,
+            }
+        }
+    }
 
     /// `wrap_text` preserves the exact sequence of words — wrapping only inserts
     /// line breaks, it never drops, splits, reorders, or invents a word.
@@ -5227,7 +5252,10 @@ mod tests {
         // decoded haystack carries them unescaped, so the match succeeds even
         // though the raw NDJSON line escapes them as `\"`.
         let line = r#"{"moment":{"input_hash":"42","vtime":"1.0"},"source":{"container":"app","name":"app","stream":"out"},"output_text":"msg \"starting\""}"#;
-        let (haystack, _row) = prepare_event_line(line);
+        let NdjsonLine::Entry(entry) = classify_line(line) else {
+            panic!("event line should classify as an entry");
+        };
+        let haystack = event_haystack(&render_event_entry(&entry));
         assert!(haystack.contains(r#"msg "starting""#));
 
         let needle = vec![r#""starting""#.to_lowercase()];

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1627,8 +1627,8 @@ fn format_log_vtime(entry: &Value) -> String {
         // The API sends vtime as a seconds string; truncate it directly so f64
         // round-trips can't nudge the displayed value.
         Some(s) => truncate_decimals(s, 3),
-        // A JSON-number vtime: VTime's Display is plain decimal and
-        // value-exact, so truncating it cuts — never rounds.
+        // A JSON-number vtime: VTime's Display is the exact text the number
+        // was printed from, so truncating it cuts — never rounds.
         None => match VTime::from_json(raw) {
             Some(v) => truncate_decimals(&v.to_string(), 3),
             None => String::new(),
@@ -4551,15 +4551,10 @@ mod tests {
         let NdjsonLine::Entry(entry) = classify_line(&line) else {
             panic!("an object line should classify as Entry");
         };
-        // The expected number text comes from the JSON writer, not Display:
-        // below ~10µs the writer uses exponent notation where Display stays
-        // plain decimal. Both carry the identical value.
-        let number_text = serde_json::to_string(&vtime).unwrap();
         assert_eq!(
             entry.to_string(),
-            format!(r#"{{"moment":{{"vtime":{number_text}}},"output_text":"x"}}"#)
+            format!(r#"{{"moment":{{"vtime":{vtime}}},"output_text":"x"}}"#)
         );
-        assert_eq!(VTime::from_json(&entry["moment"]["vtime"]), Some(vtime));
     }
 
     /// classify_line never panics, whatever the server sends; anything that

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1425,15 +1425,25 @@ async fn cmd_runs_events(
     // JSON mode emits the matching line with moment.vtime converted to an
     // exact JSON number, but matching itself runs against the DECODED fields
     // (see `event_haystack`) so it agrees with what the table shows. Parse
-    // each line once to build the haystack, then stream the matching line as
-    // it arrives.
+    // each line once: the haystack and the vtime rewrite share the `Value`.
+    // A line that isn't JSON matches against the raw text and streams raw,
+    // like the human path.
     if json {
         let result = stream_ndjson_lines(stream, NoOpTransformer {}, |line| {
-            let (haystack, _) = prepare_event_line(line);
+            let Ok(mut entry) = serde_json::from_str::<Value>(line) else {
+                if haystack_matches_all_needles(line, &lowered_matches) {
+                    writeln!(stdout, "{line}")?;
+                }
+                return Ok(());
+            };
+            let haystack = event_haystack(&render_event_entry(&entry));
             if !haystack_matches_all_needles(&haystack, &lowered_matches) {
                 return Ok(());
             }
-            writeln!(stdout, "{}", numeric_vtime_line(line))?;
+            match normalize_moment_vtime(&mut entry) {
+                Some(_) => writeln!(stdout, "{entry}")?,
+                None => writeln!(stdout, "{line}")?,
+            }
             Ok(())
         })
         .await;
@@ -1606,31 +1616,14 @@ fn format_log_entry(entry: &Value, raw: bool) -> String {
     )
 }
 
-/// Parse a `moment`'s vtime out of an NDJSON entry. The API sends
-/// `moment.vtime` as a seconds string (e.g. "398.4898"); accept a JSON number
-/// too, since the schema doesn't forbid one (and snouty's own `--json` output
-/// uses a number). Returns `None` when there's no parseable vtime.
-fn moment_vtime(entry: &Value) -> Option<VTime> {
-    let vtime = &entry["moment"]["vtime"];
-    match vtime.as_str() {
-        Some(s) => s.parse().ok(),
-        None => vtime.as_f64().and_then(VTime::from_seconds),
-    }
-}
-
-/// Rewrite an NDJSON event line's `moment.vtime` from the server's seconds
-/// string to an exact JSON number, matching every other `--json` surface (the
-/// value survives byte-identically; see [`VTime`]). A line that doesn't parse,
-/// or has no parseable vtime, passes through unchanged.
-fn numeric_vtime_line(line: &str) -> std::borrow::Cow<'_, str> {
-    let Ok(mut entry) = serde_json::from_str::<Value>(line) else {
-        return std::borrow::Cow::Borrowed(line);
-    };
-    let Some(vtime) = moment_vtime(&entry) else {
-        return std::borrow::Cow::Borrowed(line);
-    };
+/// Convert an NDJSON entry's `moment.vtime` from the server's seconds string
+/// to an exact JSON number in place — the only processing snouty does to a
+/// vtime (see [`VTime`]). Returns the vtime, or `None` (entry untouched) when
+/// there's no parseable one.
+fn normalize_moment_vtime(entry: &mut Value) -> Option<VTime> {
+    let vtime = VTime::from_json(&entry["moment"]["vtime"])?;
     entry["moment"]["vtime"] = json!(vtime);
-    std::borrow::Cow::Owned(entry.to_string())
+    Some(vtime)
 }
 
 /// Render a log line's vtime in seconds with exactly 3 decimal places,
@@ -1647,7 +1640,7 @@ fn format_log_vtime(entry: &Value) -> String {
         Some(s) => truncate_decimals(s, 3),
         // A JSON-number vtime: VTime's Display is the exact text the number
         // was printed from, so truncating it cuts — never rounds.
-        None => match raw.as_f64().and_then(VTime::from_seconds) {
+        None => match VTime::from_json(raw) {
             Some(v) => truncate_decimals(&v.to_string(), 3),
             None => String::new(),
         },
@@ -1801,7 +1794,7 @@ impl LineTransformer for FaultAnnotator {
             // The API sends moment.vtime as seconds, so the fault-window math
             // runs directly in seconds. Lines without a vtime fall back to
             // zero, which never expires a window (expiry is strict less-than).
-            let event_vtime = moment_vtime(&entry);
+            let event_vtime = normalize_moment_vtime(&mut entry);
             let latest_vtime = event_vtime.unwrap_or(VTime::ZERO);
             let fault_name = entry["fault"]["name"].as_str();
             let is_fault_injector = entry["source"]["name"]
@@ -1886,12 +1879,6 @@ impl LineTransformer for FaultAnnotator {
 
             if let Some(output_text) = entry["output_text"].as_str() {
                 entry["output_text"] = Value::String(strip_ansi(output_text));
-            }
-            // Replace the seconds string with an exact JSON number in place —
-            // the only processing snouty does to vtime (VTime guarantees the
-            // value survives byte-identically).
-            if let Some(vtime) = event_vtime {
-                entry["moment"]["vtime"] = json!(vtime);
             }
 
             if entry.is_object() {
@@ -4494,9 +4481,8 @@ mod tests {
             active_faults: json!({}),
         };
 
-        // The seconds string becomes a JSON number carrying the exact value:
-        // the full-precision text survives the string -> f64 -> text round
-        // trip byte-for-byte (a vtime is ticks / 2^32, exact in an f64).
+        // The full-precision seconds string becomes a JSON number carrying
+        // the exact value, byte-for-byte (see src/vtime.rs).
         assert_eq!(
             transformer
                 .try_transform(r#"{"moment":{"vtime":"398.4898056755774"},"output_text":"hi"}"#),
@@ -4511,17 +4497,18 @@ mod tests {
     }
 
     #[test]
-    fn numeric_vtime_line_converts_string_vtime_to_exact_number() {
+    fn normalize_moment_vtime_converts_string_vtime_to_exact_number() {
+        let mut entry = json!({"a": 1, "moment": {"vtime": "313.15126806590706"}, "z": 2});
+        assert!(normalize_moment_vtime(&mut entry).is_some());
         assert_eq!(
-            numeric_vtime_line(r#"{"a":1,"moment":{"vtime":"313.15126806590706"},"z":2}"#),
+            entry.to_string(),
             r#"{"a":1,"moment":{"vtime":313.15126806590706},"z":2}"#
         );
-        // No parseable vtime: the line passes through unchanged.
-        assert_eq!(
-            numeric_vtime_line(r#"{"moment":{"vtime":"n/a"}}"#),
-            r#"{"moment":{"vtime":"n/a"}}"#
-        );
-        assert_eq!(numeric_vtime_line("not json"), "not json");
+
+        // No parseable vtime: the entry is untouched.
+        let mut entry = json!({"moment": {"vtime": "n/a"}});
+        assert!(normalize_moment_vtime(&mut entry).is_none());
+        assert_eq!(entry, json!({"moment": {"vtime": "n/a"}}));
     }
 
     // -----------------------------------------------------------------------

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -4521,6 +4521,53 @@ mod tests {
         );
     }
 
+    /// The copy-paste contract of the log vtime column, over the whole tick
+    /// domain: the truncated text parses to a value at or before the real
+    /// vtime — never past it — and less than one millisecond behind. The
+    /// string and number wire forms render identically.
+    #[hegel::test]
+    fn truncated_log_vtime_never_lands_past_the_line(tc: hegel::TestCase) {
+        let ticks = tc.draw(generators::integers::<u64>().max_value((1 << 53) - 1));
+        let vtime = VTime::from_seconds(ticks as f64 / 4294967296.0).unwrap();
+
+        let truncated: f64 = truncate_decimals(&vtime.to_string(), 3).parse().unwrap();
+        assert!(truncated <= vtime.as_seconds());
+        assert!(vtime.as_seconds() - truncated < 0.001);
+
+        let from_string = format_log_vtime(&json!({"moment": {"vtime": vtime.to_string()}}));
+        let from_number = format_log_vtime(&json!({"moment": {"vtime": vtime}}));
+        assert_eq!(from_string, from_number);
+    }
+
+    /// The issue #191 guarantee over the whole tick domain: a vtime string
+    /// the server sends survives the stream's classify -> normalize ->
+    /// serialize pipeline byte-identically, as a JSON number.
+    #[hegel::test]
+    fn classify_line_preserves_any_real_vtime_byte_for_byte(tc: hegel::TestCase) {
+        let ticks = tc.draw(generators::integers::<u64>().max_value((1 << 53) - 1));
+        let vtime = VTime::from_seconds(ticks as f64 / 4294967296.0).unwrap();
+
+        let line = format!(r#"{{"moment":{{"vtime":"{vtime}"}},"output_text":"x"}}"#);
+        let NdjsonLine::Entry(entry) = classify_line(&line) else {
+            panic!("an object line should classify as Entry");
+        };
+        assert_eq!(
+            entry.to_string(),
+            format!(r#"{{"moment":{{"vtime":{vtime}}},"output_text":"x"}}"#)
+        );
+    }
+
+    /// classify_line never panics, whatever the server sends; anything that
+    /// isn't a JSON object comes back Raw and untouched.
+    #[hegel::test]
+    fn classify_line_never_panics_and_returns_raw_for_non_objects(tc: hegel::TestCase) {
+        let line = tc.draw(generators::text());
+        match classify_line(&line) {
+            NdjsonLine::Entry(entry) => assert!(entry.is_object()),
+            NdjsonLine::Raw(raw) => assert_eq!(raw, line),
+        }
+    }
+
     #[test]
     fn normalize_moment_vtime_converts_string_vtime_to_exact_number() {
         let mut entry = json!({"a": 1, "moment": {"vtime": "313.15126806590706"}, "z": 2});

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -780,7 +780,7 @@ fn mock_route_get_run_logs(run_id: &str) -> (u16, String) {
         r#"{"started_task":"abc_parallel_driver_fetch","task_status":"started","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"400.5"}}"#,
         r#"{"fault":{"name":"clog","type":"network","details":{"disruption_type":"Stopped"},"affected_nodes":["client2","setup"],"max_duration":0.267},"source":{"name":"fault_injector","pid":1086},"moment":{"input_hash":"5181922178177328213","vtime":"401.5"}}"#,
         r#"{"started_task":"abc_parallel_driver_fetch","task_status":"progressing","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"401.75"}}"#,
-        r#"{"started_task":"abc_parallel_driver_fetch","task_status":"completed","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"402"}}"#,
+        r#"{"started_task":"abc_parallel_driver_fetch","task_status":"completed","command":"core/parallel_driver_fetch","container_id":"d700ef3d05a263","tasks_len":"1","source":{"name":"antithesis_test_composer","pid":974},"moment":{"input_hash":"5181922178177328213","vtime":"402.0"}}"#,
     ];
     (200, lines.join("\n") + "\n")
 }
@@ -809,7 +809,10 @@ fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, St
     let status = mock_query_param(query, "status");
     let after = mock_query_param(query, "after");
 
-    let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"15.0"}}],"counterexamples":[{"moment":{"input_hash":"-200","vtime":"10.0"}},{"moment":{"input_hash":"-100","vtime":"5.0"}}]}"#.to_string();
+    // Full-precision, tick-aligned vtimes so a precision fault fails a spec:
+    // the counterexamples also pin the numeric sort ("45..." before "313...",
+    // where an alphanumeric sort would flip them).
+    let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"398.4898056755774"}}],"counterexamples":[{"moment":{"input_hash":"-200","vtime":"313.15126806590706"}},{"moment":{"input_hash":"-100","vtime":"45.334635781589895"}}]}"#.to_string();
     // A failing non-event ("system") property: the violating value lives in
     // `counterexamples`, so `--detail` must label it apart from the satisfying
     // `examples`.

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -809,9 +809,7 @@ fn mock_route_list_run_properties(run_id: &str, query: Option<&str>) -> (u16, St
     let status = mock_query_param(query, "status");
     let after = mock_query_param(query, "after");
 
-    // Full-precision, tick-aligned vtimes so a precision fault fails a spec:
-    // the counterexamples also pin the numeric sort ("45..." before "313...",
-    // where an alphanumeric sort would flip them).
+    // Full-precision vtimes so a precision fault fails a spec (see specs/runs.txt).
     let failing = r#"{"name":"Counter value stays below limit","description":"Counter stays within safe bounds","status":"Failing","is_event":true,"group":"Safety","example_count":12,"counterexample_count":3,"examples":[{"moment":{"input_hash":"-300","vtime":"398.4898056755774"}}],"counterexamples":[{"moment":{"input_hash":"-200","vtime":"313.15126806590706"}},{"moment":{"input_hash":"-100","vtime":"45.334635781589895"}}]}"#.to_string();
     // A failing non-event ("system") property: the violating value lives in
     // `counterexamples`, so `--detail` must label it apart from the satisfying

--- a/src/vtime.rs
+++ b/src/vtime.rs
@@ -1,0 +1,277 @@
+//! `VTime`: a moment's virtual time, in seconds.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+/// Ticks per second of virtual time: the hypervisor counts 2^32 ticks per
+/// second, and the API reports a vtime as `ticks / 2^32` seconds.
+const TICKS_PER_SECOND: f64 = 4294967296.0;
+
+/// A moment's virtual time in seconds.
+///
+/// A vtime is precision-sensitive: a moment sent back to the API must carry
+/// exactly the value the API named, or it identifies the wrong moment. An
+/// `f64` gives that guarantee by construction: `ticks / 2^32` has a
+/// power-of-two denominator, so the quotient is exact in an `f64` for any
+/// tick count below 2^53 (a vtime of ~24.3 days); `str::parse::<f64>` is
+/// correctly-rounded, so it recovers the exact value the API printed; and
+/// both [`fmt::Display`] and the JSON output print the shortest text that
+/// parses back to the same `f64`. Every path through this type is therefore
+/// value-exact.
+///
+/// Serialization writes a JSON *number* (not the API's string form): a number
+/// can't be compared alphanumerically by accident, where `"1000.0" < "9.0"`
+/// is true but wrong.
+#[derive(Clone, Copy, Debug)]
+pub struct VTime(f64);
+
+impl VTime {
+    /// The placeholder vtime (`"0"`) the API reports when a run has no
+    /// moment-pinned failure.
+    pub const ZERO: VTime = VTime(0.0);
+
+    /// A vtime from raw seconds, or `None` when the value is not finite —
+    /// the invariant every constructor enforces (see the `Ord` impl).
+    pub fn from_seconds(seconds: f64) -> Option<VTime> {
+        if !seconds.is_finite() {
+            return None;
+        }
+        let vtime = VTime(seconds);
+        if !vtime.is_tick_aligned() {
+            // Every vtime the API prints today sits on a hypervisor tick. A
+            // value off the tick grid means the API changed representation —
+            // surface that under --verbose instead of absorbing it silently.
+            log::debug!("vtime {seconds} is not tick-aligned (ticks / 2^32)");
+        }
+        Some(vtime)
+    }
+
+    /// The raw seconds value, for arithmetic that leaves the vtime domain.
+    pub fn as_seconds(self) -> f64 {
+        self.0
+    }
+
+    /// This vtime plus a duration in seconds — e.g. a fault window's end
+    /// projected from its start and `max_duration`. Adding two finite values
+    /// can overflow to infinity but can never produce a NaN, so the `Ord`
+    /// invariant holds.
+    pub fn plus_seconds(self, seconds: f64) -> VTime {
+        VTime(self.0 + seconds)
+    }
+
+    /// Whether this vtime sits exactly on a hypervisor tick (an integer
+    /// count of 1/2^32 seconds). Every vtime the API reports is tick-aligned.
+    pub fn is_tick_aligned(self) -> bool {
+        (self.0 * TICKS_PER_SECOND).fract() == 0.0
+    }
+}
+
+/// `total_cmp` is a total order over `f64`, which is what lets `VTime` be
+/// `Eq`/`Ord` at all. Using it is sound only because a NaN can never enter
+/// the type: `FromStr` and `Deserialize` reject non-finite values, and
+/// arithmetic on finite values can't produce one. Equality is defined through
+/// the same comparison so `Eq` and `Ord` always agree.
+impl Ord for VTime {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.total_cmp(&other.0)
+    }
+}
+
+impl PartialOrd for VTime {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for VTime {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for VTime {}
+
+/// Print with ryu — the same shortest-round-trip formatter `serde_json` uses
+/// for numbers — so the human-visible text always agrees byte-for-byte with
+/// the JSON output. (std's `{}` float formatting differs: it prints `402`
+/// where JSON needs `402.0`.)
+impl fmt::Display for VTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(ryu::Buffer::new().format(self.0))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseVTimeError;
+
+impl fmt::Display for ParseVTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("vtime is not a finite decimal number")
+    }
+}
+
+impl std::error::Error for ParseVTimeError {}
+
+impl FromStr for VTime {
+    type Err = ParseVTimeError;
+
+    /// `str::parse::<f64>` is correctly-rounded, recovering the exact `f64`
+    /// the API printed. It also accepts `inf`/`NaN`, which the finiteness
+    /// check rejects.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let seconds = s.parse::<f64>().map_err(|_| ParseVTimeError)?;
+        VTime::from_seconds(seconds).ok_or(ParseVTimeError)
+    }
+}
+
+impl serde::Serialize for VTime {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_f64(self.0)
+    }
+}
+
+/// An explicit visitor rather than `#[serde(untagged)]`: untagged buffers the
+/// value through serde's private `Content` type, which makes the string path
+/// less predictable; the visitor takes each input shape directly.
+struct VTimeVisitor;
+
+impl serde::de::Visitor<'_> for VTimeVisitor {
+    type Value = VTime;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a vtime: a finite number of seconds, or its decimal-string form")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<VTime, E> {
+        v.parse().map_err(E::custom)
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<VTime, E> {
+        VTime::from_seconds(v).ok_or_else(|| E::custom(ParseVTimeError))
+    }
+
+    // serde_json hands a whole-number JSON value (e.g. `402`) to the integer
+    // visitors, not `visit_f64`. The `as f64` conversion is exact below 2^53.
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<VTime, E> {
+        self.visit_f64(v as f64)
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<VTime, E> {
+        self.visit_f64(v as f64)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VTime {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(VTimeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every full-precision vtime that appears in the repository's fixtures
+    /// and specs. Each one is the API's own print of `ticks / 2^32`.
+    const REAL_VTIMES: &[&str] = &[
+        "398.4898056755774",
+        "313.15126806590706",
+        "22.475549569819123",
+        "45.334635781589895",
+        "329.8037810830865",
+        "73.94233945617452",
+        "311.8487535319291",
+        "90.17225814750418",
+        "22.66615231265314",
+        "402.0",
+    ];
+
+    #[test]
+    fn real_vtimes_round_trip_byte_identical() {
+        for s in REAL_VTIMES {
+            let vtime: VTime = s.parse().unwrap();
+            assert_eq!(vtime.to_string(), *s, "Display of {s}");
+            assert_eq!(
+                serde_json::to_string(&vtime).unwrap(),
+                *s,
+                "JSON number of {s}"
+            );
+            assert!(vtime.is_tick_aligned(), "{s} should be tick-aligned");
+        }
+    }
+
+    #[test]
+    fn tick_counts_recover_exactly_across_the_range() {
+        for ticks in [1u64, 1 << 20, 1 << 32, 1 << 42, 1 << 52, (1 << 53) - 1] {
+            let seconds = ticks as f64 / TICKS_PER_SECOND;
+            // Round-trip through the JSON number text, like a client would.
+            let text = serde_json::to_string(&VTime::from_seconds(seconds).unwrap()).unwrap();
+            let back: VTime = serde_json::from_str(&text).unwrap();
+            assert_eq!(
+                (back.as_seconds() * TICKS_PER_SECOND) as u64,
+                ticks,
+                "tick count {ticks} did not survive the round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_non_finite_and_non_numbers() {
+        for s in ["NaN", "nan", "inf", "-inf", "infinity", "1e999", "", "abc"] {
+            assert!(s.parse::<VTime>().is_err(), "{s:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn deserializes_from_string_and_number() {
+        let from_string: VTime = serde_json::from_str("\"398.4898056755774\"").unwrap();
+        let from_number: VTime = serde_json::from_str("398.4898056755774").unwrap();
+        assert_eq!(from_string, from_number);
+        // A whole-number JSON value arrives via the integer visitors.
+        let from_integer: VTime = serde_json::from_str("402").unwrap();
+        assert_eq!(from_integer.to_string(), "402.0");
+        assert!(serde_json::from_str::<VTime>("\"NaN\"").is_err());
+        assert!(serde_json::from_str::<VTime>("\"not a number\"").is_err());
+        assert!(serde_json::from_str::<VTime>("true").is_err());
+    }
+
+    #[test]
+    fn serializes_as_json_number() {
+        let vtime: VTime = "45.334635781589895".parse().unwrap();
+        assert!(serde_json::to_value(vtime).unwrap().is_number());
+    }
+
+    #[test]
+    fn ord_is_numeric_not_alphanumeric() {
+        let nine: VTime = "9.0".parse().unwrap();
+        let thousand: VTime = "1000.0".parse().unwrap();
+        assert!(nine < thousand);
+        assert!(
+            "1000.0" < "9.0",
+            "the string order this type guards against"
+        );
+    }
+
+    #[test]
+    fn zero_equals_the_placeholder() {
+        assert_eq!("0".parse::<VTime>().unwrap(), VTime::ZERO);
+        assert_ne!("0.5".parse::<VTime>().unwrap(), VTime::ZERO);
+    }
+
+    #[test]
+    fn plus_seconds_matches_fault_window_arithmetic() {
+        // The fault-window boundary tests pin `end = max_duration + start`
+        // exactly; plus_seconds must reproduce that sum bit-for-bit.
+        let start: VTime = "5".parse().unwrap();
+        assert_eq!(start.plus_seconds(5.0), "10".parse().unwrap());
+        let clog: VTime = "401.5".parse().unwrap();
+        assert_eq!(clog.plus_seconds(0.267), VTime(0.267 + 401.5));
+    }
+
+    #[test]
+    fn tick_alignment_detects_off_grid_values() {
+        assert!(VTime::ZERO.is_tick_aligned());
+        assert!(!VTime::from_seconds(0.1).unwrap().is_tick_aligned());
+    }
+}

--- a/src/vtime.rs
+++ b/src/vtime.rs
@@ -16,8 +16,8 @@ const TICKS_PER_SECOND: f64 = 4294967296.0;
 /// power-of-two denominator, so the quotient is exact in an `f64` for any
 /// tick count below 2^53 (a vtime of ~24.3 days); `str::parse::<f64>` is
 /// correctly-rounded, so it recovers the exact value the API printed; and
-/// both [`fmt::Display`] and the JSON output print shortest digits that
-/// parse back to the same `f64`. Every path through this type is therefore
+/// both [`fmt::Display`] and the JSON output print the shortest text that
+/// parses back to the same `f64`. Every path through this type is therefore
 /// value-exact.
 ///
 /// Serialization writes a JSON *number* (not the API's string form): a number
@@ -101,54 +101,15 @@ impl PartialEq for VTime {
 
 impl Eq for VTime {}
 
-/// Print the shortest round-trip digits (via zmij, the formatter `serde_json`
-/// uses) in plain decimal notation, never exponent notation. The API has only
-/// ever emitted plain-decimal vtimes and its spec doesn't promise it parses
-/// `e` notation, so text snouty hands back stays in the dialect the server
-/// demonstrably speaks. Where the JSON writer also prints plain decimal —
-/// every vtime the API emits — the two texts are byte-identical; a hegel
-/// property pins both facts. (std's `{}` float formatting is unsuitable
-/// either way: it prints `402` where the API prints `402.0`.)
+/// Print with zmij — the same shortest-round-trip formatter `serde_json`
+/// uses for numbers — so the human-visible text always agrees byte-for-byte
+/// with the JSON output; a hegel property pins the agreement over all finite
+/// values. (std's `{}` float formatting differs: it prints `402` where JSON
+/// needs `402.0`; ryu differs at the extremes: `1e16` where JSON prints
+/// `1e+16`.)
 impl fmt::Display for VTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut buf = zmij::Buffer::new();
-        let text = buf.format(self.0);
-        match text.contains('e') {
-            false => f.write_str(text),
-            true => f.write_str(&expand_exponent(text)),
-        }
-    }
-}
-
-/// Rewrite a float string from exponent notation to plain decimal by moving
-/// the decimal point. The digit sequence is preserved exactly, so the value —
-/// and its round-trip guarantee — is unchanged.
-fn expand_exponent(text: &str) -> String {
-    let (mantissa, exp) = text
-        .split_once('e')
-        .expect("caller checked for an exponent");
-    let exp: i32 = exp
-        .parse()
-        .expect("float exponent is a small signed integer");
-    let (sign, mantissa) = match mantissa.strip_prefix('-') {
-        Some(rest) => ("-", rest),
-        None => ("", mantissa),
-    };
-    let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
-    let digits = format!("{int_part}{frac_part}");
-    // Where the decimal point lands within (or beyond) the digit sequence.
-    let point = int_part.len() as i32 + exp;
-
-    if point <= 0 {
-        let zeros = "0".repeat(-point as usize);
-        format!("{sign}0.{zeros}{digits}")
-    } else if point as usize >= digits.len() {
-        let zeros = "0".repeat(point as usize - digits.len());
-        // Keep the ".0" an integral value carries in plain notation.
-        format!("{sign}{digits}{zeros}.0")
-    } else {
-        let (whole, frac) = digits.split_at(point as usize);
-        format!("{sign}{whole}.{frac}")
+        f.write_str(zmij::Buffer::new().format(self.0))
     }
 }
 
@@ -350,41 +311,13 @@ mod tests {
         assert_eq!((reparsed.as_seconds() * TICKS_PER_SECOND) as u64, ticks);
     }
 
-    /// `Display` never uses exponent notation (the only float dialect the
-    /// API demonstrably emits and parses is plain decimal), stays value-exact
-    /// anyway, and is byte-identical to the JSON number wherever the JSON
-    /// writer also prints plain decimal — which is every real vtime.
+    /// The human-visible `Display` text and the JSON number are the same
+    /// bytes for every finite value — the assumption that lets tables print
+    /// `Display` and stay copy-paste exact against the `--json` output.
     #[hegel::test]
-    fn display_is_plain_decimal_and_value_exact_for_any_finite_value(tc: hegel::TestCase) {
+    fn display_matches_json_number_text_for_any_finite_value(tc: hegel::TestCase) {
         let vtime = VTime::from_seconds(tc.draw(any_seconds())).unwrap();
-        let display = vtime.to_string();
-        assert!(
-            !display.contains(['e', 'E']),
-            "not plain decimal: {display}"
-        );
-        assert_eq!(display.parse::<VTime>().unwrap(), vtime);
-
-        let json = serde_json::to_string(&vtime).unwrap();
-        if !json.contains('e') {
-            assert_eq!(display, json);
-        }
-    }
-
-    #[test]
-    fn display_expands_exponent_notation_to_plain_decimal() {
-        // One tick — the smallest real vtime, and the value the issue's
-        // edge-case section flagged: serde_json prints it as an exponent.
-        let one_tick = VTime::from_seconds(1.0 / TICKS_PER_SECOND).unwrap();
-        assert_eq!(one_tick.to_string(), "0.00000000023283064365386963");
-        assert_eq!(
-            serde_json::to_string(&one_tick).unwrap(),
-            "2.3283064365386963e-10"
-        );
-        assert_eq!(one_tick.to_string().parse::<VTime>().unwrap(), one_tick);
-        // Beyond the plain regime on the large side, the ".0" convention of
-        // plain notation is kept.
-        let big = VTime::from_seconds(1e16).unwrap();
-        assert_eq!(big.to_string(), "10000000000000000.0");
+        assert_eq!(vtime.to_string(), serde_json::to_string(&vtime).unwrap());
     }
 
     /// The two wire shapes — the API's seconds string and snouty's JSON

--- a/src/vtime.rs
+++ b/src/vtime.rs
@@ -39,12 +39,21 @@ impl VTime {
         }
         let vtime = VTime(seconds);
         if !vtime.is_tick_aligned() {
-            // Every vtime the API prints today sits on a hypervisor tick. A
-            // value off the tick grid means the API changed representation —
-            // surface that under --verbose instead of absorbing it silently.
+            // Every vtime the API prints today sits on a hypervisor tick; log
+            // the exception so a representation change is visible under
+            // --verbose instead of silently absorbed.
             log::debug!("vtime {seconds} is not tick-aligned (ticks / 2^32)");
         }
         Some(vtime)
+    }
+
+    /// A vtime out of a JSON value, in either wire form: the API's seconds
+    /// string, or the number snouty itself emits.
+    pub fn from_json(value: &serde_json::Value) -> Option<VTime> {
+        match value.as_str() {
+            Some(s) => s.parse().ok(),
+            None => value.as_f64().and_then(VTime::from_seconds),
+        }
     }
 
     /// The raw seconds value, for arithmetic that leaves the vtime domain.
@@ -243,14 +252,20 @@ mod tests {
     }
 
     #[test]
+    fn from_json_accepts_both_wire_forms() {
+        let string_form = VTime::from_json(&serde_json::json!("398.4898056755774")).unwrap();
+        let number_form = VTime::from_json(&serde_json::json!(398.4898056755774)).unwrap();
+        assert_eq!(string_form, number_form);
+        assert!(VTime::from_json(&serde_json::json!(null)).is_none());
+        assert!(VTime::from_json(&serde_json::json!("n/a")).is_none());
+    }
+
+    #[test]
     fn ord_is_numeric_not_alphanumeric() {
+        // As strings, "1000.0" < "9.0" — the order this type guards against.
         let nine: VTime = "9.0".parse().unwrap();
         let thousand: VTime = "1000.0".parse().unwrap();
         assert!(nine < thousand);
-        assert!(
-            "1000.0" < "9.0",
-            "the string order this type guards against"
-        );
     }
 
     #[test]

--- a/src/vtime.rs
+++ b/src/vtime.rs
@@ -101,13 +101,15 @@ impl PartialEq for VTime {
 
 impl Eq for VTime {}
 
-/// Print with ryu — the same shortest-round-trip formatter `serde_json` uses
-/// for numbers — so the human-visible text always agrees byte-for-byte with
-/// the JSON output. (std's `{}` float formatting differs: it prints `402`
-/// where JSON needs `402.0`.)
+/// Print with zmij — the same shortest-round-trip formatter `serde_json`
+/// uses for numbers — so the human-visible text always agrees byte-for-byte
+/// with the JSON output; a hegel property pins the agreement over all finite
+/// values. (std's `{}` float formatting differs: it prints `402` where JSON
+/// needs `402.0`; ryu differs at the extremes: `1e16` where JSON prints
+/// `1e+16`.)
 impl fmt::Display for VTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(ryu::Buffer::new().format(self.0))
+        f.write_str(zmij::Buffer::new().format(self.0))
     }
 }
 
@@ -288,5 +290,45 @@ mod tests {
     fn tick_alignment_detects_off_grid_values() {
         assert!(VTime::ZERO.is_tick_aligned());
         assert!(!VTime::from_seconds(0.1).unwrap().is_tick_aligned());
+    }
+
+    /// Any finite, non-NaN seconds value the generators can produce.
+    fn any_seconds() -> hegel::generators::FloatGenerator<f64> {
+        hegel::generators::floats::<f64>()
+            .allow_nan(false)
+            .allow_infinity(false)
+    }
+
+    /// Every tick-aligned vtime in the representable range (ticks < 2^53,
+    /// ~24.3 days) survives the print/parse cycle, and the original tick
+    /// count recovers exactly — the type's core claim over its whole domain.
+    #[hegel::test]
+    fn any_tick_count_round_trips_exactly(tc: hegel::TestCase) {
+        let ticks = tc.draw(hegel::generators::integers::<u64>().max_value((1 << 53) - 1));
+        let vtime = VTime::from_seconds(ticks as f64 / TICKS_PER_SECOND).unwrap();
+        let reparsed: VTime = vtime.to_string().parse().unwrap();
+        assert_eq!(reparsed, vtime);
+        assert_eq!((reparsed.as_seconds() * TICKS_PER_SECOND) as u64, ticks);
+    }
+
+    /// The human-visible `Display` text and the JSON number are the same
+    /// bytes for every finite value — the assumption that lets tables print
+    /// `Display` and stay copy-paste exact against the `--json` output.
+    #[hegel::test]
+    fn display_matches_json_number_text_for_any_finite_value(tc: hegel::TestCase) {
+        let vtime = VTime::from_seconds(tc.draw(any_seconds())).unwrap();
+        assert_eq!(vtime.to_string(), serde_json::to_string(&vtime).unwrap());
+    }
+
+    /// The two wire shapes — the API's seconds string and snouty's JSON
+    /// number — deserialize to the same vtime for every finite value.
+    #[hegel::test]
+    fn string_and_number_wire_forms_agree_for_any_finite_value(tc: hegel::TestCase) {
+        let vtime = VTime::from_seconds(tc.draw(any_seconds())).unwrap();
+        let text = serde_json::to_string(&vtime).unwrap();
+        let from_number: VTime = serde_json::from_str(&text).unwrap();
+        let from_string: VTime = serde_json::from_str(&format!("\"{text}\"")).unwrap();
+        assert_eq!(from_number, vtime);
+        assert_eq!(from_string, vtime);
     }
 }

--- a/src/vtime.rs
+++ b/src/vtime.rs
@@ -16,8 +16,8 @@ const TICKS_PER_SECOND: f64 = 4294967296.0;
 /// power-of-two denominator, so the quotient is exact in an `f64` for any
 /// tick count below 2^53 (a vtime of ~24.3 days); `str::parse::<f64>` is
 /// correctly-rounded, so it recovers the exact value the API printed; and
-/// both [`fmt::Display`] and the JSON output print the shortest text that
-/// parses back to the same `f64`. Every path through this type is therefore
+/// both [`fmt::Display`] and the JSON output print shortest digits that
+/// parse back to the same `f64`. Every path through this type is therefore
 /// value-exact.
 ///
 /// Serialization writes a JSON *number* (not the API's string form): a number
@@ -101,15 +101,54 @@ impl PartialEq for VTime {
 
 impl Eq for VTime {}
 
-/// Print with zmij — the same shortest-round-trip formatter `serde_json`
-/// uses for numbers — so the human-visible text always agrees byte-for-byte
-/// with the JSON output; a hegel property pins the agreement over all finite
-/// values. (std's `{}` float formatting differs: it prints `402` where JSON
-/// needs `402.0`; ryu differs at the extremes: `1e16` where JSON prints
-/// `1e+16`.)
+/// Print the shortest round-trip digits (via zmij, the formatter `serde_json`
+/// uses) in plain decimal notation, never exponent notation. The API has only
+/// ever emitted plain-decimal vtimes and its spec doesn't promise it parses
+/// `e` notation, so text snouty hands back stays in the dialect the server
+/// demonstrably speaks. Where the JSON writer also prints plain decimal —
+/// every vtime the API emits — the two texts are byte-identical; a hegel
+/// property pins both facts. (std's `{}` float formatting is unsuitable
+/// either way: it prints `402` where the API prints `402.0`.)
 impl fmt::Display for VTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(zmij::Buffer::new().format(self.0))
+        let mut buf = zmij::Buffer::new();
+        let text = buf.format(self.0);
+        match text.contains('e') {
+            false => f.write_str(text),
+            true => f.write_str(&expand_exponent(text)),
+        }
+    }
+}
+
+/// Rewrite a float string from exponent notation to plain decimal by moving
+/// the decimal point. The digit sequence is preserved exactly, so the value —
+/// and its round-trip guarantee — is unchanged.
+fn expand_exponent(text: &str) -> String {
+    let (mantissa, exp) = text
+        .split_once('e')
+        .expect("caller checked for an exponent");
+    let exp: i32 = exp
+        .parse()
+        .expect("float exponent is a small signed integer");
+    let (sign, mantissa) = match mantissa.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", mantissa),
+    };
+    let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let digits = format!("{int_part}{frac_part}");
+    // Where the decimal point lands within (or beyond) the digit sequence.
+    let point = int_part.len() as i32 + exp;
+
+    if point <= 0 {
+        let zeros = "0".repeat(-point as usize);
+        format!("{sign}0.{zeros}{digits}")
+    } else if point as usize >= digits.len() {
+        let zeros = "0".repeat(point as usize - digits.len());
+        // Keep the ".0" an integral value carries in plain notation.
+        format!("{sign}{digits}{zeros}.0")
+    } else {
+        let (whole, frac) = digits.split_at(point as usize);
+        format!("{sign}{whole}.{frac}")
     }
 }
 
@@ -311,13 +350,41 @@ mod tests {
         assert_eq!((reparsed.as_seconds() * TICKS_PER_SECOND) as u64, ticks);
     }
 
-    /// The human-visible `Display` text and the JSON number are the same
-    /// bytes for every finite value — the assumption that lets tables print
-    /// `Display` and stay copy-paste exact against the `--json` output.
+    /// `Display` never uses exponent notation (the only float dialect the
+    /// API demonstrably emits and parses is plain decimal), stays value-exact
+    /// anyway, and is byte-identical to the JSON number wherever the JSON
+    /// writer also prints plain decimal — which is every real vtime.
     #[hegel::test]
-    fn display_matches_json_number_text_for_any_finite_value(tc: hegel::TestCase) {
+    fn display_is_plain_decimal_and_value_exact_for_any_finite_value(tc: hegel::TestCase) {
         let vtime = VTime::from_seconds(tc.draw(any_seconds())).unwrap();
-        assert_eq!(vtime.to_string(), serde_json::to_string(&vtime).unwrap());
+        let display = vtime.to_string();
+        assert!(
+            !display.contains(['e', 'E']),
+            "not plain decimal: {display}"
+        );
+        assert_eq!(display.parse::<VTime>().unwrap(), vtime);
+
+        let json = serde_json::to_string(&vtime).unwrap();
+        if !json.contains('e') {
+            assert_eq!(display, json);
+        }
+    }
+
+    #[test]
+    fn display_expands_exponent_notation_to_plain_decimal() {
+        // One tick — the smallest real vtime, and the value the issue's
+        // edge-case section flagged: serde_json prints it as an exponent.
+        let one_tick = VTime::from_seconds(1.0 / TICKS_PER_SECOND).unwrap();
+        assert_eq!(one_tick.to_string(), "0.00000000023283064365386963");
+        assert_eq!(
+            serde_json::to_string(&one_tick).unwrap(),
+            "2.3283064365386963e-10"
+        );
+        assert_eq!(one_tick.to_string().parse::<VTime>().unwrap(), one_tick);
+        // Beyond the plain regime on the large side, the ".0" convention of
+        // plain notation is kept.
+        let big = VTime::from_seconds(1e16).unwrap();
+        assert_eq!(big.to_string(), "10000000000000000.0");
     }
 
     /// The two wire shapes — the API's seconds string and snouty's JSON


### PR DESCRIPTION
A vtime is precision-sensitive: a moment sent back to the API must carry the exact value the API named, or it identifies the wrong moment. Snouty held vtimes as plain strings, and its `--json` surfaces disagreed on the type — `runs logs` printed a number while events, show, and properties printed strings. No type enforced the conversion, and no fixture could detect a precision fault.

This PR adds a `VTime` type and uses it everywhere snouty holds a vtime. The type wraps one private, finite `f64`, which holds any real vtime exactly (a vtime is `ticks / 2^32`, so the division only shifts the binary exponent). Parsing is correctly-rounded and printing is shortest-round-trip, so every path through the type is value-exact — the full test plan from the issue pins this, including byte-identical round trips for every full-precision vtime in the repository and tick recovery up to 2^53−1.

The main changes:

- `build.rs` tags `Moment.vtime` with a `format: vtime` marker and maps it onto `crate::vtime::VTime` with progenitor's `with_conversion`. The vendored `src/openapi.json` is not edited. The build asserts the mapping took, so a spec refresh or generator change cannot silently fall back to a string.
- Every `--json` surface now shows `vtime` as an exact JSON number. The NDJSON stream classifies each line once at its boundary (`NdjsonLine::Entry` — a parsed object with `moment.vtime` already normalized — or `NdjsonLine::Raw`), so no consumer re-parses lines or re-invents the junk-line fallback; commands whose contract is raw passthrough (`runs logs --json --raw`, `runs build-logs --json`) use the raw line streamer and never parse.
- The fault windows (`FaultWindowBounds`) hold `VTime`; the boundary arithmetic and its tests are unchanged. `sorted_by_vtime` shrinks to a `sort_by_key` on the type's `Ord`.
- Human output keeps its shape: the log stream still truncates vtime to 3 decimals (cuts, never rounds — a test pins that the string and number forms agree), and tables show the full-precision `Display` text, which matches the JSON number byte-for-byte.
- `Moment.from` vtimes (number or string) route through `VTime`, so an integer vtime normalizes to the API's own print (`402` → `"402.0"`) and a non-numeric vtime is rejected.
- Fixtures and specs use real full-precision vtimes, chosen so an alphanumeric sort or a one-ULP precision fault fails the suite. `scripts/gen-gallery.py` holds the vtime as the exact number text. `COOKBOOK.md` documents the numeric type and the numeric placeholder check.

**Breaking change:** `vtime` changes from a JSON string to a JSON number in `runs events --json`, `runs show --json` (`failure_moment.vtime`), and `runs properties --json`. A client that reads the value with `jq -r` keeps working; a client that expects a JSON string fails. `runs logs --json` already emitted a number and does not change.

Testing: the mock suite (546 tests), clippy, fmt, and pyright pass, and the staging spec suite passes against orbitinghail. Live probes against orbitinghail confirm the numeric output on real data and answer the issue's open question: the logs endpoint parses the vtime by value, not by text — the exact string, a trailing-zero variant, and `1.297957244166173e1` all stream the identical timeline, so `e` notation is also accepted. A full 83-story gallery generated with the new binary drives every moment-based story through the numeric vtimes end to end.

fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9UYm4w97yWTsvMeRHC2uZ



