### PR TITLE
Add CHANGELOG.md and a changelog step to the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -42,7 +42,12 @@ If any check fails, report the issue clearly and stop.
 
 Read `CHANGELOG.md` and check the `# Unreleased` section.
 
-If the `# Unreleased` section is missing, empty, or stale (it does not cover the changes since the last release tag), draft entries first: list the commits with `git log --oneline vPREV..HEAD` (where `vPREV` is the most recent tag), and write one factual bullet per user-visible change with its PR number, e.g. `- Add \`--limit\` to \`runs events\` (#176)`. Group bullets under `##` topic headings when there are many. Skip internal-only changes (CI, refactors) or group them in one bullet.
+If the `# Unreleased` section is missing, empty, or stale (it does not cover the changes since the last release tag), draft entries first: list the commits with `git log --oneline vPREV..HEAD` (where `vPREV` is the most recent tag), and write one factual bullet per notable feature. Follow these rules:
+
+- Write each entry as the net change relative to the previous release. When a feature is new in this release, describe the feature once; do not list the iterations that built it (e.g. a rewrite of a command that did not exist in the previous release is part of the feature, not an entry).
+- Compress to the set of notable features. The changelog does not need to describe every change or every detail of a feature.
+- Link PR numbers with the public base URL, e.g. `([#176](https://github.com/antithesishq/snouty/pull/176))`. Do not use the exe proxy hostname.
+- Skip internal-only changes (CI, refactors, dependency bumps).
 
 Then, depending on the release type:
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: Release Snouty
-description: This skill should be used when the user asks to "release snouty", "cut a release", "cut a pre-release", "cut an rc", "bump the version", "create a release", or provides a version like "release snouty v0.2.0" or "release snouty v0.7.0-rc.1". Handles version validation, Cargo.toml bump, build, test, commit, and tagging, for releases and pre-releases.
+description: This skill should be used when the user asks to "release snouty", "cut a release", "cut a pre-release", "cut an rc", "bump the version", "create a release", or provides a version like "release snouty v0.2.0" or "release snouty v0.7.0-rc.1". Handles version validation, changelog update, Cargo.toml bump, build, test, commit, and tagging, for releases and pre-releases.
 ---
 
 # Release Snouty
 
-Perform a versioned release of snouty by bumping `Cargo.toml`, building, testing, committing, and tagging. _Do not_ push the resulting commit so the user has a chance to audit it first.
+Perform a versioned release of snouty by updating `CHANGELOG.md`, bumping `Cargo.toml`, building, testing, committing, and tagging. _Do not_ push the resulting commit so the user has a chance to audit it first.
+
+## How the changelog reaches GitHub Releases
+
+cargo-dist reads the top-level `CHANGELOG.md` when the release tag is pushed. It finds the section for the version and puts it in the GitHub Release body. The matching rules are:
+
+1. A heading with the exact version (e.g. `# Version 0.7.0`) matches that version.
+2. A pre-release (e.g. `0.7.0-rc.2`) with no exact heading falls back to the stable heading (`# Version 0.7.0`), then to the `# Unreleased` heading. cargo-dist rewrites the heading to include the pre-release version in the GitHub Release.
+3. A stable version matches only its exact heading. A missing heading does not fail the release; cargo-dist just omits the notes.
+
+The convention: entries accumulate under `# Unreleased` as PRs land. Pre-releases publish the `# Unreleased` section as-is. A stable release renames `# Unreleased` to its version, so all rc-era entries fold into the final release notes.
 
 ## Pre-releases
 
@@ -28,27 +38,46 @@ Run all of the following sanity checks before making any changes:
 
 If any check fails, report the issue clearly and stop.
 
-### 2. Bump the Version in Cargo.toml
+### 2. Update CHANGELOG.md
+
+Read `CHANGELOG.md` and check the `# Unreleased` section.
+
+If the `# Unreleased` section is missing, empty, or stale (it does not cover the changes since the last release tag), draft entries first: list the commits with `git log --oneline vPREV..HEAD` (where `vPREV` is the most recent tag), and write one factual bullet per user-visible change with its PR number, e.g. `- Add \`--limit\` to \`runs events\` (#176)`. Group bullets under `##` topic headings when there are many. Skip internal-only changes (CI, refactors) or group them in one bullet.
+
+Then, depending on the release type:
+
+- **Pre-release (`-rc.N`)**: do not rename anything. cargo-dist publishes the `# Unreleased` section under the rc version automatically. Do not create a heading for the rc version.
+- **Stable release**: rename `# Unreleased` to `# Version X.Y.Z (YYYY-MM-DD)` with today's date, and insert a fresh section above it:
+
+  ```markdown
+  # Unreleased
+
+  Nothing Yet!
+  ```
+
+Verify the result parses: `parse-changelog CHANGELOG.md X.Y.Z` must print the section for a stable release; `parse-changelog CHANGELOG.md Unreleased` must print it for a pre-release. Install the CLI with `cargo install parse-changelog` if it is missing. cargo-dist uses this same library, so this check proves the GitHub Release will pick up the notes.
+
+### 3. Bump the Version in Cargo.toml
 
 Edit the `version = "..."` line in `Cargo.toml` to the new version.
 
