### PR TITLE
Add support for filter_logs_matching in snouty CLI

### DIFF
--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -137,3 +137,9 @@ stderr 'API error: 404 Not Found.*'
 mock-server 200 '{"runId":"run-123","statusCode":202}'
 snouty run -w basic_test --duration 30
 stderr 'snouty run.*is deprecated.*snouty launch'
+
+mock-server 200 '{"runId":"run-123","statusCode":202}'
+snouty launch -w basic_test --duration 30 --filter_logs_matching debug
+stderr '"antithesis.duration": "30"'
+stderr '"antithesis.filter_logs_matching": "debug"'
+stdout 'Test run started: run_id run-123'

--- a/specs/launch.txt
+++ b/specs/launch.txt
@@ -139,7 +139,7 @@ snouty run -w basic_test --duration 30
 stderr 'snouty run.*is deprecated.*snouty launch'
 
 mock-server 200 '{"runId":"run-123","statusCode":202}'
-snouty launch -w basic_test --duration 30 --filter_logs_matching debug
+snouty launch -w basic_test --duration 30 --filter-logs-matching debug
 stderr '"antithesis.duration": "30"'
 stderr '"antithesis.filter_logs_matching": "debug"'
 stdout 'Test run started: run_id run-123'

--- a/src/api.rs
+++ b/src/api.rs
@@ -777,6 +777,7 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
                 generated::types::ParamsAntithesisIsEphemeral::try_from(value)
                     .wrap_err("invalid antithesis.is_ephemeral value")?,
             )),
+            "antithesis.filter_logs_matching" => builder.antithesis_filter_logs_matching(Some(value.to_string())),
             "antithesis.report.recipients" => {
                 builder.antithesis_report_recipients(Some(value.to_string()))
             }

--- a/src/api.rs
+++ b/src/api.rs
@@ -777,7 +777,9 @@ fn launch_request(params: &Params) -> Result<generated::types::LaunchRequest> {
                 generated::types::ParamsAntithesisIsEphemeral::try_from(value)
                     .wrap_err("invalid antithesis.is_ephemeral value")?,
             )),
-            "antithesis.filter_logs_matching" => builder.antithesis_filter_logs_matching(Some(value.to_string())),
+            "antithesis.filter_logs_matching" => {
+                builder.antithesis_filter_logs_matching(Some(value.to_string()))
+            }
             "antithesis.report.recipients" => {
                 builder.antithesis_report_recipients(Some(value.to_string()))
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -483,6 +483,10 @@ pub struct LaunchArgs {
     #[arg(long)]
     pub recipients: Option<String>,
 
+    /// Regular Expression to filter out logs as part of test run. Filtered logs are recoverable in multi-verse debugging sessions
+    #[arg(long)]
+    pub filter_logs_matching: Option<String>,
+
     /// Extra parameters as key=value pairs (repeatable)
     #[arg(long = "param")]
     pub params: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,10 @@ async fn cmd_launch(
         params.insert("antithesis.config_image", config_image);
     }
 
+    if let Some(filter_logs_matching) = args.filter_logs_matching {
+        params.insert("antithesis.filter_logs_matching", filter_logs_matching);
+    }
+
     let config_image_ref = if let Some(config_dir) = args.config {
         let detected = config::detect_config(&config_dir)?;
         let registry = snouty::settings::require(settings.repository(), "repository")?;

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1238,6 +1238,11 @@
             "type": "string",
             "description": "An identifier used to separate property history in reports. Each property's history is generated from all previous runs sharing the same source value. Useful for tracking test history per branch.",
             "example": "main"
+          },
+          "antithesis.filter_logs_matching" : {
+            "type": "string",
+            "description": "Regular Expression to filter out logs as part of test run. Filtered logs are recoverable in multi-verse debugging sessions",
+            "example": "debug"
           }
         },
         "additionalProperties": {

--- a/src/params_schema.json
+++ b/src/params_schema.json
@@ -69,6 +69,10 @@
         "antithesis.test_name": {
           "type": "string",
           "description": "Name of the test to run; defaults to the config image name if not specified"
+        },
+        "antithesis.filter_logs_matching": {
+          "type": "string",
+          "description": "Regular Expression to filter out logs as part of test run. Filtered logs are recoverable in multi-verse debugging sessions"
         }
       }
     },

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -5072,6 +5072,7 @@ mod tests {
                 antithesis_is_ephemeral: None,
                 antithesis_report_recipients: None,
                 antithesis_source: None,
+                antithesis_filter_logs_matching: None,
                 extra,
             })
         } else {


### PR DESCRIPTION
Add support to pass `--filter-logs-matching` to snouty launch.

The filter_logs_matching parameter is a regular expression evaluated by RE2 that is applied on every log message that is outputted during the test run. If the log matches the regular expression, the log is "thrown out" and not stored in the database and does not influence fuzzing in the run. However, the logs are recoverable if the moment is re-warmed in multi-verse debugging sessions.