### PR TITLE
Fix clippy::await_holding_lock in the token-adoption test

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1115,15 +1115,17 @@ mod tests {
         .await
         .unwrap();
 
-        // Adopted the persisted token; no network refresh happened.
+        // Adopted the persisted token; no network refresh happened. The
+        // network assertion runs before the read lock is taken, so no guard
+        // is held across an await point (clippy::await_holding_lock).
         assert_eq!(result.as_deref(), Some("fresh-from-other-process"));
-        let in_memory = active_credential.read().unwrap();
-        assert_eq!(in_memory.antithesis_token, "fresh-from-other-process");
-        assert_eq!(in_memory.refresh_token.as_deref(), Some("fresh-refresh"));
         assert!(
             server.received_requests().await.unwrap().is_empty(),
             "must not refresh when the origin already holds a newer token"
         );
+        let in_memory = active_credential.read().unwrap();
+        assert_eq!(in_memory.antithesis_token, "fresh-from-other-process");
+        assert_eq!(in_memory.refresh_token.as_deref(), Some("fresh-refresh"));
     }
 
     /// Build a `v4.public` PASETO whose payload is `claims_json ‖ signature`,


### PR DESCRIPTION
This fixes the one clippy warning on main, `clippy::await_holding_lock` in `refresh_adopts_token_persisted_by_another_process`: the test read-locked the active credential and then awaited the mock server's request log, so the guard was held across an await point. The fix asserts on the network first and takes the read lock after; the assertion order carries no meaning in this test. `cargo clippy --all-targets` is now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzYUcdFMSpfu1Z8Vt4aZb