-### 3. Build
+### 4. Build
 
 Run `cargo build` to update `Cargo.lock` and verify the project compiles.
 
-### 4. Run Tests
+### 5. Run Tests
 
 Run `cargo nextest run` to ensure everything passes. If tests fail, stop and report.
 
-### 5. Commit the Release
+### 6. Commit the Release
 
-Stage only `Cargo.toml` and `Cargo.lock`. If there are any other changes abort. Then commit with message:
+Stage only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md`. If there are any other changes abort. Then commit with message:
 
 ```
 chore: Release snouty version X.Y.Z
 ```
 
-### 6. Create an Annotated Tag
+### 7. Create an Annotated Tag
 
 Create an annotated git tag:
 
@@ -56,7 +85,7 @@ Create an annotated git tag:
 git tag -a vX.Y.Z -m "chore: Release snouty version X.Y.Z"
 ```
 
-### 7. Ask user to audit
+### 8. Ask user to audit
 
 Do NOT push. Show the user:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Unreleased
+
+## Login and credentials
+
+- Add OAuth login: `snouty login` offers a browser-based OAuth flow when the tenant supports it, and refreshes tokens automatically with a file-based lock so concurrent snouty processes do not race (#178)
+- Migrate `snouty login` to a small TUI (#178)
+- `snouty login` stores credentials in the OS keychain on macOS; Linux uses a `credentials.toml` file in the home directory (#157)
+- Add GitHub Actions OIDC authentication, with the OIDC token cached within a single invocation (#157)
+- `snouty login` confirms what it saved and where (#173)
+- `snouty login` rejects blank usernames and empty argument values (#173)
+- `snouty login` backs up unparsable settings/credentials files before it overwrites them, and merges into the targeted profile instead of overwriting the whole file (#157)
+- Credential setup can be skipped during `snouty login` (#157)
+- Log keychain lookup failures other than a missing entry (#181)
+
+## Container engines
+
+- Support the `docker compose` plugin in addition to standalone `docker-compose` (#172)
+- `launch` and `validate` announce the auto-detected container engine (#171)
+- Warn about the container engine only when the choice is ambiguous (#175)
+- When an image is missing, point to the other container engine if it holds the image (#170)
+- Detect podman that masquerades as docker via `--version` instead of the `version` subcommand (#182)
+- `validate` fails when the compose file resolves differently in the Antithesis environment (#168)
+- Explain in errors why images must be local and point to the `--config-image` escape hatch (#169)
+
+## API and CLI
+
+- Add a `VTime` type and show vtime as an exact JSON number (#192)
+- Render property-failure concerns at print time for cleaner failure output (#193)
+- Classify API failures on the HTTP status alone (#183)
+- Events v2: update the OpenAPI spec and add `--limit` to `runs events` (#176)
+- `docs search` treats the query as literal text by default; `--match` enables FTS5 syntax (#166)
+- Add a Snouty-specific proxy setting (`ANTITHESIS_HTTPS_PROXY` / `https_proxy`), separate from `HTTP(S)_PROXY` which docker/podman also honor (#164)
+- Allow extra images via `--param antithesis.images` for images the config parser cannot discover (#161)
+- Allow arbitrary additional HTTP headers via `ANTITHESIS_EXTRA_HEADERS`, for consumption by proxies (#158)
+- Add an unstable update channel (#195)
+
+## Docs and dependencies
+
+- Add `COOKBOOK.md` with the failure-moment logs recipe (#185)
+- Remove the experimental warning from the README (#174)
+- Update Cargo dependencies (#196)
+
+
+# Version 0.6.1 (2026-06-21)
+
+See the [v0.6.1 release notes](https://github.com/antithesishq/snouty/releases/tag/v0.6.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,18 @@
 # Unreleased
 
-## Login and credentials
-
-- Add OAuth login: `snouty login` offers a browser-based OAuth flow when the tenant supports it, and refreshes tokens automatically with a file-based lock so concurrent snouty processes do not race (#178)
-- Migrate `snouty login` to a small TUI (#178)
-- `snouty login` stores credentials in the OS keychain on macOS; Linux uses a `credentials.toml` file in the home directory (#157)
-- Add GitHub Actions OIDC authentication, with the OIDC token cached within a single invocation (#157)
-- `snouty login` confirms what it saved and where (#173)
-- `snouty login` rejects blank usernames and empty argument values (#173)
-- `snouty login` backs up unparsable settings/credentials files before it overwrites them, and merges into the targeted profile instead of overwriting the whole file (#157)
-- Credential setup can be skipped during `snouty login` (#157)
-- Log keychain lookup failures other than a missing entry (#181)
-
-## Container engines
-
-- Support the `docker compose` plugin in addition to standalone `docker-compose` (#172)
-- `launch` and `validate` announce the auto-detected container engine (#171)
-- Warn about the container engine only when the choice is ambiguous (#175)
-- When an image is missing, point to the other container engine if it holds the image (#170)
-- Detect podman that masquerades as docker via `--version` instead of the `version` subcommand (#182)
-- `validate` fails when the compose file resolves differently in the Antithesis environment (#168)
-- Explain in errors why images must be local and point to the `--config-image` escape hatch (#169)
-
-## API and CLI
-
-- Add a `VTime` type and show vtime as an exact JSON number (#192)
-- Render property-failure concerns at print time for cleaner failure output (#193)
-- Classify API failures on the HTTP status alone (#183)
-- Events v2: update the OpenAPI spec and add `--limit` to `runs events` (#176)
-- `docs search` treats the query as literal text by default; `--match` enables FTS5 syntax (#166)
-- Add a Snouty-specific proxy setting (`ANTITHESIS_HTTPS_PROXY` / `https_proxy`), separate from `HTTP(S)_PROXY` which docker/podman also honor (#164)
-- Allow extra images via `--param antithesis.images` for images the config parser cannot discover (#161)
-- Allow arbitrary additional HTTP headers via `ANTITHESIS_EXTRA_HEADERS`, for consumption by proxies (#158)
-- Add an unstable update channel (#195)
-
-## Docs and dependencies
-
-- Add `COOKBOOK.md` with the failure-moment logs recipe (#185)
-- Remove the experimental warning from the README (#174)
-- Update Cargo dependencies (#196)
+- Add `snouty login`: interactive sign-in with browser-based OAuth or an API key, multiple profiles, and credential storage in the macOS keychain or a credentials file on Linux ([#157](https://github.com/antithesishq/snouty/pull/157), [#173](https://github.com/antithesishq/snouty/pull/173), [#178](https://github.com/antithesishq/snouty/pull/178))
+- Add GitHub Actions OIDC authentication ([#157](https://github.com/antithesishq/snouty/pull/157))
+- Add support for the `docker compose` plugin in addition to standalone `docker-compose` ([#172](https://github.com/antithesishq/snouty/pull/172))
+- Announce the auto-detected container engine during `launch` and `validate`, and point to the other engine when it holds a missing image ([#170](https://github.com/antithesishq/snouty/pull/170), [#171](https://github.com/antithesishq/snouty/pull/171), [#175](https://github.com/antithesishq/snouty/pull/175))
+- `snouty validate` fails when the compose file resolves differently in the Antithesis environment ([#168](https://github.com/antithesishq/snouty/pull/168))
+- Add `--limit` to `snouty runs events` ([#176](https://github.com/antithesishq/snouty/pull/176))
+- `snouty docs search` treats the query as literal text; add `--match` for FTS5 query syntax ([#166](https://github.com/antithesishq/snouty/pull/166))
+- Add the `ANTITHESIS_HTTPS_PROXY` setting to proxy snouty API requests without affecting docker/podman ([#164](https://github.com/antithesishq/snouty/pull/164))
+- Add `--param antithesis.images` to register images the config parser cannot discover ([#161](https://github.com/antithesishq/snouty/pull/161))
+- Add `ANTITHESIS_EXTRA_HEADERS` to set additional HTTP headers on API requests ([#158](https://github.com/antithesishq/snouty/pull/158))
+- Add an unstable update channel ([#195](https://github.com/antithesishq/snouty/pull/195))
+- Show vtime as an exact JSON number ([#192](https://github.com/antithesishq/snouty/pull/192))
+- Add `COOKBOOK.md` with the failure-moment logs recipe ([#185](https://github.com/antithesishq/snouty/pull/185))
 
 
 # Version 0.6.1 (2026-06-21)


### PR DESCRIPTION
This PR adds a top-level `CHANGELOG.md` and teaches the release skill to maintain it. cargo-dist auto-detects the file: when the release tag is pushed, it extracts the section for the version and puts it in the GitHub Release body. `dist-workspace.toml` needs no change.

The changelog follows cargo-dist's own idiomatic convention. Entries accumulate under `# Unreleased` as PRs land. A pre-release tag (`-rc.N`) publishes the `# Unreleased` section as-is; cargo-dist rewrites the title to the rc version in the GitHub Release. A stable release renames `# Unreleased` to `# Version X.Y.Z (date)`, so all rc-era entries fold into the final release notes and rc sections never exist in the file.

The file starts with the 0.7.0-rc.1 entries (all changes since v0.6.1) under `# Unreleased`, so the next rc or the final 0.7.0 release publishes them. A stub `# Version 0.6.1` section marks where the changelog starts.

Changes:

- Add `CHANGELOG.md` with the changes since v0.6.1
- Add a "How the changelog reaches GitHub Releases" section to the release skill
- Add a changelog step to the release procedure: draft `# Unreleased` entries from `git log` if stale, rename the heading for a stable release, and verify the result with `parse-changelog` (the same library cargo-dist uses)
- Stage `CHANGELOG.md` in the release commit

I verified all three match paths with the `parse-changelog` CLI: the `Unreleased` lookup (what an rc publishes), the `0.6.1` stub, and a simulated rename to `# Version 0.7.0`. A missing changelog entry is non-fatal: cargo-dist logs a message and skips the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9UYm4w97yWTsvMeRHC2uZ
