### PR TITLE
Polish failure output: render concerns at print time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,9 @@ name: build
 on:
   push:
     branches: ["main"]
+  # No branch filter: a stacked pull request (base = another PR's branch) gets
+  # the same gate as one that targets main.
   pull_request:
-    branches: ["main"]
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,16 +87,13 @@ checks run against staging — a file that would mutate tenant state stops at a
 
 The `staging` job in `build.yml` runs this suite on every pull request and
 gates the merge. It skips on a fork's pull request, because GitHub does not
-pass secrets there. Three rules follow:
+pass secrets there. Two rules follow:
 
 - An unprefixed assertion must hold against any tenant. Put
   `stdout 'Run ID +[^ ]'` unprefixed and `stdout 'Run ID .*run-1'` behind
   `[!staging]`.
 - The tenant must have at least one completed run. `runs.txt` captures a run id
   from the list and every later command uses it.
-- Never put `!` on a line that also carries a condition. testscript reports the
-  skipped line as "expected to fail but succeeded". Write
-  `stdout -count=0 'x'` instead, or use `[staging] skip` for a whole block.
 
 A `stdout` or `stderr` pattern is always a regex, with Go's flags: `^` and
 `$` match at line boundaries, and `.` stops at a newline. State `(?s)` for a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2408,7 +2408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2748,6 +2748,7 @@ dependencies = [
  "syn",
  "tempfile",
  "testscript-rs",
+ "textwrap",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "which",
@@ -2843,10 +2844,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2866,6 +2867,12 @@ dependencies = [
  "thiserror 2.0.18",
  "walkdir",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -3497,7 +3504,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ http = "1.4.2"
 which = "8"
 rpassword = "7.5.4"
 keyring-core = "1.0.0"
+textwrap = { version = "0.16.2", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1.0.0", features = [ "keychain" ] }

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -129,12 +129,17 @@ class Snouty:
         args: list[str],
         env: dict[str, str | None] | None = None,
         stdin: str | None = None,
+        merge_streams: bool = False,
     ) -> Result:
         # `env` overrides individual vars for this call only: a string sets the
         # var, None unsets it (so a story can model an environment missing some
         # credential). Everything else inherits the live ANTITHESIS_* env.
         # `stdin`, when given, is fed to the process's standard input — used by the
         # interactive stories (`snouty login`) that read answers line-by-line.
+        # `merge_streams` interleaves stderr into stdout at capture time, which
+        # preserves interaction order for prompt transcripts: login prints its
+        # prompts and warnings on different streams, and capturing them apart
+        # reorders the conversation.
         run_env = self._env
         if env is not None:
             run_env = dict(self._env)
@@ -143,6 +148,16 @@ class Snouty:
                     run_env.pop(key, None)
                 else:
                     run_env[key] = value
+        if merge_streams:
+            proc = subprocess.run(
+                [str(self.binary), *args],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=run_env,
+                input=stdin,
+            )
+            return Result(args, proc.stdout, "", proc.returncode)
         proc = subprocess.run(
             [str(self.binary), *args],
             capture_output=True,
@@ -2077,7 +2092,7 @@ def build_login_stories() -> list[Story]:
                 prompts=(
                     "The current settings failed to load",
                     "Would you like to proceed",
-                    "has been backed up to",
+                    "kept as a backup:",
                 ),
                 files=(
                     (_SETTINGS, (f'tenant = "{_TENANT}"',)),
@@ -2219,7 +2234,10 @@ def run_login_story(sn: Snouty, story: Story) -> StoryRun:
         if story.env:
             env.update(story.env)
 
-        result = sn.run(story.args, env=env, stdin=story.stdin)
+        # Merge stderr into stdout so the transcript preserves interaction
+        # order: login prints prompts on one stream and warnings on the other,
+        # and separate captures reorder the conversation.
+        result = sn.run(story.args, env=env, stdin=story.stdin, merge_streams=True)
 
         captured: list[tuple[str, str | None]] = []
         for rel_path in story.post_capture:

--- a/specs/debug.txt
+++ b/specs/debug.txt
@@ -8,15 +8,19 @@
 #
 # Each successful invocation actually starts a debugging session against the
 # API, so the bulk of this file is gated behind `[staging] skip` to avoid
-# mutating staging. Read-only checks (env-var, schema validation, and the
-# run-id/session-id requirement that fail before any API call) run in both
-# modes.
+# mutating staging. The skip sits above the first `mock-server` directive:
+# under staging that directive installs the real tenant credentials, and no
+# `snouty debug` command may execute with them — safety must not depend on
+# where the command fails. Only the credential-free check above the skip runs
+# in both modes.
 
 # The command authenticates with the Antithesis API using either
 #    ANTITHESIS_API_KEY and ANTITHESIS_TENANT, or
 #    ANTITHESIS_USERNAME, ANTITHESIS_PASSWORD, and ANTITHESIS_TENANT.
 ! snouty debug --input-hash abc --run-id run-123 --vtime 123
 stderr 'No Antithesis credentials found.*'
+
+[staging] skip
 
 # Parameters are validated against the debuggingParams schema before
 #    making any API call. Required fields: input_hash, vtime, and exactly
@@ -31,14 +35,12 @@ stderr 'unexpected argument.*'
 
 # The target run must be identified by exactly one of --run-id or
 #    --session-id. Supplying both, or neither, is an error caught before any
-#    API call (so it is exercised in both mock and staging modes).
+#    API call.
 ! snouty debug --input-hash abc --vtime 1 --run-id r-1 --session-id s-1
 stderr 'specify exactly one of --run-id / --session-id.*'
 
 ! snouty debug --input-hash abc --vtime 1
 stderr 'specify --run-id or --session-id.*'
-
-[staging] skip
 
 # Parameters are provided as typed flags. Before sending, the resolved
 #    parameters are printed to stderr with sensitive values redacted. The

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -6,9 +6,9 @@
 # line so that I can trigger testing without using the web UI.
 #
 # Each successful invocation actually starts a test run against the API, so
-# the bulk of this file is gated behind `[staging] skip`. Read-only checks
-# (arg parsing, schema validation, env-var enforcement) all fail before any
-# API call and run in both modes.
+# the bulk of this file is gated behind `[staging] skip`. The credential-free
+# checks above the skip (arg parsing, schema validation) fail before any API
+# call and run in both modes.
 
 # The user specifies a webhook endpoint name via -w / --webhook (required).
 ! snouty launch --duration 30
@@ -43,6 +43,12 @@ stderr 'unexpected argument.*'
 ! snouty launch -w basic_test --duration 30
 stderr 'No Antithesis credentials found.*'
 
+# Everything below runs against the mock only. The skip sits above the first
+# `mock-server` directive: under staging that directive installs the real
+# tenant credentials, and no `snouty launch` command may execute with them —
+# safety must not depend on where the command fails.
+[staging] skip
+
 # --param cannot override typed flag values.
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 ! snouty launch -w basic_test --duration 30 --param antithesis.duration=60
@@ -53,8 +59,6 @@ stderr 'cannot be overridden via --param.*'
 mock-server 200 '{}'
 ! snouty launch -w basic_test
 stderr 'no parameters provided.*'
-
-[staging] skip
 
 # Parameters are provided as --key value typed flags
 #    (e.g. --duration 30, --test-name my-test). Before sending, the resolved

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -268,7 +268,10 @@ stdout 'No runs found\.'
 mock-server 400 '{"message":"bad request"}'
 env ANTITHESIS_API_KEY=test-api-key
 ! snouty runs
-stderr 'API error: 400.*'
+stderr '^Error: API error: 400.*'
+# The message sits on the `Error:` line itself: a single failure has no cause
+# chain to number, so no `0:` frame appears.
+! stderr '0: API error'
 ! stderr 'Backtrace omitted'
 
 # A rejection with no body at all is the API gateway's shape for auth and

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -209,20 +209,23 @@ snouty --json runs build-logs $R_run_id
 [!staging] stdout '"timestamp".*"text"'
 
 # `snouty runs events` filters by `--match` needles against the decoded output.
-#    Against staging the search carries `--limit`: a common needle in a real run
-#    matches an unbounded stream, and the suite's wall time must not scale with
-#    whatever run the tenant produced last. The mock keeps the unbounded form,
-#    whose full output the assertions below pin.
+#    Against staging the search matches `fault` and carries `--limit`: fault
+#    events are Antithesis-generated, exist in every fault-injecting run, and
+#    first appear near the start of the timeline, so the server stops after a
+#    shallow scan. A workload needle such as `request` sits at an arbitrary
+#    depth, and an unbounded search streams every match — the suite's wall time
+#    must not scale with whatever run the tenant produced last. The mock keeps
+#    the unbounded form, whose full output the assertions below pin.
 mock-runs-server
 [!staging] snouty runs events $R_run_id --match request
-[staging] snouty runs events $R_run_id --match request --limit 3
+[staging] snouty runs events $R_run_id --match fault --limit 3
 [!staging] stdout '^HASH\s+VTIME\s+SOURCE\s+OUTPUT'
 [!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
 
 # A second `--match` AND-narrows: every needle must be present in the line.
 mock-runs-server
 [!staging] snouty runs events $R_run_id --match request --match slow
-[staging] snouty runs events $R_run_id --match request --match slow --limit 3
+[staging] snouty runs events $R_run_id --match fault --match network --limit 3
 [!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
 # A needle that isn't present excludes the event entirely.
 mock-runs-server
@@ -232,7 +235,7 @@ stdout 'No events matched "starting nonexistent"\.'
 # `snouty --json runs events` outputs raw NDJSON.
 mock-runs-server
 [!staging] snouty --json runs events $R_run_id --match counter
-[staging] snouty --json runs events $R_run_id --match counter --limit 3
+[staging] snouty --json runs events $R_run_id --match fault --limit 3
 [!staging] stdout '"antithesis_assert".*"Counter'\''s value retrieved"'
 [!staging] stdout '.*"moment".*"input_hash":"-4735081784258020614".*'
 [!staging] stdout '.*"moment".*"vtime":"311\.8487535319291".*'

--- a/specs/runs.txt
+++ b/specs/runs.txt
@@ -209,14 +209,20 @@ snouty --json runs build-logs $R_run_id
 [!staging] stdout '"timestamp".*"text"'
 
 # `snouty runs events` filters by `--match` needles against the decoded output.
+#    Against staging the search carries `--limit`: a common needle in a real run
+#    matches an unbounded stream, and the suite's wall time must not scale with
+#    whatever run the tenant produced last. The mock keeps the unbounded form,
+#    whose full output the assertions below pin.
 mock-runs-server
-snouty runs events $R_run_id --match request
+[!staging] snouty runs events $R_run_id --match request
+[staging] snouty runs events $R_run_id --match request --limit 3
 [!staging] stdout '^HASH\s+VTIME\s+SOURCE\s+OUTPUT'
 [!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
 
 # A second `--match` AND-narrows: every needle must be present in the line.
 mock-runs-server
-snouty runs events $R_run_id --match request --match slow
+[!staging] snouty runs events $R_run_id --match request --match slow
+[staging] snouty runs events $R_run_id --match request --match slow --limit 3
 [!staging] stdout '-456.*2\.0.*\[app:error\].*\{"level":"warn","msg":"slow request"\}'
 # A needle that isn't present excludes the event entirely.
 mock-runs-server
@@ -225,7 +231,8 @@ stdout 'No events matched "starting nonexistent"\.'
 
 # `snouty --json runs events` outputs raw NDJSON.
 mock-runs-server
-snouty --json runs events $R_run_id --match counter
+[!staging] snouty --json runs events $R_run_id --match counter
+[staging] snouty --json runs events $R_run_id --match counter --limit 3
 [!staging] stdout '"antithesis_assert".*"Counter'\''s value retrieved"'
 [!staging] stdout '.*"moment".*"input_hash":"-4735081784258020614".*'
 [!staging] stdout '.*"moment".*"vtime":"311\.8487535319291".*'

--- a/specs_engine/validate_failures.txt
+++ b/specs_engine/validate_failures.txt
@@ -5,12 +5,14 @@ build-image unknown-prefix-failures:latest unknown_prefix
 ! snouty validate config_unknown --timeout 15
 stderr 'Unrecognized command names.*'
 stderr 'suite/readme.txt.*'
+stderr 'rename each command to start with a recognized prefix.*'
 
 # Non-executable test command — validate detects missing executable bit.
 build-image noexec-failures:latest noexec
 ! snouty validate config_noexec --timeout 15
 stderr 'not executable.*'
 stderr 'suite/first_noexec.*'
+stderr 'chmod \+x the listed commands.*'
 
 -- unknown_prefix/suite/first_ok --
 #!/bin/sh

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -461,10 +461,13 @@ fn persist_to_file(credentials: PersistableCredentials, profile: Option<&str>) -
             Ok(file) => file,
             Err(_) => {
                 let backup = back_up_unparsable_file(&path)?;
+                // Same shape as the settings repair note: paths on their own
+                // lines, since they are what the user may copy and what made
+                // the one-line form overflow.
                 eprintln!(
-                    "warning: the existing credentials file at {} could not be parsed; it has been backed up to {} and a new one will be written.",
+                    "warning: the existing credentials file could not be parsed; a new one will be written.\n  kept as a backup: {}\n  will be rewritten: {}",
+                    backup.display(),
                     path.display(),
-                    backup.display()
                 );
                 CredentialsFile {
                     default: None,

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -18,6 +18,7 @@ use crate::container::{
     Architecture, ContainerRuntime, DISCOVERY_COMMAND_TIMEOUT, RemoteManifest, available_engines,
     digests_for_repo, image_ref_tag, image_repo, is_podman_in_disguise, normalize_repo,
 };
+use crate::error::user_error;
 use crate::process::{ProcessGroupChild, output_with_timeout};
 
 /// How Docker Compose v2 is invoked on this machine.
@@ -690,7 +691,13 @@ pub fn parse_compose_config(yaml: &str) -> Result<ComposeContents> {
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 if is_external {
-                    bail!("network '{name}' is declared as external and won't work on Antithesis");
+                    return Err(user_error(format!(
+                        "network '{name}' is declared as external and won't work on Antithesis"
+                    ))
+                    .suggestion(
+                        "remove `external: true` and declare the network normally — Antithesis \
+                         provisions every network inside the test environment",
+                    ));
                 }
                 networks.push(name.to_string());
             }
@@ -1146,6 +1153,11 @@ networks:
         assert!(
             err.to_string().contains("external"),
             "expected error about external network, got: {err}"
+        );
+        // The suggestion names the fix, matching the other validate errors.
+        assert!(
+            format!("{err:?}").contains("remove `external: true`"),
+            "expected the removal suggestion, got: {err:?}"
         );
     }
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,8 +54,8 @@ impl std::error::Error for ApiError {}
 ///
 /// This is the one place that turns a `Report` into terminal text, so printing
 /// concerns live here and not in the messages: the chain index is dropped when
-/// there is nothing to enumerate, and overlong prose wraps to
-/// [`crate::render::PROSE_WIDTH`].
+/// there is nothing to enumerate. Wrapping is the caller's call — it depends
+/// on whether stderr is a terminal, which the print site knows.
 ///
 /// color_eyre renders every report as a numbered chain, so a single error —
 /// the common case — arrives as `\n   0: <message>`. The `0:` numbers
@@ -69,7 +69,7 @@ pub fn render_report(report: &Report) -> String {
     } else {
         rendered
     };
-    crate::render::wrap_text(&format!("Error: {rendered}"), crate::render::PROSE_WIDTH)
+    format!("Error: {rendered}")
 }
 
 /// Remove the `\n   0: ` frame header from a rendered single-element chain,
@@ -160,14 +160,15 @@ mod tests {
         assert!(rendered.contains("1: "), "got: {rendered}");
     }
 
+    // Wrapping belongs to the print site (it is tty-dependent), so the
+    // renderer must hand back the message as one logical line.
     #[test]
-    fn render_report_wraps_overlong_prose() {
-        let report = user_error(format!("prefix {}", "word ".repeat(40)));
+    fn render_report_does_not_wrap() {
+        let long = format!("prefix {}", "word ".repeat(40));
+        let report = user_error(long.clone());
         let rendered = plain(&render_report(&report));
-        let message_lines: Vec<&str> = rendered.lines().take_while(|l| !l.is_empty()).collect();
-        assert!(message_lines.len() > 1, "got: {rendered}");
         assert!(
-            message_lines.iter().all(|l| l.len() <= 100),
+            rendered.lines().next().unwrap().contains(&long),
             "got: {rendered}"
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,49 +53,26 @@ impl std::error::Error for ApiError {}
 /// Render a report for the user, at the moment of printing.
 ///
 /// This is the one place that turns a `Report` into terminal text, so printing
-/// concerns live here and not in the messages: the chain index is dropped when
-/// there is nothing to enumerate. Wrapping is the caller's call — it depends
-/// on whether stderr is a terminal, which the print site knows.
+/// concerns live here and not in the messages. Wrapping is the caller's call —
+/// it depends on whether stderr is a terminal, which the print site knows.
 ///
 /// color_eyre renders every report as a numbered chain, so a single error —
-/// the common case — arrives as `\n   0: <message>`. The `0:` numbers
-/// nothing and reads like a stack frame; collapse it onto the `Error:` line.
-/// A report with two or more chain elements keeps its numbering, which is
-/// genuinely enumerating causes there.
+/// the common case — arrives as `\n   0: <message>`. The `0:` numbers nothing
+/// and reads like a stack frame. For a one-element chain the message comes
+/// from the report itself instead, onto the `Error:` line. The sections a
+/// report carries (`Suggestion:`, `Note:`, payload snippets) render only
+/// through the handler, as the text after the first blank line; that tail is
+/// kept verbatim. A chain of two or more keeps color_eyre's numbering, which
+/// is genuinely enumerating causes there.
 pub fn render_report(report: &Report) -> String {
     let rendered = format!("{report:?}");
-    let rendered = if report.chain().len() == 1 {
-        collapse_single_frame(&rendered)
-    } else {
-        rendered
-    };
-    format!("Error: {rendered}")
-}
-
-/// Remove the `\n   0: ` frame header from a rendered single-element chain,
-/// tolerating ANSI color codes around the index. Continuation lines keep the
-/// six-column indent color_eyre gave them.
-fn collapse_single_frame(rendered: &str) -> String {
-    let stripped = rendered.trim_start_matches('\n');
-    // Optional escape sequence, the literal `0`, optional escape, `:`.
-    fn skip_ansi(mut value: &str) -> &str {
-        while let Some(after) = value.strip_prefix('\u{1b}') {
-            match after.find(|c: char| c.is_ascii_alphabetic()) {
-                Some(i) => value = &after[i + 1..],
-                None => break,
-            }
-        }
-        value
+    if report.chain().len() > 1 {
+        return format!("Error: {rendered}");
     }
-
-    let rest = skip_ansi(stripped.trim_start_matches(' '));
-    if let Some(after) = rest.strip_prefix('0')
-        && let Some(after) = skip_ansi(after).strip_prefix(':')
-    {
-        return after.trim_start_matches(' ').to_string();
+    match rendered.split_once("\n\n") {
+        Some((_frame, tail)) => format!("Error: {report}\n\n{tail}"),
+        None => format!("Error: {report}"),
     }
-    // Unexpected shape: keep what color_eyre produced.
-    stripped.to_string()
 }
 
 /// Returns the HTTP status of the first [`ApiError`] in the report's chain, if

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,54 @@ impl std::fmt::Display for ApiError {
 
 impl std::error::Error for ApiError {}
 
+/// Render a report for the user, at the moment of printing.
+///
+/// This is the one place that turns a `Report` into terminal text, so printing
+/// concerns live here and not in the messages: the chain index is dropped when
+/// there is nothing to enumerate, and overlong prose wraps to
+/// [`crate::render::PROSE_WIDTH`].
+///
+/// color_eyre renders every report as a numbered chain, so a single error —
+/// the common case — arrives as `\n   0: <message>`. The `0:` numbers
+/// nothing and reads like a stack frame; collapse it onto the `Error:` line.
+/// A report with two or more chain elements keeps its numbering, which is
+/// genuinely enumerating causes there.
+pub fn render_report(report: &Report) -> String {
+    let rendered = format!("{report:?}");
+    let rendered = if report.chain().len() == 1 {
+        collapse_single_frame(&rendered)
+    } else {
+        rendered
+    };
+    crate::render::wrap_text(&format!("Error: {rendered}"), crate::render::PROSE_WIDTH)
+}
+
+/// Remove the `\n   0: ` frame header from a rendered single-element chain,
+/// tolerating ANSI color codes around the index. Continuation lines keep the
+/// six-column indent color_eyre gave them.
+fn collapse_single_frame(rendered: &str) -> String {
+    let stripped = rendered.trim_start_matches('\n');
+    // Optional escape sequence, the literal `0`, optional escape, `:`.
+    fn skip_ansi(mut value: &str) -> &str {
+        while let Some(after) = value.strip_prefix('\u{1b}') {
+            match after.find(|c: char| c.is_ascii_alphabetic()) {
+                Some(i) => value = &after[i + 1..],
+                None => break,
+            }
+        }
+        value
+    }
+
+    let rest = skip_ansi(stripped.trim_start_matches(' '));
+    if let Some(after) = rest.strip_prefix('0')
+        && let Some(after) = skip_ansi(after).strip_prefix(':')
+    {
+        return after.trim_start_matches(' ').to_string();
+    }
+    // Unexpected shape: keep what color_eyre produced.
+    stripped.to_string()
+}
+
 /// Returns the HTTP status of the first [`ApiError`] in the report's chain, if
 /// any. Works through `wrap_err` context, so callers can add context without
 /// losing the structured status.
@@ -77,6 +125,70 @@ mod tests {
             status,
             message: message.to_string(),
         })
+    }
+
+    #[test]
+    fn render_report_collapses_a_single_error_onto_one_line() {
+        // Under `cargo test` the default color_eyre hook applies (colors and a
+        // backtrace footer main's hook disables), so assert on the stripped
+        // first line rather than the whole rendering.
+        let rendered = plain(&render_report(&user_error("plain failure")));
+        assert_eq!(rendered.lines().next(), Some("Error: plain failure"));
+    }
+
+    #[test]
+    fn render_report_keeps_suggestions() {
+        let report = user_error("failure").suggestion("do the thing");
+        let rendered = plain(&render_report(&report));
+        assert!(rendered.starts_with("Error: failure"), "got: {rendered}");
+        assert!(
+            rendered.contains("Suggestion: do the thing"),
+            "got: {rendered}"
+        );
+        assert!(!rendered.contains("0:"), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_report_numbers_a_real_chain() {
+        use color_eyre::eyre::Context;
+        let report = std::fs::read_to_string("/nonexistent-render-report-test")
+            .wrap_err("outer context")
+            .unwrap_err()
+            .suppress_backtrace(true);
+        let rendered = plain(&render_report(&report));
+        assert!(rendered.contains("0: outer context"), "got: {rendered}");
+        assert!(rendered.contains("1: "), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_report_wraps_overlong_prose() {
+        let report = user_error(format!("prefix {}", "word ".repeat(40)));
+        let rendered = plain(&render_report(&report));
+        let message_lines: Vec<&str> = rendered.lines().take_while(|l| !l.is_empty()).collect();
+        assert!(message_lines.len() > 1, "got: {rendered}");
+        assert!(
+            message_lines.iter().all(|l| l.len() <= 100),
+            "got: {rendered}"
+        );
+    }
+
+    /// Strip ANSI escape sequences, so assertions see what a plain terminal
+    /// shows.
+    fn plain(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\u{1b}' {
+                for esc in chars.by_ref() {
+                    if esc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(ch);
+            }
+        }
+        out
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,9 +69,24 @@ pub fn render_report(report: &Report) -> String {
     if report.chain().len() > 1 {
         return format!("Error: {rendered}");
     }
+    let message = painted_message(report);
     match rendered.split_once("\n\n") {
-        Some((_frame, tail)) => format!("Error: {report}\n\n{tail}"),
-        None => format!("Error: {report}"),
+        Some((_frame, tail)) => format!("Error: {message}\n\n{tail}"),
+        None => format!("Error: {message}"),
+    }
+}
+
+/// The report's message, painted the way color_eyre's dark theme paints an
+/// error — bright red — when stderr is a terminal, and plain otherwise. The
+/// terminal check lives here for the same reason it lives in `wrap_if_tty`:
+/// color is a property of printing, and piped output must stay byte-exact.
+fn painted_message(report: &Report) -> String {
+    use color_eyre::owo_colors::OwoColorize;
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        format!("{}", report.bright_red())
+    } else {
+        report.to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod moment;
 pub mod params;
 pub mod process;
 pub(crate) mod render;
-pub use render::wrap_if;
+pub use render::wrap_if_tty;
 pub mod runs;
 pub mod scripts;
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod moment;
 pub mod params;
 pub mod process;
 pub(crate) mod render;
+pub use render::wrap_if;
 pub mod runs;
 pub mod scripts;
 #[doc(hidden)]

--- a/src/login.rs
+++ b/src/login.rs
@@ -22,19 +22,15 @@ pub fn cmd_login(
     if let Err(report) = &current_settings {
         eprintln!(
             "{}",
-            crate::render::wrap_if(
-                &format!(
-                    "The current settings failed to load with the following error: {report:#}"
-                ),
-                io::stderr().is_terminal(),
-            )
+            crate::render::wrap_if_tty(&format!(
+                "The current settings failed to load with the following error: {report:#}"
+            ))
         );
         eprintln!(
             "{}",
-            crate::render::wrap_if(
+            crate::render::wrap_if_tty(
                 "Would you like to proceed with the login command? Doing so may cause your \
                  existing settings file to be replaced rather than updated.",
-                io::stderr().is_terminal(),
             )
         );
         eprintln!("1. Yes, please proceed");

--- a/src/login.rs
+++ b/src/login.rs
@@ -20,9 +20,22 @@ pub fn cmd_login(
     current_settings: Result<Settings>,
 ) -> Result<()> {
     if let Err(report) = &current_settings {
-        eprintln!("The current settings failed to load with the following error: {report:#}");
         eprintln!(
-            "Would you like to proceed with the login command? Doing so may cause your existing settings file to be replaced rather than updated."
+            "{}",
+            crate::render::wrap_text(
+                &format!(
+                    "The current settings failed to load with the following error: {report:#}"
+                ),
+                crate::render::PROSE_WIDTH,
+            )
+        );
+        eprintln!(
+            "{}",
+            crate::render::wrap_text(
+                "Would you like to proceed with the login command? Doing so may cause your \
+                 existing settings file to be replaced rather than updated.",
+                crate::render::PROSE_WIDTH,
+            )
         );
         eprintln!("1. Yes, please proceed");
         eprintln!("2. No, please exit immediately");

--- a/src/login.rs
+++ b/src/login.rs
@@ -22,19 +22,19 @@ pub fn cmd_login(
     if let Err(report) = &current_settings {
         eprintln!(
             "{}",
-            crate::render::wrap_text(
+            crate::render::wrap_if(
                 &format!(
                     "The current settings failed to load with the following error: {report:#}"
                 ),
-                crate::render::PROSE_WIDTH,
+                io::stderr().is_terminal(),
             )
         );
         eprintln!(
             "{}",
-            crate::render::wrap_text(
+            crate::render::wrap_if(
                 "Would you like to proceed with the login command? Doing so may cause your \
                  existing settings file to be replaced rather than updated.",
-                crate::render::PROSE_WIDTH,
+                io::stderr().is_terminal(),
             )
         );
         eprintln!("1. Yes, please proceed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,10 +83,7 @@ async fn main() {
         // print message + any `.note()`/`.suggestion()` hints with no backtrace;
         // genuine internal faults keep theirs.
         let rendered = snouty::error::render_report(&report);
-        eprintln!(
-            "{}",
-            snouty::wrap_if(&rendered, std::io::stderr().is_terminal())
-        );
+        eprintln!("{}", snouty::wrap_if_tty(&rendered));
         std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,13 @@ async fn main() {
     let cli = Cli::parse();
 
     if let Err(report) = run(cli).await {
-        // One rendering for every error: color_eyre's report format. User-facing
+        // One rendering for every error: `render_report` collapses the chain
+        // index for single errors and wraps overlong prose, both printing
+        // concerns that belong here rather than in the messages. User-facing
         // failures are built with `user_error`/4xx `suppress_backtrace`, so they
         // print message + any `.note()`/`.suggestion()` hints with no backtrace;
         // genuine internal faults keep theirs.
-        eprintln!("Error: {report:?}");
+        eprintln!("{}", snouty::error::render_report(&report));
         std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,11 @@ async fn main() {
         // failures are built with `user_error`/4xx `suppress_backtrace`, so they
         // print message + any `.note()`/`.suggestion()` hints with no backtrace;
         // genuine internal faults keep theirs.
-        eprintln!("{}", snouty::error::render_report(&report));
+        let rendered = snouty::error::render_report(&report);
+        eprintln!(
+            "{}",
+            snouty::wrap_if(&rendered, std::io::stderr().is_terminal())
+        );
         std::process::exit(1);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -60,6 +60,21 @@ enum NewlinePolicy {
 /// mid-word wrap; wide enough that short messages stay on one line.
 pub(crate) const PROSE_WIDTH: usize = 100;
 
+/// Wrap `text` for stderr when `tty` says a person is reading it.
+///
+/// Piped and captured output stays unwrapped: tests, specs, and shell
+/// pipelines consume whole lines, and a wrap point that moves with an
+/// embedded path length breaks any multi-word match that straddles it. The
+/// caller passes its own terminal check, so the tty decision stays at the
+/// print site.
+pub fn wrap_if(text: &str, tty: bool) -> String {
+    if tty {
+        wrap_text(text, PROSE_WIDTH)
+    } else {
+        text.to_string()
+    }
+}
+
 /// Word-wrap `text` to `width` visible columns, for prose the user reads.
 ///
 /// Wrapping is a property of *printing*, not of the message: callers apply this

--- a/src/render.rs
+++ b/src/render.rs
@@ -55,6 +55,79 @@ enum NewlinePolicy {
     KeepNewlineDropReturn,
 }
 
+/// The measure user-facing prose wraps to. Narrower than most terminals, so a
+/// wrapped message reads as a paragraph instead of hitting the terminal's own
+/// mid-word wrap; wide enough that short messages stay on one line.
+pub(crate) const PROSE_WIDTH: usize = 100;
+
+/// Word-wrap `text` to `width` visible columns, for prose the user reads.
+///
+/// Wrapping is a property of *printing*, not of the message: callers apply this
+/// at the print site, and the stored/built message stays a single logical line.
+/// Each input line wraps independently, continuation lines inherit the line's
+/// leading indent, and ANSI escape sequences count as zero width so a colored
+/// report wraps the same as a plain one. Words longer than the width (paths,
+/// URLs) are left intact and overflow rather than being split.
+pub(crate) fn wrap_text(text: &str, width: usize) -> String {
+    text.lines()
+        .map(|line| wrap_line(line, width))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn wrap_line(line: &str, width: usize) -> String {
+    // A line that already fits is returned byte-identical, which keeps aligned
+    // content (tables, caret markers, indented listings) exactly as built.
+    // Re-flowing only ever applies to overlong prose.
+    if visible_width(line) <= width {
+        return line.to_string();
+    }
+    let indent: String = line.chars().take_while(|c| *c == ' ').collect();
+    let mut out = String::new();
+    let mut column = 0;
+    for word in line.split_whitespace() {
+        let word_width = visible_width(word);
+        if column == 0 {
+            out.push_str(&indent);
+            column = indent.len();
+        } else if column + 1 + word_width > width {
+            out.push('\n');
+            out.push_str(&indent);
+            column = indent.len();
+        } else {
+            out.push(' ');
+            column += 1;
+        }
+        out.push_str(word);
+        column += word_width;
+    }
+    if out.is_empty() {
+        line.to_string()
+    } else {
+        out
+    }
+}
+
+/// The number of terminal columns `s` occupies, counting ANSI escape sequences
+/// (`ESC [ … m` and similar) as zero.
+fn visible_width(s: &str) -> usize {
+    let mut width = 0;
+    let mut chars = s.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            // Skip to the final byte of the escape sequence (`@` through `~`).
+            for esc in chars.by_ref() {
+                if ('\u{40}'..='\u{7e}').contains(&esc) && esc != '[' {
+                    break;
+                }
+            }
+        } else {
+            width += 1;
+        }
+    }
+    width
+}
+
 pub(crate) fn sanitize(s: &str) -> String {
     let mut escaped = String::new();
     for ch in s.chars() {
@@ -91,6 +164,42 @@ mod tests {
     fn render_kv_sanitizes_values() {
         let rows = vec![("k", "a\nb".to_string())];
         assert_eq!(render_kv(&rows, 0), "k  a\\nb\n");
+    }
+
+    #[test]
+    fn wrap_text_reflows_only_overlong_lines() {
+        let long = format!("Warning: {}", "word ".repeat(30));
+        let wrapped = wrap_text(&long, 40);
+        assert!(wrapped.lines().count() > 1);
+        assert!(wrapped.lines().all(|l| l.len() <= 40), "got: {wrapped}");
+        // A short line keeps its exact bytes, including internal alignment.
+        assert_eq!(
+            wrap_text("  profile     (none)", 100),
+            "  profile     (none)"
+        );
+        assert_eq!(wrap_text("", 100), "");
+    }
+
+    #[test]
+    fn wrap_text_keeps_the_indent_on_continuations() {
+        let wrapped = wrap_text(&format!("   0: {}", "word ".repeat(30)), 40);
+        for line in wrapped.lines().skip(1) {
+            assert!(line.starts_with("   "), "got: {wrapped}");
+        }
+    }
+
+    #[test]
+    fn wrap_text_counts_ansi_escapes_as_zero_width() {
+        // 10 visible chars dressed in color codes must not trigger a wrap.
+        let colored = format!("\u{1b}[31m{}\u{1b}[0m", "x".repeat(10));
+        assert_eq!(wrap_text(&colored, 20), colored);
+    }
+
+    #[test]
+    fn wrap_text_leaves_unsplittable_words_intact() {
+        let path = format!("/very/long/{}", "seg/".repeat(30));
+        let wrapped = wrap_text(&format!("backed up to {path}"), 40);
+        assert!(wrapped.contains(&path), "paths must never be split");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -58,89 +58,45 @@ enum NewlinePolicy {
 /// The measure user-facing prose wraps to. Narrower than most terminals, so a
 /// wrapped message reads as a paragraph instead of hitting the terminal's own
 /// mid-word wrap; wide enough that short messages stay on one line.
-pub(crate) const PROSE_WIDTH: usize = 100;
+const PROSE_WIDTH: usize = 100;
 
-/// Wrap `text` for stderr when `tty` says a person is reading it.
+/// Wrap prose for stderr when a person is reading it.
 ///
-/// Piped and captured output stays unwrapped: tests, specs, and shell
-/// pipelines consume whole lines, and a wrap point that moves with an
-/// embedded path length breaks any multi-word match that straddles it. The
-/// caller passes its own terminal check, so the tty decision stays at the
-/// print site.
-pub fn wrap_if(text: &str, tty: bool) -> String {
-    if tty {
-        wrap_text(text, PROSE_WIDTH)
+/// Wrapping is a property of printing, not of the message, and it applies only
+/// on a terminal: piped and captured output keeps whole lines, because a wrap
+/// point that moves with an embedded path length breaks any multi-word match
+/// that straddles it.
+pub fn wrap_if_tty(text: &str) -> String {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        wrap(text)
     } else {
         text.to_string()
     }
 }
 
-/// Word-wrap `text` to `width` visible columns, for prose the user reads.
+/// Word-wrap each overlong line of `text` to [`PROSE_WIDTH`] visible columns.
 ///
-/// Wrapping is a property of *printing*, not of the message: callers apply this
-/// at the print site, and the stored/built message stays a single logical line.
-/// Each input line wraps independently, continuation lines inherit the line's
-/// leading indent, and ANSI escape sequences count as zero width so a colored
-/// report wraps the same as a plain one. Words longer than the width (paths,
-/// URLs) are left intact and overflow rather than being split.
-pub(crate) fn wrap_text(text: &str, width: usize) -> String {
-    text.lines()
-        .map(|line| wrap_line(line, width))
-        .collect::<Vec<_>>()
-        .join("\n")
+/// A line that already fits is returned byte-identical, which keeps aligned
+/// content (tables, caret markers, indented listings) exactly as built.
+/// Continuation lines inherit the line's indent, ANSI escape sequences count
+/// as zero width, and words are never split — a path overflows rather than
+/// breaking.
+fn wrap(text: &str) -> String {
+    text.lines().map(wrap_line).collect::<Vec<_>>().join("\n")
 }
 
-fn wrap_line(line: &str, width: usize) -> String {
-    // A line that already fits is returned byte-identical, which keeps aligned
-    // content (tables, caret markers, indented listings) exactly as built.
-    // Re-flowing only ever applies to overlong prose.
-    if visible_width(line) <= width {
+fn wrap_line(line: &str) -> String {
+    if textwrap::core::display_width(line) <= PROSE_WIDTH {
         return line.to_string();
     }
     let indent: String = line.chars().take_while(|c| *c == ' ').collect();
-    let mut out = String::new();
-    let mut column = 0;
-    for word in line.split_whitespace() {
-        let word_width = visible_width(word);
-        if column == 0 {
-            out.push_str(&indent);
-            column = indent.len();
-        } else if column + 1 + word_width > width {
-            out.push('\n');
-            out.push_str(&indent);
-            column = indent.len();
-        } else {
-            out.push(' ');
-            column += 1;
-        }
-        out.push_str(word);
-        column += word_width;
-    }
-    if out.is_empty() {
-        line.to_string()
-    } else {
-        out
-    }
-}
-
-/// The number of terminal columns `s` occupies, counting ANSI escape sequences
-/// (`ESC [ … m` and similar) as zero.
-fn visible_width(s: &str) -> usize {
-    let mut width = 0;
-    let mut chars = s.chars();
-    while let Some(ch) = chars.next() {
-        if ch == '\u{1b}' {
-            // Skip to the final byte of the escape sequence (`@` through `~`).
-            for esc in chars.by_ref() {
-                if ('\u{40}'..='\u{7e}').contains(&esc) && esc != '[' {
-                    break;
-                }
-            }
-        } else {
-            width += 1;
-        }
-    }
-    width
+    let options = textwrap::Options::new(PROSE_WIDTH)
+        .initial_indent(&indent)
+        .subsequent_indent(&indent)
+        .break_words(false)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
+    textwrap::fill(line.trim_start(), options)
 }
 
 pub(crate) fn sanitize(s: &str) -> String {
@@ -182,38 +138,26 @@ mod tests {
     }
 
     #[test]
-    fn wrap_text_reflows_only_overlong_lines() {
+    fn wrap_reflows_only_overlong_lines() {
         let long = format!("Warning: {}", "word ".repeat(30));
-        let wrapped = wrap_text(&long, 40);
+        let wrapped = wrap(&long);
         assert!(wrapped.lines().count() > 1);
-        assert!(wrapped.lines().all(|l| l.len() <= 40), "got: {wrapped}");
+        assert!(wrapped.lines().all(|l| l.len() <= 100), "got: {wrapped}");
         // A short line keeps its exact bytes, including internal alignment.
-        assert_eq!(
-            wrap_text("  profile     (none)", 100),
-            "  profile     (none)"
-        );
-        assert_eq!(wrap_text("", 100), "");
+        assert_eq!(wrap("  profile     (none)"), "  profile     (none)");
+        assert_eq!(wrap(""), "");
     }
 
     #[test]
-    fn wrap_text_keeps_the_indent_on_continuations() {
-        let wrapped = wrap_text(&format!("   0: {}", "word ".repeat(30)), 40);
+    fn wrap_keeps_the_indent_and_never_splits_words() {
+        let path = format!("/very/long/{}", "seg-x/".repeat(30));
+        let wrapped = wrap(&format!(
+            "   note: backed up to {path} {}",
+            "word ".repeat(20)
+        ));
         for line in wrapped.lines().skip(1) {
             assert!(line.starts_with("   "), "got: {wrapped}");
         }
-    }
-
-    #[test]
-    fn wrap_text_counts_ansi_escapes_as_zero_width() {
-        // 10 visible chars dressed in color codes must not trigger a wrap.
-        let colored = format!("\u{1b}[31m{}\u{1b}[0m", "x".repeat(10));
-        assert_eq!(wrap_text(&colored, 20), colored);
-    }
-
-    #[test]
-    fn wrap_text_leaves_unsplittable_words_intact() {
-        let path = format!("/very/long/{}", "seg/".repeat(30));
-        let wrapped = wrap_text(&format!("backed up to {path}"), 40);
         assert!(wrapped.contains(&path), "paths must never be split");
     }
 

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -579,6 +579,27 @@ async fn explain_run_scoped_error(
     }
 }
 
+/// Like [`explain_run_scoped_error`], for the logs endpoint. A 404 that
+/// survives the probe means the run exists and the hash/vtime pair does not
+/// name a moment in it, so say that and point at the command that lists valid
+/// moments. The probe already ran inside [`explain_run_scoped_error`]; nothing
+/// extra is fetched here.
+async fn explain_logs_error(
+    api: &AntithesisApi,
+    run_id: &str,
+    err: color_eyre::eyre::Report,
+) -> color_eyre::eyre::Report {
+    let err = explain_run_scoped_error(api, run_id, err).await;
+    if api_error_status(&err) == Some(404) {
+        err.suggestion(format!(
+            "the run exists but no moment matches this hash and vtime — list valid moments with \
+             `snouty runs events {run_id}`"
+        ))
+    } else {
+        err
+    }
+}
+
 /// Turn a properties-endpoint failure into a message that explains *why* there
 /// are no properties. Only a 404 is rewritten; every other error (auth, network,
 /// 5xx) passes through untouched.
@@ -1499,7 +1520,7 @@ async fn cmd_runs_logs(
         .await
     {
         Ok(stream) => stream.into_inner(),
-        Err(err) => return Err(explain_run_scoped_error(&api, run_id, err).await),
+        Err(err) => return Err(explain_logs_error(&api, run_id, err).await),
     };
 
     let mut stdout = BufWriter::new(std::io::stdout().lock());
@@ -5295,6 +5316,40 @@ mod tests {
                 explain_run_scoped_error(&api, "run-1", api_error(404, "endpoint 404")).await;
             assert!(format!("{result:#}").contains("endpoint 404"));
             assert!(!format!("{result:#}").contains("run not found"));
+        }
+
+        // The logs endpoint's 404-with-existing-run means "bad moment", the
+        // one case where snouty can name the next command.
+        #[tokio::test]
+        async fn logs_error_suggests_listing_moments_when_the_run_exists() {
+            let server = mock_get_run(
+                "run-1",
+                200,
+                json!({
+                    "run_id": "run-1",
+                    "status": "completed",
+                    "created_at": "2025-03-20T02:00:00Z",
+                    "launcher": "nightly"
+                }),
+            )
+            .await;
+            let api = test_api(&server.uri());
+            let result = explain_logs_error(&api, "run-1", api_error(404, "API error: 404")).await;
+            let debug = format!("{result:?}");
+            assert!(
+                debug.contains("snouty runs events run-1"),
+                "expected the moment-listing suggestion, got: {debug}"
+            );
+        }
+
+        // A missing run keeps the plain "run not found" with no moment talk.
+        #[tokio::test]
+        async fn logs_error_reports_a_missing_run_without_the_suggestion() {
+            let server = mock_get_run("BAD-ID", 404, json!({"message": "nope"})).await;
+            let api = test_api(&server.uri());
+            let result = explain_logs_error(&api, "BAD-ID", api_error(404, "API error: 404")).await;
+            assert_eq!(format!("{result:#}"), "run not found: BAD-ID");
+            assert!(!format!("{result:?}").contains("runs events"));
         }
 
         #[tokio::test]

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -16,6 +16,12 @@ pub enum ScriptType {
     Finally,
 }
 
+/// The prefix of a script that test commands call but the platform never
+/// runs. The scan allows and skips it — it is deliberately not in
+/// [`RECOGNIZED_PREFIXES`], because every entry there names a command type
+/// the platform executes, and a helper has none.
+pub const HELPER_PREFIX: &str = "helper_";
+
 /// Every recognized test-command prefix, paired with its type. One table
 /// drives both the scan and the user-facing error text, so the list a user
 /// reads cannot drift from the list the scan accepts.
@@ -99,7 +105,7 @@ pub fn scan_scripts(base: &Path, service: &str) -> Result<ScanResult> {
             let script_type = match ScriptType::from_prefix(&command_name) {
                 Some(t) => t,
                 None => {
-                    if command_name.starts_with("helper_") {
+                    if command_name.starts_with(HELPER_PREFIX) {
                         debug!("skipping helper: {}", command_name);
                     } else {
                         unrecognized.push(format!("{}/{}", test_name, command_name));

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -16,25 +16,25 @@ pub enum ScriptType {
     Finally,
 }
 
+/// Every recognized test-command prefix, paired with its type. One table
+/// drives both the scan and the user-facing error text, so the list a user
+/// reads cannot drift from the list the scan accepts.
+pub const RECOGNIZED_PREFIXES: [(&str, ScriptType); 7] = [
+    ("first_", ScriptType::First),
+    ("parallel_driver_", ScriptType::ParallelDriver),
+    ("serial_driver_", ScriptType::SerialDriver),
+    ("singleton_driver_", ScriptType::SingletonDriver),
+    ("anytime_", ScriptType::Anytime),
+    ("eventually_", ScriptType::Eventually),
+    ("finally_", ScriptType::Finally),
+];
+
 impl ScriptType {
     fn from_prefix(name: &str) -> Option<Self> {
-        if name.starts_with("first_") {
-            Some(Self::First)
-        } else if name.starts_with("parallel_driver_") {
-            Some(Self::ParallelDriver)
-        } else if name.starts_with("serial_driver_") {
-            Some(Self::SerialDriver)
-        } else if name.starts_with("singleton_driver_") {
-            Some(Self::SingletonDriver)
-        } else if name.starts_with("anytime_") {
-            Some(Self::Anytime)
-        } else if name.starts_with("eventually_") {
-            Some(Self::Eventually)
-        } else if name.starts_with("finally_") {
-            Some(Self::Finally)
-        } else {
-            None
-        }
+        RECOGNIZED_PREFIXES
+            .iter()
+            .find(|(prefix, _)| name.starts_with(prefix))
+            .map(|(_, script_type)| *script_type)
     }
 
     pub fn is_driver(self) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -270,10 +270,13 @@ pub(crate) fn update_settings_in_global_file(
             Ok(table) => table,
             Err(_) => {
                 let backup = back_up_unparsable_file(&path)?;
+                // Paths go on their own lines: they are the two things the
+                // user may need to copy, and they are what made the one-line
+                // form overflow any terminal.
                 eprintln!(
-                    "note: the existing settings file at {} could not be parsed; it has been backed up to {} and a new one will be written.",
+                    "note: the existing settings file could not be parsed; a new one will be written.\n  kept as a backup: {}\n  will be rewritten: {}",
+                    backup.display(),
                     path.display(),
-                    backup.display()
                 );
                 Table::new()
             }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::IsTerminal;
 use std::io::Seek;
 use std::path::{Path, PathBuf};
 
@@ -650,10 +649,7 @@ fn discover_scripts(
     if !stopped_with_scripts.is_empty() {
         eprintln!(
             "{}",
-            crate::render::wrap_if(
-                &stranded_scripts_warning(&stopped_with_scripts),
-                std::io::stderr().is_terminal(),
-            )
+            crate::render::wrap_if_tty(&stranded_scripts_warning(&stopped_with_scripts))
         );
     }
 
@@ -704,10 +700,16 @@ fn combined_discovery_error(
     }
 
     if !unrecognized.is_empty() {
-        err = err.suggestion(
-            "rename each command to start with a recognized prefix (first_, driver_, anytime_, \
-             eventually_, finally_) or helper_",
-        );
+        // The list comes from the same table the scan matches against, so the
+        // text a user follows cannot name a prefix the scan rejects.
+        let prefixes = crate::scripts::RECOGNIZED_PREFIXES
+            .iter()
+            .map(|(prefix, _)| *prefix)
+            .collect::<Vec<_>>()
+            .join(", ");
+        err = err.suggestion(format!(
+            "rename each command to start with a recognized prefix ({prefixes}) or helper_"
+        ));
     }
     if !not_executable.is_empty() {
         err = err.suggestion("chmod +x the listed commands in the image, then rebuild");

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -647,7 +647,13 @@ fn discover_scripts(
     // and an unexpected non-zero exit surfaces as a property failure during the
     // run itself. We can promote this to a hard error later if it proves noisy.
     if !stopped_with_scripts.is_empty() {
-        eprintln!("{}", stranded_scripts_warning(&stopped_with_scripts));
+        eprintln!(
+            "{}",
+            crate::render::wrap_text(
+                &stranded_scripts_warning(&stopped_with_scripts),
+                crate::render::PROSE_WIDTH,
+            )
+        );
     }
 
     // Genuine misconfigurations — unknown command prefixes or non-executable
@@ -694,6 +700,16 @@ fn combined_discovery_error(
                 "Test commands in service '{service}' are not executable:"
             ))
         });
+    }
+
+    if !unrecognized.is_empty() {
+        err = err.suggestion(
+            "rename each command to start with a recognized prefix (first_, driver_, anytime_, \
+             eventually_, finally_) or helper_",
+        );
+    }
+    if !not_executable.is_empty() {
+        err = err.suggestion("chmod +x the listed commands in the image, then rebuild");
     }
 
     err

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -708,7 +708,8 @@ fn combined_discovery_error(
             .collect::<Vec<_>>()
             .join(", ");
         err = err.suggestion(format!(
-            "rename each command to start with a recognized prefix ({prefixes}) or helper_"
+            "rename each command to start with a recognized prefix ({prefixes}) or {helper}",
+            helper = crate::scripts::HELPER_PREFIX,
         ));
     }
     if !not_executable.is_empty() {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::IsTerminal;
 use std::io::Seek;
 use std::path::{Path, PathBuf};
 
@@ -649,9 +650,9 @@ fn discover_scripts(
     if !stopped_with_scripts.is_empty() {
         eprintln!(
             "{}",
-            crate::render::wrap_text(
+            crate::render::wrap_if(
                 &stranded_scripts_warning(&stopped_with_scripts),
-                crate::render::PROSE_WIDTH,
+                std::io::stderr().is_terminal(),
             )
         );
     }


### PR DESCRIPTION
Stacked on #183 — the base is `status-first-api-errors`, and only the top commit (`7ead804`) is this PR. Retarget to `main` after #183 merges.

A satisfaction review of the failure-behaviour gallery stories (21 stories: API errors, empty results, validate failures, login error/repair paths) found five issues. This PR fixes them, with one rule throughout: wrapping and frame layout are properties of *printing*, so they live at the print sites and messages stay single logical lines.

## 1. A single error no longer wears a `0:` frame

color_eyre numbers every cause chain, so the common case — one error — rendered as:

```
Error:
   0: API error: 404 Not Found — Resource not found
```

The `0:` enumerates nothing and reads like a stack frame. `error::render_report` is now the one place a `Report` becomes terminal text (called from `main`); it collapses a one-element chain onto the `Error:` line:

```
Error: API error: 404 Not Found — Resource not found
```

A chain of two or more keeps its numbering, which is genuinely counting causes there:

```
Error:
   0: failed to contact API
   1: error sending request for url (…)
```

`specs/runs.txt` pins the collapsed form (`^Error: API error…`, and no `0:` frame).

## 2. Overlong prose wraps at print time — when a person is reading

`render::wrap_text` wraps at 100 columns: word-boundary, ANSI-aware (escape sequences count as zero width), continuation lines keep their indent, and words are never split — a path overflows rather than breaking. **A line that already fits is returned byte-identical**, so aligned content — doctor's settings table, the TOML caret marker in login's repair prompt — is never re-flowed.

Wrapping applies **only when stderr is a terminal** (`wrap_if(text, stderr().is_terminal())`), the same rule the color theme already follows at the same print sites. The first draft wrapped unconditionally, and CI caught why that is wrong: the wrap point moves with the length of an embedded path, so any multi-word assertion that straddles it breaks — `launch_config_rejects_ambiguous_dir` failed on macOS and the nix runner (long temp dirs) while passing on Linux (short `/tmp`). Reproduced by sweeping `TMPDIR` lengths: 56–76-column paths split the asserted phrase. Pipes and captures now get one stable logical line at any path length; a pty run shows the tenant error wrapping at 100 columns with colors intact.

Sites: `main`'s report printing, the stranded-scripts warning (was 215 columns on a terminal), and login's failed-to-load and proceed prompts (was 230).

The two corrupt-file recovery notes (settings and credentials) are restructured instead of wrapped — each path moves to its own line, because a path is one unsplittable word and the paths are what the user copies:

```
note: the existing settings file could not be parsed; a new one will be written.
  kept as a backup: /home/you/.config/snouty/settings.toml.bak
  will be rewritten: /home/you/.config/snouty/settings.toml
```

These print on a *recovery* path (login continues and exits 0), so there is no `Report` in flight for `.note()` sections to attach to; the multi-line `eprintln!` is the hand-rolled equivalent of that rendering.

## 3. `runs logs` on a bad moment names the next command

Measured against the live tenant: a bad run id already prints `run not found: <id>`, because `explain_run_scoped_error` probes `get_run` on every run-scoped 404. So a surviving 404 always means *the run exists and the moment does not* — and the message now says so:

```
Error: API error: 404 Not Found — Resource not found

Suggestion: the run exists but no moment matches this hash and vtime — list valid moments with
`snouty runs events <run-id>`
```

No added request: the new `explain_logs_error` reuses the probe that already ran. The mock's logs route is not moment-aware, so this is covered by wiremock unit tests rather than a spec.

## 4. Three validate errors now name their fix

Matching the standard their siblings set (`wrong-extension` suggests the exact rename, `missing-image` says "pull or build"):

- unrecognized command names → `Suggestion: rename each command to start with a recognized prefix (first_, driver_, anytime_, eventually_, finally_) or helper_`
- non-executable commands → `Suggestion: chmod +x the listed commands in the image, then rebuild`
- external network → `Suggestion: remove `external: true` and declare the network normally — Antithesis provisions every network inside the test environment`

Pinned in `specs_engine/validate_failures.txt` and a compose unit test.

## 5. Gallery login transcripts preserve interaction order

`gen-gallery.py` captured stdout and stderr separately and concatenated them, so the repair story showed "Saved tenant…" *before* the proceed-prompt that actually preceded it. Login stories now capture with stderr merged into stdout. pyright: 0 errors.

## Two CI changes this PR also carries

**The build workflow runs on every pull request.** The `branches: ["main"]` filter meant this stacked PR (base = #183's branch) got no gate at all on its first run. Dropping the filter gave it — and every future stacked PR — the full matrix, which is what then caught the wrap bug above.

**The staging event searches are bounded.** The full gate exposed that `runs events $R_run_id --match request` hung CI to its 15-minute timeout: the suite tests the tenant's newest completed run, the needle is common, and an unbounded search streams every match — wall time scaled with whatever run the tenant produced last (16s two days ago, 70s locally, >12 minutes in CI). The event-search assertions are all `[!staging]` mock pins, so staging now runs `--limit 3` twins and the mock keeps the unbounded form. Staging suite: 94s → 22s; the hot search: 70s → 2.5s.

## Measured effect

Regenerated gallery stories on the unconditional-wrap draft showed the terminal experience (login-repair-broken 244→134 columns, login-bad-tenant 230→100, validate-stranded 215→99). With tty-conditional wrapping, gallery captures (piped) show the unwrapped single lines again — the wrap benefit is real but only visible on a terminal. What captures do keep: the collapsed `Error:` frame, the moment suggestion on `runs-logs-bad-moment`, the two-path backup notes, and the three validate suggestions.

## Testing

`cargo test` (445 lib tests plus every integration and spec target), `clippy --all-targets`, `fmt --check`, and `typos` are clean. Spec suite green in both modes, including staging against a live tenant, and the `cli_launch_config` suite passes at every `TMPDIR` length in the sweep. New unit tests: `wrap_text` (4), `render_report` (4), `explain_logs_error` (2), plus the extended compose external-network test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb
