### PR TITLE
Add snouty runs wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add `snouty runs wait`: poll a run until it reaches a terminal state (completed, cancelled, or incomplete), then print its details like `runs show`. The wait is unbounded unless `--timeout` is given, `--poll-interval` tunes the check frequency (30-second floor), a run that reports status `unknown` fails the command, and a run active for more than twice its scheduled duration gets a one-time warning ([#221](https://github.com/antithesishq/snouty/pull/221))
 - `snouty validate` reads the SDK output file from the start instead of tailing it, so a setup-complete event written over bytes snouty had already read is still detected ([#218](https://github.com/antithesishq/snouty/pull/218))
 - Add `snouty runs exec`: run a bash script in a run's live session at a given moment, on a fresh branch of the multiverse. The command is gated behind the `runs-exec` unstable feature (`SNOUTY_UNSTABLE_FEATURES=runs-exec`), because the API it calls is unstable and unavailable on most tenants ([#208](https://github.com/antithesishq/snouty/pull/208))
 - snouty now requires Docker Compose v2.24.7 or newer, checked up front ([#214](https://github.com/antithesishq/snouty/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Add `snouty runs wait`: poll a run until it reaches a terminal state (completed, cancelled, or incomplete), then print its details like `runs show`. The wait is unbounded unless `--timeout` is given, `--poll-interval` tunes the check frequency (30-second floor), a run that reports status `unknown` fails the command, and a run active for more than twice its scheduled duration gets a one-time warning ([#221](https://github.com/antithesishq/snouty/pull/221))
+- Add `snouty runs wait`: poll a run until it reaches a terminal state (completed, cancelled, or incomplete) ([#221](https://github.com/antithesishq/snouty/pull/221))
 - `snouty validate` reads the SDK output file from the start instead of tailing it, so a setup-complete event written over bytes snouty had already read is still detected ([#218](https://github.com/antithesishq/snouty/pull/218))
 - Add `snouty runs exec`: run a bash script in a run's live session at a given moment, on a fresh branch of the multiverse. The command is gated behind the `runs-exec` unstable feature (`SNOUTY_UNSTABLE_FEATURES=runs-exec`), because the API it calls is unstable and unavailable on most tenants ([#208](https://github.com/antithesishq/snouty/pull/208))
 - snouty now requires Docker Compose v2.24.7 or newer, checked up front ([#214](https://github.com/antithesishq/snouty/pull/214))

--- a/build.rs
+++ b/build.rs
@@ -52,6 +52,7 @@ fn generate_api_client(out_dir: &Path) {
     untype_error_responses(&mut spec_value);
     drop_use_otis(&mut spec_value);
     mark_vtime_schema(&mut spec_value);
+    mark_run_status_schema(&mut spec_value);
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
@@ -68,6 +69,17 @@ fn generate_api_client(out_dir: &Path) {
         "crate::vtime::VTime",
         std::iter::empty::<progenitor::TypeImpl>(),
     );
+    // Map the marked run-status schema onto the handwritten RunStatus, whose
+    // `Other` variant preserves a status value the enum doesn't name instead
+    // of failing the whole response parse.
+    let run_status_schema: schemars::schema::SchemaObject =
+        serde_json::from_value(serde_json::json!({"type": "string", "format": "run_status"}))
+            .unwrap();
+    settings.with_conversion(
+        run_status_schema,
+        "crate::api::RunStatus",
+        std::iter::empty::<progenitor::TypeImpl>(),
+    );
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(&spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();
@@ -82,6 +94,11 @@ fn generate_api_client(out_dir: &Path) {
     assert!(
         content.contains("pub vtime: crate::vtime::VTime"),
         "generated client does not use crate::vtime::VTime for Moment.vtime; \
+         the with_conversion schema match no longer applies"
+    );
+    assert!(
+        content.contains("pub status: crate::api::RunStatus"),
+        "generated client does not use crate::api::RunStatus for run statuses; \
          the with_conversion schema match no longer applies"
     );
 
@@ -174,6 +191,70 @@ fn drop_use_otis(spec: &mut serde_json::Value) {
         properties.remove("use_otis").is_some(),
         "Execute_Command_Request no longer has `use_otis`; delete `drop_use_otis` in build.rs"
     );
+}
+
+/// Replace every `Run_Status` reference with an inline string schema tagged
+/// for the `run_status` conversion mapping (see the registration above), and
+/// drop the named component. Generated as an enum, an undocumented status
+/// value fails the whole response parse; the handwritten
+/// `crate::api::RunStatus` preserves it instead. Inlining matters: typify
+/// wraps a *named* schema that hits a conversion in a needless newtype, while
+/// an inline schema maps to the conversion type directly (like `Moment.vtime`
+/// and `VTime`). The assertions pin the spec shape, so a refresh that changes
+/// it fails the build.
+fn mark_run_status_schema(spec: &mut serde_json::Value) {
+    let status = spec
+        .pointer("/components/schemas/Run_Status")
+        .expect("openapi spec has no Run_Status schema; update the RunStatus wiring in build.rs");
+    let known = serde_json::json!([
+        "starting",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "incomplete",
+        "unknown"
+    ]);
+    assert_eq!(
+        status["enum"], known,
+        "Run_Status gained or lost values; give crate::api::RunStatus a matching variant, then \
+         update this pin"
+    );
+
+    let marker = serde_json::json!({"type": "string", "format": "run_status"});
+    let replaced = replace_refs(spec, "#/components/schemas/Run_Status", &marker);
+    assert!(
+        replaced > 0,
+        "nothing references Run_Status anymore; delete mark_run_status_schema in build.rs"
+    );
+    spec.pointer_mut("/components/schemas")
+        .and_then(serde_json::Value::as_object_mut)
+        .unwrap()
+        .remove("Run_Status");
+}
+
+/// Recursively replace every `{"$ref": target}` object with `replacement`,
+/// returning how many were replaced.
+fn replace_refs(
+    value: &mut serde_json::Value,
+    target: &str,
+    replacement: &serde_json::Value,
+) -> usize {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("$ref").and_then(serde_json::Value::as_str) == Some(target) {
+                *value = replacement.clone();
+                return 1;
+            }
+            map.values_mut()
+                .map(|v| replace_refs(v, target, replacement))
+                .sum()
+        }
+        serde_json::Value::Array(items) => items
+            .iter_mut()
+            .map(|v| replace_refs(v, target, replacement))
+            .sum(),
+        _ => 0,
+    }
 }
 
 fn mark_vtime_schema(spec: &mut serde_json::Value) {

--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,6 @@ fn generate_api_client(out_dir: &Path) {
     untype_error_responses(&mut spec_value);
     drop_use_otis(&mut spec_value);
     mark_vtime_schema(&mut spec_value);
-    mark_run_status_schema(&mut spec_value);
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_value).unwrap();
 
     let mut settings = progenitor::GenerationSettings::default();
@@ -69,17 +68,6 @@ fn generate_api_client(out_dir: &Path) {
         "crate::vtime::VTime",
         std::iter::empty::<progenitor::TypeImpl>(),
     );
-    // Map the marked run-status schema onto the handwritten RunStatus, whose
-    // `Other` variant preserves a status value the enum doesn't name instead
-    // of failing the whole response parse.
-    let run_status_schema: schemars::schema::SchemaObject =
-        serde_json::from_value(serde_json::json!({"type": "string", "format": "run_status"}))
-            .unwrap();
-    settings.with_conversion(
-        run_status_schema,
-        "crate::api::RunStatus",
-        std::iter::empty::<progenitor::TypeImpl>(),
-    );
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(&spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();
@@ -94,11 +82,6 @@ fn generate_api_client(out_dir: &Path) {
     assert!(
         content.contains("pub vtime: crate::vtime::VTime"),
         "generated client does not use crate::vtime::VTime for Moment.vtime; \
-         the with_conversion schema match no longer applies"
-    );
-    assert!(
-        content.contains("pub status: crate::api::RunStatus"),
-        "generated client does not use crate::api::RunStatus for run statuses; \
          the with_conversion schema match no longer applies"
     );
 
@@ -191,70 +174,6 @@ fn drop_use_otis(spec: &mut serde_json::Value) {
         properties.remove("use_otis").is_some(),
         "Execute_Command_Request no longer has `use_otis`; delete `drop_use_otis` in build.rs"
     );
-}
-
-/// Replace every `Run_Status` reference with an inline string schema tagged
-/// for the `run_status` conversion mapping (see the registration above), and
-/// drop the named component. Generated as an enum, an undocumented status
-/// value fails the whole response parse; the handwritten
-/// `crate::api::RunStatus` preserves it instead. Inlining matters: typify
-/// wraps a *named* schema that hits a conversion in a needless newtype, while
-/// an inline schema maps to the conversion type directly (like `Moment.vtime`
-/// and `VTime`). The assertions pin the spec shape, so a refresh that changes
-/// it fails the build.
-fn mark_run_status_schema(spec: &mut serde_json::Value) {
-    let status = spec
-        .pointer("/components/schemas/Run_Status")
-        .expect("openapi spec has no Run_Status schema; update the RunStatus wiring in build.rs");
-    let known = serde_json::json!([
-        "starting",
-        "in_progress",
-        "completed",
-        "cancelled",
-        "incomplete",
-        "unknown"
-    ]);
-    assert_eq!(
-        status["enum"], known,
-        "Run_Status gained or lost values; give crate::api::RunStatus a matching variant, then \
-         update this pin"
-    );
-
-    let marker = serde_json::json!({"type": "string", "format": "run_status"});
-    let replaced = replace_refs(spec, "#/components/schemas/Run_Status", &marker);
-    assert!(
-        replaced > 0,
-        "nothing references Run_Status anymore; delete mark_run_status_schema in build.rs"
-    );
-    spec.pointer_mut("/components/schemas")
-        .and_then(serde_json::Value::as_object_mut)
-        .unwrap()
-        .remove("Run_Status");
-}
-
-/// Recursively replace every `{"$ref": target}` object with `replacement`,
-/// returning how many were replaced.
-fn replace_refs(
-    value: &mut serde_json::Value,
-    target: &str,
-    replacement: &serde_json::Value,
-) -> usize {
-    match value {
-        serde_json::Value::Object(map) => {
-            if map.get("$ref").and_then(serde_json::Value::as_str) == Some(target) {
-                *value = replacement.clone();
-                return 1;
-            }
-            map.values_mut()
-                .map(|v| replace_refs(v, target, replacement))
-                .sum()
-        }
-        serde_json::Value::Array(items) => items
-            .iter_mut()
-            .map(|v| replace_refs(v, target, replacement))
-            .sum(),
-        _ => 0,
-    }
 }
 
 fn mark_vtime_schema(spec: &mut serde_json::Value) {

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -1457,8 +1457,8 @@ def build_stories(d: Discovery) -> list[Story]:
             "Block until a run reaches a terminal state",
             "I scripted a launch and want one command that blocks until the run finishes, "
             "instead of writing my own polling loop.",
-            "A status line on stderr, then the run's details (same as `runs show`) once the "
-            "run is terminal — immediately here, since this run is already completed.",
+            "A single final-status line once the run is terminal — immediately here, since "
+            "this run is already completed.",
             ["runs", "wait", d.success],
             contains_all(d.success, "completed"),
             json_capable=False,
@@ -1901,8 +1901,8 @@ def build_help_stories(d: Discovery) -> list[Story]:
             "fails the command, and what --poll-interval and --timeout do.",
             ["runs", "wait"],
             ["runs", "wait", s],
-            # wait on a terminal run prints the `runs show` card; like
-            # help-runs-show there is no columnar output to align tokens against.
+            # wait on a terminal run prints one status line; nothing columnar
+            # to align tokens against.
         ),
         _help_story(
             "help-runs-properties",

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -1452,6 +1452,17 @@ def build_stories(d: Discovery) -> list[Story]:
             contains_all("cancelled"),
             json_capable=False,
         ),
+        Story(
+            "runs-wait",
+            "Block until a run reaches a terminal state",
+            "I scripted a launch and want one command that blocks until the run finishes, "
+            "instead of writing my own polling loop.",
+            "A status line on stderr, then the run's details (same as `runs show`) once the "
+            "run is terminal — immediately here, since this run is already completed.",
+            ["runs", "wait", d.success],
+            contains_all(d.success, "completed"),
+            json_capable=False,
+        ),
         # -- properties -----------------------------------------------------
         Story(
             "runs-properties",
@@ -1882,6 +1893,16 @@ def build_help_stories(d: Discovery) -> list[Story]:
             # show prints a key/value card (prose help vs Title-Case labels), not a
             # columnar table — no strict token alignment; the reviewer compares the
             # prose field list and the failure-moment claim against the two samples.
+        ),
+        _help_story(
+            "help-runs-wait",
+            "Learn how to wait for a run to finish",
+            "I want the help to explain the terminal states, that an `unknown` status "
+            "fails the command, and what --poll-interval and --timeout do.",
+            ["runs", "wait"],
+            ["runs", "wait", s],
+            # wait on a terminal run prints the `runs show` card; like
+            # help-runs-show there is no columnar output to align tokens against.
         ),
         _help_story(
             "help-runs-properties",

--- a/specs/wait.txt
+++ b/specs/wait.txt
@@ -1,0 +1,90 @@
+# snouty runs wait
+#
+# Wait for a run to reach a terminal state (completed, cancelled, or
+# incomplete), then print the run's details — the same output as `runs show`.
+# The command exits 0 for every terminal state; the caller reads the status
+# from the output. A run that reports status `unknown` fails the command
+# instead of waiting forever on a run that may never make progress.
+#
+# The status transitions themselves (poll until in_progress becomes completed,
+# the timeout path mid-wait, the over-schedule warning) are covered by Rust
+# integration tests in src/runs.rs, where the test server can change the run's
+# status between polls. This spec pins the static behavior: argument
+# validation, terminal-state handling, output shapes, and errors.
+
+# Like every runs command, wait requires an API key.
+! snouty runs wait some-run
+stderr 'No Antithesis credentials found.*'
+
+# A run ID is required.
+! snouty runs wait
+stderr '.*RUN_ID.*'
+
+# The poll interval has a 30-second floor, enforced by the CLI: anything
+# faster just burns API requests without observing runs (which take minutes
+# to hours) any sooner.
+! snouty runs wait some-run --poll-interval 10
+stderr 'invalid value .*10.* for .*--poll-interval.*'
+
+# `snouty runs --help` lists the wait subcommand.
+snouty runs --help
+stdout 'wait.*terminal state'
+
+# `snouty runs wait --help` explains the terminal states, the unknown-status
+# failure, and that re-running resumes the wait after an interruption.
+snouty runs wait --help
+stdout 'completed, cancelled, or incomplete'
+stdout 'unknown'
+stdout 'interrupt and re-run'
+stdout '--poll-interval'
+stdout '--timeout'
+
+# A run that is already terminal returns immediately: one status line on
+# stderr, the run's details on stdout (same rendering as `runs show`), exit 0.
+mock-runs-server
+snouty --json runs list --status completed
+env_from_json 0 run_id
+
+mock-runs-server
+snouty runs wait $R_run_id
+stderr 'run .* is completed'
+stdout 'Run ID.*$R_run_id'
+[!staging] stdout 'Status.*completed'
+
+# `snouty --json runs wait` prints the run detail as JSON — the same shape as
+# `runs show --json`, so a launch-to-report pipeline needs no second call.
+mock-runs-server
+snouty --json runs wait $R_run_id
+stdout '"run_id".*"$R_run_id"'
+[!staging] stdout '"status".*"completed"'
+
+# incomplete is a terminal state too: the wait succeeds and reports it (the
+# run's outcome is in the output, not the exit code). run-3 is the mock's
+# incomplete fixture.
+mock-runs-server
+[!staging] snouty runs wait run-3
+[!staging] stderr 'run run-3 is incomplete'
+[!staging] stdout 'Status.*incomplete'
+
+# A run that reports status `unknown` fails the wait: snouty cannot tell
+# whether such a run will still make progress, so the caller decides what to
+# do. The error names the status the server sent.
+mock-runs-server
+[!staging] ! snouty runs wait run-unknown-status
+[!staging] stderr 'run run-unknown-status reported status "unknown"'
+[!staging] stderr 'snouty runs show run-unknown-status'
+
+# A bad run id gives the same friendly "run not found" message as every other
+# run-scoped subcommand.
+mock-runs-server
+! snouty runs wait no-such-run
+stderr '.*run not found: no-such-run.*'
+! stderr '.*API error.*'
+
+# --timeout bounds the wait. run-2 stays in_progress on the mock, so a zero
+# timeout polls once, reports the status it saw, and fails with a resume hint.
+mock-runs-server
+[!staging] ! snouty runs wait run-2 --timeout 0
+[!staging] stderr 'run run-2 is in_progress'
+[!staging] stderr 'timed out waiting for run run-2'
+[!staging] stderr 'snouty runs wait run-2'

--- a/specs/wait.txt
+++ b/specs/wait.txt
@@ -6,11 +6,8 @@
 # from the output. A run that reports status `unknown` fails the command
 # instead of waiting forever on a run that may never make progress.
 #
-# The status transitions themselves (poll until in_progress becomes completed,
-# the timeout path mid-wait, the over-schedule warning) are covered by Rust
-# integration tests in src/runs.rs, where the test server can change the run's
-# status between polls. This spec pins the static behavior: argument
-# validation, terminal-state handling, output shapes, and errors.
+# Status transitions mid-wait are covered by Rust integration tests in
+# src/runs.rs, where the test server can change the run's status between polls.
 
 # Like every runs command, wait requires an API key.
 ! snouty runs wait some-run

--- a/specs/wait.txt
+++ b/specs/wait.txt
@@ -1,10 +1,10 @@
 # snouty runs wait
 #
 # Wait for a run to reach a terminal state (completed, cancelled, or
-# incomplete), then print the run's details — the same output as `runs show`.
-# The command exits 0 for every terminal state; the caller reads the status
-# from the output. A run that reports status `unknown` fails the command
-# instead of waiting forever on a run that may never make progress.
+# incomplete), then report the final status. The command exits 0 for every
+# terminal state; the run's outcome is in the output, not the exit code. A run
+# that reports status `unknown` fails the command instead of waiting forever
+# on a run that may never make progress.
 #
 # Status transitions mid-wait are covered by Rust integration tests in
 # src/runs.rs, where the test server can change the run's status between polls.
@@ -17,11 +17,13 @@ stderr 'No Antithesis credentials found.*'
 ! snouty runs wait
 stderr '.*RUN_ID.*'
 
-# The poll interval has a 30-second floor, enforced by the CLI: anything
-# faster just burns API requests without observing runs (which take minutes
-# to hours) any sooner.
-! snouty runs wait some-run --poll-interval 10
-stderr 'invalid value .*10.* for .*--poll-interval.*'
+# The poll interval takes the same duration forms as `launch --duration`
+# (minutes, or h/m/s units) and has a 1-minute floor: polling faster cannot
+# observe a run (which takes minutes to hours) any sooner.
+! snouty runs wait some-run --poll-interval 30s
+stderr 'poll interval must be at least 1 minute'
+! snouty runs wait some-run --poll-interval abc
+stderr 'must be a number of minutes'
 
 # `snouty runs --help` lists the wait subcommand.
 snouty runs --help
@@ -36,36 +38,32 @@ stdout 'interrupt and re-run'
 stdout '--poll-interval'
 stdout '--timeout'
 
-# A run that is already terminal returns immediately: one status line on
-# stderr, the run's details on stdout (same rendering as `runs show`), exit 0.
+# A run that is already terminal returns immediately: the final status is the
+# whole output, exit 0.
 mock-runs-server
 snouty --json runs list --status completed
 env_from_json 0 run_id
 
 mock-runs-server
 snouty runs wait $R_run_id
-stderr 'run .* is completed'
-stdout 'Run ID.*$R_run_id'
-[!staging] stdout 'Status.*completed'
+stdout 'run .* is completed'
+! stdout 'Launcher'
 
-# `snouty --json runs wait` prints the run detail as JSON — the same shape as
-# `runs show --json`, so a launch-to-report pipeline needs no second call.
+# `snouty --json runs wait` reports the run id and final status as JSON.
 mock-runs-server
 snouty --json runs wait $R_run_id
 stdout '"run_id".*"$R_run_id"'
 [!staging] stdout '"status".*"completed"'
 
-# incomplete is a terminal state too: the wait succeeds and reports it (the
-# run's outcome is in the output, not the exit code). run-3 is the mock's
-# incomplete fixture.
+# incomplete is a terminal state too: the wait succeeds and reports it.
+# run-3 is the mock's incomplete fixture.
 mock-runs-server
 [!staging] snouty runs wait run-3
-[!staging] stderr 'run run-3 is incomplete'
-[!staging] stdout 'Status.*incomplete'
+[!staging] stdout 'run run-3 is incomplete'
 
 # A run that reports status `unknown` fails the wait: snouty cannot tell
 # whether such a run will still make progress, so the caller decides what to
-# do. The error names the status the server sent.
+# do. The error names the status the server sent and points at `runs show`.
 mock-runs-server
 [!staging] ! snouty runs wait run-unknown-status
 [!staging] stderr 'run run-unknown-status reported status "unknown"'
@@ -78,10 +76,8 @@ mock-runs-server
 stderr '.*run not found: no-such-run.*'
 ! stderr '.*API error.*'
 
-# --timeout bounds the wait. run-2 stays in_progress on the mock, so a zero
-# timeout polls once, reports the status it saw, and fails with a resume hint.
+# --timeout bounds the whole wait, in-flight request included. run-2 stays
+# in_progress on the mock, so a zero timeout fails immediately.
 mock-runs-server
 [!staging] ! snouty runs wait run-2 --timeout 0
-[!staging] stderr 'run run-2 is in_progress'
 [!staging] stderr 'timed out waiting for run run-2'
-[!staging] stderr 'snouty runs wait run-2'

--- a/src/api.rs
+++ b/src/api.rs
@@ -30,7 +30,7 @@ mod generated {
 pub(crate) use generated::types::Params as RunParams;
 pub use generated::types::{
     BuildLogLine, Event, EventProperty, Moment, NonEventProperty, Property, PropertyStatus,
-    RunDetail, RunSummary,
+    RunDetail, RunStatus, RunSummary,
 };
 pub use progenitor_client::ByteStream;
 
@@ -67,95 +67,15 @@ pub enum VersionError {
     Unreachable(String),
 }
 
-/// A run's lifecycle status.
-///
-/// The documented statuses get variants; any other value the server sends is
-/// preserved verbatim as [`RunStatus::Other`], so a status this snouty
-/// predates never fails a whole response parse. Wired into the generated
-/// client by the `run_status` conversion in build.rs, like [`VTime`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum RunStatus {
-    Starting,
-    InProgress,
-    Completed,
-    Cancelled,
-    Incomplete,
-    Unknown,
-    /// A status this snouty does not know, carried verbatim.
-    Other(String),
-}
-
 impl RunStatus {
-    /// The wire string, e.g. `in_progress`.
-    pub fn as_str(&self) -> &str {
-        match self {
-            RunStatus::Starting => "starting",
-            RunStatus::InProgress => "in_progress",
-            RunStatus::Completed => "completed",
-            RunStatus::Cancelled => "cancelled",
-            RunStatus::Incomplete => "incomplete",
-            RunStatus::Unknown => "unknown",
-            RunStatus::Other(raw) => raw,
-        }
-    }
-
     /// Whether the run has stopped and its status will not change again.
     /// `unknown` is not terminal: it is the server saying it cannot classify
-    /// the run. Neither is [`RunStatus::Other`], which snouty cannot judge.
-    pub(crate) fn is_terminal(&self) -> bool {
+    /// the run.
+    pub(crate) fn is_terminal(self) -> bool {
         matches!(
             self,
             RunStatus::Completed | RunStatus::Cancelled | RunStatus::Incomplete
         )
-    }
-}
-
-impl std::fmt::Display for RunStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl std::str::FromStr for RunStatus {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(match s {
-            "starting" => RunStatus::Starting,
-            "in_progress" => RunStatus::InProgress,
-            "completed" => RunStatus::Completed,
-            "cancelled" => RunStatus::Cancelled,
-            "incomplete" => RunStatus::Incomplete,
-            "unknown" => RunStatus::Unknown,
-            other => RunStatus::Other(other.to_string()),
-        })
-    }
-}
-
-impl From<RunStatus> for String {
-    fn from(status: RunStatus) -> Self {
-        match status {
-            RunStatus::Other(raw) => raw,
-            known => known.as_str().to_owned(),
-        }
-    }
-}
-
-impl serde::Serialize for RunStatus {
-    fn serialize<S: serde::Serializer>(
-        &self,
-        serializer: S,
-    ) -> std::result::Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for RunStatus {
-    fn deserialize<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
-        let raw = String::deserialize(deserializer)?;
-        Ok(raw.parse().expect("RunStatus::from_str is infallible"))
     }
 }
 
@@ -582,7 +502,7 @@ impl AntithesisApi {
             request = request.after(cursor);
         }
         if let Some(ref status) = opts.status {
-            request = request.status(status.clone());
+            request = request.status(*status);
         }
         if let Some(ref launcher) = opts.launcher {
             request = request.launcher(launcher.clone());
@@ -2514,51 +2434,6 @@ mod tests {
 
         let api = test_api_optionally_with_cache(&mock_server, None);
         api.search_run_events("run-1", "slow", None).await.unwrap();
-    }
-
-    // A status the enum predates round-trips verbatim instead of failing the
-    // whole response parse — the point of the open RunStatus.
-    #[test]
-    fn run_status_preserves_unrecognized_values() {
-        let run: RunDetail = serde_json::from_value(serde_json::json!({
-            "run_id": "run-1",
-            "status": "paused",
-            "created_at": "2025-03-20T02:00:00Z",
-            "launcher": "nightly"
-        }))
-        .unwrap();
-        assert_eq!(run.status, RunStatus::Other("paused".to_string()));
-        assert_eq!(run.status.to_string(), "paused");
-        assert!(!run.status.is_terminal());
-        assert_eq!(
-            serde_json::to_value(&run.status).unwrap(),
-            serde_json::json!("paused")
-        );
-    }
-
-    #[test]
-    fn run_status_round_trips_documented_values() {
-        for (raw, status) in [
-            ("starting", RunStatus::Starting),
-            ("in_progress", RunStatus::InProgress),
-            ("completed", RunStatus::Completed),
-            ("cancelled", RunStatus::Cancelled),
-            ("incomplete", RunStatus::Incomplete),
-            ("unknown", RunStatus::Unknown),
-        ] {
-            assert_eq!(raw.parse::<RunStatus>().unwrap(), status);
-            assert_eq!(status.to_string(), raw);
-            assert_eq!(String::from(status.clone()), raw);
-            assert_eq!(
-                serde_json::to_value(&status).unwrap(),
-                serde_json::json!(raw)
-            );
-        }
-        assert!(RunStatus::Completed.is_terminal());
-        assert!(RunStatus::Cancelled.is_terminal());
-        assert!(RunStatus::Incomplete.is_terminal());
-        assert!(!RunStatus::Unknown.is_terminal());
-        assert!(!RunStatus::InProgress.is_terminal());
     }
 
     fn rid(version: u32) -> String {

--- a/src/api.rs
+++ b/src/api.rs
@@ -68,6 +68,19 @@ pub enum VersionError {
     Unreachable(String),
 }
 
+impl RunStatus {
+    /// Whether this status is final: the run has stopped and its status will
+    /// not change again. `unknown` is deliberately not terminal — it is the
+    /// server saying it cannot classify the run, and callers that poll must
+    /// decide for themselves what to do with it.
+    pub(crate) fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            RunStatus::Completed | RunStatus::Cancelled | RunStatus::Incomplete
+        )
+    }
+}
+
 fn params_test_name(params: Option<&RunParams>) -> Option<&str> {
     params.and_then(|p| p.extra.get("antithesis.test_name").map(String::as_str))
 }
@@ -185,6 +198,23 @@ fn normalize_property(property: Property) -> Result<Property> {
 /// to return (e.g. massive log files) and must not be aborted — the user can ctrl-c.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Where API responses are cached, per [`AntithesisApi::build`].
+#[derive(Debug)]
+pub(crate) enum ResponseCache {
+    /// `$XDG_RUNTIME_DIR/snouty/api-cache-v1` — the default for every command.
+    /// Caching is disabled when `XDG_RUNTIME_DIR` is unusable.
+    Default,
+    /// No response cache: every request hits the server. For poll loops that
+    /// must observe fresh state — the server marks run detail cacheable
+    /// (`Cache-Control: private, max-age=3600`), so a cached poll could
+    /// re-read the same status for up to an hour.
+    Disabled,
+    /// Cache under this directory. Only tests construct this variant (the
+    /// commands all use `Default` or `Disabled`), hence the dead-code allow.
+    #[allow(dead_code)]
+    Dir(PathBuf),
+}
+
 pub struct AntithesisApi {
     client: generated::Client,
     base_url: String,
@@ -202,7 +232,21 @@ impl AntithesisApi {
                 PasswordPolicy::Reject,
             )?,
             verbose,
-            None,
+            ResponseCache::Default,
+        )
+    }
+
+    /// Like [`AntithesisApi::new`], but with the response cache disabled
+    /// ([`ResponseCache::Disabled`]), for commands that poll for fresh state.
+    pub fn new_uncached(settings: &Settings, verbose: bool) -> Result<Self> {
+        Self::build(
+            settings,
+            AuthenticationInfo::for_ambient_configuration(
+                settings.profile(),
+                PasswordPolicy::Reject,
+            )?,
+            verbose,
+            ResponseCache::Disabled,
         )
     }
 
@@ -218,17 +262,15 @@ impl AntithesisApi {
                 PasswordPolicy::WarnDeprecated,
             )?,
             verbose,
-            None,
+            ResponseCache::Default,
         )
     }
 
-    /// The response cache lives at `cache_dir`/api-cache-v1 when `Some`; pass
-    /// `None` to disable caching (used by tests that don't exercise it).
     pub(crate) fn build(
         settings: &Settings,
         authn_info: AuthenticationInfo,
         verbose: bool,
-        cache_dir: Option<PathBuf>,
+        cache: ResponseCache,
     ) -> Result<Self> {
         // base_url() is None exactly when neither an explicit base_url nor a
         // tenant resolved; surface the tenant diagnostic, since that's what a
@@ -238,7 +280,13 @@ impl AntithesisApi {
 
         let default_headers = default_request_headers()?;
         let http_client = build_http_client(default_headers.clone(), settings)?;
-        let cached = api_cache::build_cached_client(http_client.clone(), cache_dir);
+        let cached = match cache {
+            ResponseCache::Default => api_cache::build_cached_client(http_client.clone(), None),
+            ResponseCache::Disabled => None,
+            ResponseCache::Dir(dir) => {
+                Some(api_cache::build_cached_client_at(http_client.clone(), dir))
+            }
+        };
         let state = ClientState {
             authn_info,
             cached,
@@ -1211,7 +1259,9 @@ mod tests {
                 password: "pass".to_owned(),
             },
             false,
-            cache_dir.map(|d| d.path().to_path_buf()),
+            cache_dir.map_or(ResponseCache::Disabled, |d| {
+                ResponseCache::Dir(d.path().to_path_buf())
+            }),
         )
         .unwrap()
     }
@@ -1510,7 +1560,7 @@ mod tests {
                 password: "pass".to_owned(),
             },
             true,
-            None,
+            ResponseCache::Disabled,
         )
         .unwrap();
         assert_eq!(api.base_url, "http://example.com");
@@ -1525,7 +1575,7 @@ mod tests {
                 password: "pass".to_owned(),
             },
             true,
-            None,
+            ResponseCache::Disabled,
         )
         .unwrap();
         assert_eq!(api.base_url, "http://example.com");
@@ -2121,7 +2171,7 @@ mod tests {
             &Settings::for_test_base_url(mock_server.uri()),
             auth,
             false,
-            None,
+            ResponseCache::Disabled,
         )
         .unwrap();
 
@@ -2178,7 +2228,7 @@ mod tests {
             &Settings::for_test_base_url(mock_server.uri()),
             auth,
             false,
-            None,
+            ResponseCache::Disabled,
         )
         .unwrap();
 
@@ -2216,7 +2266,7 @@ mod tests {
                 api_key: "some-key".to_owned(),
             },
             false,
-            None,
+            ResponseCache::Disabled,
         )
         .unwrap();
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, VecDeque};
-use std::path::PathBuf;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Report, Result, eyre};
@@ -31,7 +30,7 @@ mod generated {
 pub(crate) use generated::types::Params as RunParams;
 pub use generated::types::{
     BuildLogLine, Event, EventProperty, Moment, NonEventProperty, Property, PropertyStatus,
-    RunDetail, RunStatus, RunSummary,
+    RunDetail, RunSummary,
 };
 pub use progenitor_client::ByteStream;
 
@@ -68,15 +67,95 @@ pub enum VersionError {
     Unreachable(String),
 }
 
+/// A run's lifecycle status.
+///
+/// The documented statuses get variants; any other value the server sends is
+/// preserved verbatim as [`RunStatus::Other`], so a status this snouty
+/// predates never fails a whole response parse. Wired into the generated
+/// client by the `run_status` conversion in build.rs, like [`VTime`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RunStatus {
+    Starting,
+    InProgress,
+    Completed,
+    Cancelled,
+    Incomplete,
+    Unknown,
+    /// A status this snouty does not know, carried verbatim.
+    Other(String),
+}
+
 impl RunStatus {
+    /// The wire string, e.g. `in_progress`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            RunStatus::Starting => "starting",
+            RunStatus::InProgress => "in_progress",
+            RunStatus::Completed => "completed",
+            RunStatus::Cancelled => "cancelled",
+            RunStatus::Incomplete => "incomplete",
+            RunStatus::Unknown => "unknown",
+            RunStatus::Other(raw) => raw,
+        }
+    }
+
     /// Whether the run has stopped and its status will not change again.
     /// `unknown` is not terminal: it is the server saying it cannot classify
-    /// the run.
-    pub(crate) fn is_terminal(self) -> bool {
+    /// the run. Neither is [`RunStatus::Other`], which snouty cannot judge.
+    pub(crate) fn is_terminal(&self) -> bool {
         matches!(
             self,
             RunStatus::Completed | RunStatus::Cancelled | RunStatus::Incomplete
         )
+    }
+}
+
+impl std::fmt::Display for RunStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for RunStatus {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s {
+            "starting" => RunStatus::Starting,
+            "in_progress" => RunStatus::InProgress,
+            "completed" => RunStatus::Completed,
+            "cancelled" => RunStatus::Cancelled,
+            "incomplete" => RunStatus::Incomplete,
+            "unknown" => RunStatus::Unknown,
+            other => RunStatus::Other(other.to_string()),
+        })
+    }
+}
+
+impl From<RunStatus> for String {
+    fn from(status: RunStatus) -> Self {
+        match status {
+            RunStatus::Other(raw) => raw,
+            known => known.as_str().to_owned(),
+        }
+    }
+}
+
+impl serde::Serialize for RunStatus {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RunStatus {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Ok(raw.parse().expect("RunStatus::from_str is infallible"))
     }
 }
 
@@ -207,9 +286,9 @@ pub(crate) enum ResponseCache {
     /// cacheable (`Cache-Control: private, max-age=3600`), so a cached poll
     /// can re-read the same status for up to an hour.
     Disabled,
-    /// Cache under this directory. Only tests construct this variant.
-    #[allow(dead_code)]
-    Dir(PathBuf),
+    /// Cache under this directory.
+    #[cfg(test)]
+    Dir(std::path::PathBuf),
 }
 
 pub struct AntithesisApi {
@@ -279,6 +358,7 @@ impl AntithesisApi {
         let cached = match cache {
             ResponseCache::Default => api_cache::build_cached_client(http_client.clone(), None),
             ResponseCache::Disabled => None,
+            #[cfg(test)]
             ResponseCache::Dir(dir) => {
                 Some(api_cache::build_cached_client_at(http_client.clone(), dir))
             }
@@ -502,7 +582,7 @@ impl AntithesisApi {
             request = request.after(cursor);
         }
         if let Some(ref status) = opts.status {
-            request = request.status(*status);
+            request = request.status(status.clone());
         }
         if let Some(ref launcher) = opts.launcher {
             request = request.launcher(launcher.clone());
@@ -755,7 +835,7 @@ fn redact_sensitive_value(name: &HeaderName, value: &str) -> String {
 
 #[derive(Clone, Default)]
 pub struct RunsFilterOptions {
-    pub status: Option<generated::types::RunStatus>,
+    pub status: Option<RunStatus>,
     pub launcher: Option<String>,
     pub created_after: Option<chrono::DateTime<chrono::Utc>>,
     pub created_before: Option<chrono::DateTime<chrono::Utc>>,
@@ -2434,6 +2514,51 @@ mod tests {
 
         let api = test_api_optionally_with_cache(&mock_server, None);
         api.search_run_events("run-1", "slow", None).await.unwrap();
+    }
+
+    // A status the enum predates round-trips verbatim instead of failing the
+    // whole response parse — the point of the open RunStatus.
+    #[test]
+    fn run_status_preserves_unrecognized_values() {
+        let run: RunDetail = serde_json::from_value(serde_json::json!({
+            "run_id": "run-1",
+            "status": "paused",
+            "created_at": "2025-03-20T02:00:00Z",
+            "launcher": "nightly"
+        }))
+        .unwrap();
+        assert_eq!(run.status, RunStatus::Other("paused".to_string()));
+        assert_eq!(run.status.to_string(), "paused");
+        assert!(!run.status.is_terminal());
+        assert_eq!(
+            serde_json::to_value(&run.status).unwrap(),
+            serde_json::json!("paused")
+        );
+    }
+
+    #[test]
+    fn run_status_round_trips_documented_values() {
+        for (raw, status) in [
+            ("starting", RunStatus::Starting),
+            ("in_progress", RunStatus::InProgress),
+            ("completed", RunStatus::Completed),
+            ("cancelled", RunStatus::Cancelled),
+            ("incomplete", RunStatus::Incomplete),
+            ("unknown", RunStatus::Unknown),
+        ] {
+            assert_eq!(raw.parse::<RunStatus>().unwrap(), status);
+            assert_eq!(status.to_string(), raw);
+            assert_eq!(String::from(status.clone()), raw);
+            assert_eq!(
+                serde_json::to_value(&status).unwrap(),
+                serde_json::json!(raw)
+            );
+        }
+        assert!(RunStatus::Completed.is_terminal());
+        assert!(RunStatus::Cancelled.is_terminal());
+        assert!(RunStatus::Incomplete.is_terminal());
+        assert!(!RunStatus::Unknown.is_terminal());
+        assert!(!RunStatus::InProgress.is_terminal());
     }
 
     fn rid(version: u32) -> String {

--- a/src/api.rs
+++ b/src/api.rs
@@ -69,10 +69,9 @@ pub enum VersionError {
 }
 
 impl RunStatus {
-    /// Whether this status is final: the run has stopped and its status will
-    /// not change again. `unknown` is deliberately not terminal — it is the
-    /// server saying it cannot classify the run, and callers that poll must
-    /// decide for themselves what to do with it.
+    /// Whether the run has stopped and its status will not change again.
+    /// `unknown` is not terminal: it is the server saying it cannot classify
+    /// the run.
     pub(crate) fn is_terminal(self) -> bool {
         matches!(
             self,
@@ -198,19 +197,17 @@ fn normalize_property(property: Property) -> Result<Property> {
 /// to return (e.g. massive log files) and must not be aborted — the user can ctrl-c.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Where API responses are cached, per [`AntithesisApi::build`].
+/// Where API responses are cached.
 #[derive(Debug)]
 pub(crate) enum ResponseCache {
     /// `$XDG_RUNTIME_DIR/snouty/api-cache-v1` — the default for every command.
     /// Caching is disabled when `XDG_RUNTIME_DIR` is unusable.
     Default,
-    /// No response cache: every request hits the server. For poll loops that
-    /// must observe fresh state — the server marks run detail cacheable
-    /// (`Cache-Control: private, max-age=3600`), so a cached poll could
-    /// re-read the same status for up to an hour.
+    /// No response cache: every request hits the server. Run detail is
+    /// cacheable (`Cache-Control: private, max-age=3600`), so a cached poll
+    /// can re-read the same status for up to an hour.
     Disabled,
-    /// Cache under this directory. Only tests construct this variant (the
-    /// commands all use `Default` or `Disabled`), hence the dead-code allow.
+    /// Cache under this directory. Only tests construct this variant.
     #[allow(dead_code)]
     Dir(PathBuf),
 }
@@ -236,8 +233,7 @@ impl AntithesisApi {
         )
     }
 
-    /// Like [`AntithesisApi::new`], but with the response cache disabled
-    /// ([`ResponseCache::Disabled`]), for commands that poll for fresh state.
+    /// Like [`AntithesisApi::new`], but with [`ResponseCache::Disabled`].
     pub fn new_uncached(settings: &Settings, verbose: bool) -> Result<Self> {
         Self::build(
             settings,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,7 @@ Examples:
   snouty runs
   snouty runs list --status completed --launcher nightly
   snouty runs show <run_id>
+  snouty runs wait <run_id>
   snouty runs properties <run_id>
   snouty runs properties --failing <run_id>
   snouty runs properties <run_id> --name <substring> --detail
@@ -562,6 +563,42 @@ Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
         /// Open the run's triage report in a browser instead of printing details
         #[arg(short = 'w', long)]
         web: bool,
+    },
+
+    /// Wait for a run to reach a terminal state
+    #[command(
+        long_about = r#"Wait for a run to reach a terminal state (completed, cancelled, or incomplete).
+
+Polls the run's status until it is terminal, then prints the run's details —
+the same output as `runs show` — and exits 0 whatever the terminal state is;
+the run's outcome is in the output, not the exit code. A run that reports
+status `unknown` fails the command instead: snouty cannot tell whether such a
+run will still make progress, so the caller decides what to do.
+
+The wait is unbounded unless --timeout is given, and the command is safe to
+interrupt and re-run: waiting holds no state beyond the run id, so re-running
+resumes the wait.
+
+Examples:
+  snouty runs wait <run_id>
+  snouty runs wait <run_id> --timeout 7200
+  snouty launch --json -w basic_test ... | jq -r .runId | xargs snouty runs wait"#
+    )]
+    Wait {
+        /// Run ID
+        run_id: String,
+
+        /// Seconds between status checks
+        // The 30-second floor keeps a scripted wait from hammering the API:
+        // polling faster cannot observe a run (which takes minutes to hours)
+        // any sooner.
+        #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(30..))]
+        poll_interval: u64,
+
+        /// Maximum seconds to wait before the command fails; without it the
+        /// wait is unbounded
+        #[arg(long)]
+        timeout: Option<u64>,
     },
 
     /// List property results for a run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,15 +10,29 @@ use crate::features::{self, Feature};
 use crate::time::HumanDuration;
 use crate::vtime::VTime;
 
-/// clap value parser for `--status` that keeps a friendly, enumerated error
-/// message (the generated `RunStatus::from_str` only says "invalid value").
+/// clap value parser for `--status`. `RunStatus::from_str` never fails — it
+/// preserves an unrecognized server value as `Other` — but a filter the user
+/// typed must name a documented status, so `Other` is rejected here.
 fn parse_run_status(value: &str) -> Result<RunStatus, String> {
-    value.parse::<RunStatus>().map_err(|_| {
-        format!(
+    let Ok(status) = value.parse::<RunStatus>();
+    if matches!(status, RunStatus::Other(_)) {
+        return Err(format!(
             "invalid status: '{value}'\n\
              valid values: starting, in_progress, completed, cancelled, incomplete, unknown"
-        )
-    })
+        ));
+    }
+    Ok(status)
+}
+
+/// clap value parser for `runs wait --poll-interval`: a [`HumanDuration`] of
+/// at least 1 minute — polling faster cannot observe a run (which takes
+/// minutes to hours) any sooner, and only hammers the API.
+fn parse_poll_interval(value: &str) -> Result<HumanDuration, String> {
+    let interval = value.parse::<HumanDuration>().map_err(|e| e.to_string())?;
+    if interval.seconds() < 60 {
+        return Err("poll interval must be at least 1 minute".to_string());
+    }
+    Ok(interval)
 }
 
 #[derive(Parser)]
@@ -569,11 +583,11 @@ Incomplete runs also show the failure moment (Failure Hash/VTime) to pass to
     #[command(
         long_about = r#"Wait for a run to reach a terminal state (completed, cancelled, or incomplete).
 
-Polls the run's status until it is terminal, then prints the run's details —
-the same output as `runs show` — and exits 0 whatever the terminal state is;
-the run's outcome is in the output, not the exit code. A run that reports
-status `unknown` fails the command instead: snouty cannot tell whether such a
-run will still make progress, so the caller decides what to do.
+Polls the run's status until it is terminal, then reports the final status and
+exits 0 whatever that status is; the run's outcome is in the output, not the
+exit code. A run that reports status `unknown` fails the command instead:
+snouty cannot tell whether such a run will still make progress, so the caller
+decides what to do.
 
 The wait is unbounded unless --timeout is given, and the command is safe to
 interrupt and re-run: waiting holds no state beyond the run id, so re-running
@@ -581,24 +595,22 @@ resumes the wait.
 
 Examples:
   snouty runs wait <run_id>
-  snouty runs wait <run_id> --timeout 7200
+  snouty runs wait <run_id> --timeout 2h
   snouty launch --json -w basic_test ... | jq -r .runId | xargs snouty runs wait"#
     )]
     Wait {
         /// Run ID
         run_id: String,
 
-        /// Seconds between status checks
-        // The 30-second floor keeps a scripted wait from hammering the API:
-        // polling faster cannot observe a run (which takes minutes to hours)
-        // any sooner.
-        #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(30..))]
-        poll_interval: u64,
+        /// Time between status checks, in minutes or h/m/s units (e.g. 90s;
+        /// minimum 1 minute)
+        #[arg(long, default_value = "1m", value_parser = parse_poll_interval)]
+        poll_interval: HumanDuration,
 
-        /// Maximum seconds to wait before the command fails; without it the
-        /// wait is unbounded
+        /// Give up after this long (minutes, or h/m/s units, e.g. 2h);
+        /// without it the wait is unbounded
         #[arg(long)]
-        timeout: Option<u64>,
+        timeout: Option<HumanDuration>,
     },
 
     /// List property results for a run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,18 +10,15 @@ use crate::features::{self, Feature};
 use crate::time::HumanDuration;
 use crate::vtime::VTime;
 
-/// clap value parser for `--status`. `RunStatus::from_str` never fails — it
-/// preserves an unrecognized server value as `Other` — but a filter the user
-/// typed must name a documented status, so `Other` is rejected here.
+/// clap value parser for `--status` that keeps a friendly, enumerated error
+/// message (the generated `RunStatus::from_str` only says "invalid value").
 fn parse_run_status(value: &str) -> Result<RunStatus, String> {
-    let Ok(status) = value.parse::<RunStatus>();
-    if matches!(status, RunStatus::Other(_)) {
-        return Err(format!(
+    value.parse::<RunStatus>().map_err(|_| {
+        format!(
             "invalid status: '{value}'\n\
              valid values: starting, in_progress, completed, cancelled, incomplete, unknown"
-        ));
-    }
-    Ok(status)
+        )
+    })
 }
 
 /// clap value parser for `runs wait --poll-interval`: a [`HumanDuration`] of

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -6355,9 +6355,20 @@ mod tests {
             mock_status_sequence(&server, &["in_progress"]).await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", FAST, Some(Duration::from_millis(25)))
-                .await
-                .unwrap_err();
+            // A poll interval far past the timeout makes the poll count exact:
+            // the one sleep is clipped to the 25ms deadline, so there is the
+            // initial poll and one final poll at the deadline. Scheduler jitter
+            // can only delay the second poll, never add a third — an interval
+            // near the timeout would make the count jitter-dependent (it did,
+            // on a loaded CI runner).
+            let err = wait_for_run(
+                &api,
+                "run-w",
+                Duration::from_secs(3600),
+                Some(Duration::from_millis(25)),
+            )
+            .await
+            .unwrap_err();
 
             let msg = format!("{err:#}");
             assert_eq!(
@@ -6368,10 +6379,8 @@ mod tests {
                 format!("{err:?}").contains("snouty runs wait run-w"),
                 "the timeout must hand back the resume command"
             );
-            // Polls at 0ms and 10ms, then a final one at the 25ms deadline
-            // (the last sleep is clipped to the deadline, not a full interval).
             let requests = server.received_requests().await.unwrap();
-            assert_eq!(requests.len(), 3);
+            assert_eq!(requests.len(), 2);
         }
 
         #[tokio::test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -380,9 +380,8 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
 }
 
 /// `runs wait`: poll the run until it reaches a terminal state, then print its
-/// detail exactly as `runs show` would. The poll uses an uncached API client —
-/// the server marks run detail cacheable for an hour, and a wait that re-reads
-/// a cached status would sleep through the very transition it exists to see.
+/// detail exactly as `runs show` would. The client is uncached (see
+/// [`crate::api::ResponseCache::Disabled`]) so every poll observes fresh state.
 async fn cmd_runs_wait(
     run_id: &str,
     poll_interval: std::time::Duration,
@@ -406,14 +405,12 @@ async fn cmd_runs_wait(
 }
 
 /// Poll `get_run` every `poll_interval` until the run reaches a terminal
-/// state, and return that final detail. Progress goes to stderr — one line per
-/// status change, plus a one-time warning when the run overshoots twice its
-/// scheduled duration — so stdout stays reserved for the final result.
+/// state. Status changes and warnings go to stderr; stdout stays reserved for
+/// the final result.
 ///
-/// A run that reports status `unknown` fails the wait: the server is saying it
-/// cannot classify the run, so waiting further could mean waiting forever, and
-/// the caller decides what to do instead. When `timeout` elapses, one final
-/// poll still runs before the wait fails.
+/// A run that reports `unknown` fails the wait (see
+/// [`RunStatus::is_terminal`]). When `timeout` elapses, one final poll still
+/// runs before the wait fails.
 async fn wait_for_run(
     api: &AntithesisApi,
     run_id: &str,
@@ -466,19 +463,18 @@ async fn wait_for_run(
                 ))
                 .suggestion(format!("resume waiting with `snouty runs wait {run_id}`")));
             }
-            // Never sleep past the deadline: the last poll lands at the
-            // deadline instead of up to a full interval later.
+            // Clip the final sleep so the last poll lands at the deadline,
+            // not up to a full interval later.
             Some(deadline) => tokio::time::sleep(poll_interval.min(deadline - now)).await,
             None => tokio::time::sleep(poll_interval).await,
         }
     }
 }
 
-/// The warning line for a run that has been active for more than twice its
-/// scheduled duration (`antithesis.duration`), or `None` while it hasn't. The
-/// wall clock also spans provisioning, setup, and teardown, so some overshoot
-/// is normal; twice the schedule is far enough out to be worth flagging once.
-/// Runs that haven't started or record no usable scheduled duration never warn.
+/// The warning line for a run active for more than twice its scheduled
+/// duration (`antithesis.duration`); the wall clock also spans provisioning,
+/// setup, and teardown, so some overshoot is normal. Runs that haven't started
+/// or record no usable scheduled duration never warn.
 fn over_schedule_warning(run: &RunDetail, now: DateTime<Utc>) -> Option<String> {
     let scheduled = run.requested_duration()?.parse::<ReportDuration>().ok()?;
     let elapsed = elapsed_duration(run.started_at?, run.completed_at.unwrap_or(now))?;
@@ -6253,12 +6249,10 @@ mod tests {
         }
     }
 
-    /// `runs wait`: the status transitions the specs can't exercise against a
-    /// static mock. Each test mounts a sequence of `get_run` responses —
-    /// wiremock matches mocks in mount order, and a mock whose `up_to_n_times`
-    /// budget is spent stops matching — so the run's status changes between
-    /// polls, exactly like a live run. Sub-30s intervals are fine here: the
-    /// CLI enforces the floor, `wait_for_run` takes any `Duration`.
+    /// `runs wait` status transitions: each test mounts a sequence of
+    /// `get_run` responses so the run's status changes between polls. Sub-30s
+    /// intervals are fine here: the CLI enforces the floor, `wait_for_run`
+    /// takes any `Duration`.
     mod wait {
         use super::*;
         use crate::auth::AuthenticationInfo;
@@ -6289,9 +6283,10 @@ mod tests {
             })
         }
 
-        /// Mount `get_run` responses that serve each status in order, the last
-        /// one indefinitely.
-        async fn mock_status_sequence(server: &MockServer, statuses: &[&str]) {
+        /// Serve each status in order, the last one indefinitely: wiremock
+        /// matches in mount order and skips a mock whose `up_to_n_times`
+        /// budget is spent.
+        async fn mount_get_run_statuses(server: &MockServer, statuses: &[&str]) {
             for (i, status) in statuses.iter().enumerate() {
                 let mock = Mock::given(method("GET"))
                     .and(path("/api/v0/runs/run-w"))
@@ -6305,15 +6300,15 @@ mod tests {
             }
         }
 
-        const FAST: Duration = Duration::from_millis(10);
+        const FAST_POLL: Duration = Duration::from_millis(10);
 
         #[tokio::test]
         async fn wait_polls_until_the_run_completes() {
             let server = MockServer::start().await;
-            mock_status_sequence(&server, &["starting", "in_progress", "completed"]).await;
+            mount_get_run_statuses(&server, &["starting", "in_progress", "completed"]).await;
             let api = test_api(&server.uri());
 
-            let run = wait_for_run(&api, "run-w", FAST, None).await.unwrap();
+            let run = wait_for_run(&api, "run-w", FAST_POLL, None).await.unwrap();
 
             assert_eq!(run.status, RunStatus::Completed);
             // One poll per status: the loop stopped at the first terminal one.
@@ -6325,10 +6320,10 @@ mod tests {
         async fn wait_treats_every_terminal_state_as_success() {
             for status in ["completed", "cancelled", "incomplete"] {
                 let server = MockServer::start().await;
-                mock_status_sequence(&server, &["in_progress", status]).await;
+                mount_get_run_statuses(&server, &["in_progress", status]).await;
                 let api = test_api(&server.uri());
 
-                let run = wait_for_run(&api, "run-w", FAST, None).await.unwrap();
+                let run = wait_for_run(&api, "run-w", FAST_POLL, None).await.unwrap();
                 assert_eq!(run.status.to_string(), status);
             }
         }
@@ -6336,10 +6331,12 @@ mod tests {
         #[tokio::test]
         async fn wait_fails_when_the_run_turns_unknown() {
             let server = MockServer::start().await;
-            mock_status_sequence(&server, &["in_progress", "unknown"]).await;
+            mount_get_run_statuses(&server, &["in_progress", "unknown"]).await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", FAST, None).await.unwrap_err();
+            let err = wait_for_run(&api, "run-w", FAST_POLL, None)
+                .await
+                .unwrap_err();
 
             let msg = format!("{err:#}");
             assert_eq!(msg, "run run-w reported status \"unknown\"", "got: {msg}");
@@ -6352,15 +6349,12 @@ mod tests {
         #[tokio::test]
         async fn wait_times_out_on_a_run_that_never_finishes() {
             let server = MockServer::start().await;
-            mock_status_sequence(&server, &["in_progress"]).await;
+            mount_get_run_statuses(&server, &["in_progress"]).await;
             let api = test_api(&server.uri());
 
-            // A poll interval far past the timeout makes the poll count exact:
-            // the one sleep is clipped to the 25ms deadline, so there is the
-            // initial poll and one final poll at the deadline. Scheduler jitter
-            // can only delay the second poll, never add a third — an interval
-            // near the timeout would make the count jitter-dependent (it did,
-            // on a loaded CI runner).
+            // A poll interval far past the timeout pins the poll count at two
+            // (the initial poll and the final one at the clipped deadline):
+            // jitter can only delay the final poll, never add a third.
             let err = wait_for_run(
                 &api,
                 "run-w",
@@ -6393,14 +6387,15 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "BAD-ID", FAST, None).await.unwrap_err();
+            let err = wait_for_run(&api, "BAD-ID", FAST_POLL, None)
+                .await
+                .unwrap_err();
             assert_eq!(format!("{err:#}"), "run not found: BAD-ID");
         }
 
         #[tokio::test]
         async fn wait_passes_through_a_server_fault() {
-            // A 500 mid-wait is a genuine fault, not a missing run: it fails the
-            // wait with the API error intact so nothing masks a broken server.
+            // Unlike a 404, a 500 must not be reshaped into "run not found".
             let server = MockServer::start().await;
             Mock::given(method("GET"))
                 .and(path("/api/v0/runs/run-w"))
@@ -6409,13 +6404,16 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", FAST, None).await.unwrap_err();
+            let err = wait_for_run(&api, "run-w", FAST_POLL, None)
+                .await
+                .unwrap_err();
             assert_eq!(api_error_status(&err), Some(500));
         }
 
-        /// A `RunDetail` as the over-schedule check sees it: started at
-        /// 2025-03-20T02:00:00Z, still running, with the given
-        /// `antithesis.duration` (minutes, or absent).
+        const STARTED_AT: &str = "2025-03-20T02:00:00Z";
+
+        /// A still-running `RunDetail`, started at [`STARTED_AT`], with the
+        /// given `antithesis.duration` (minutes, or absent).
         fn active_run(duration_minutes: Option<&str>) -> RunDetail {
             let mut parameters = serde_json::Map::new();
             if let Some(d) = duration_minutes {
@@ -6424,26 +6422,24 @@ mod tests {
             serde_json::from_value(json!({
                 "run_id": "run-w",
                 "status": "in_progress",
-                "created_at": "2025-03-20T02:00:00Z",
-                "started_at": "2025-03-20T02:00:00Z",
+                "created_at": STARTED_AT,
+                "started_at": STARTED_AT,
                 "launcher": "nightly",
                 "parameters": parameters
             }))
             .unwrap()
         }
 
-        fn at(minutes_after_start: i64) -> DateTime<Utc> {
-            "2025-03-20T02:00:00Z".parse::<DateTime<Utc>>().unwrap()
-                + chrono::Duration::minutes(minutes_after_start)
+        fn minutes_after_start(minutes: i64) -> DateTime<Utc> {
+            STARTED_AT.parse::<DateTime<Utc>>().unwrap() + chrono::Duration::minutes(minutes)
         }
 
         #[test]
         fn over_schedule_warns_past_twice_the_scheduled_duration() {
             let run = active_run(Some("30"));
-            // At exactly twice the schedule there is no warning yet …
-            assert_eq!(over_schedule_warning(&run, at(60)), None);
-            // … one minute past it, the warning names both durations.
-            let warning = over_schedule_warning(&run, at(61)).unwrap();
+            // Strictly past twice the schedule: exactly 2x does not warn.
+            assert_eq!(over_schedule_warning(&run, minutes_after_start(60)), None);
+            let warning = over_schedule_warning(&run, minutes_after_start(61)).unwrap();
             assert!(warning.contains("run run-w"), "got: {warning}");
             assert!(warning.contains("1h1m"), "got: {warning}");
             assert!(warning.contains("30m"), "got: {warning}");
@@ -6451,28 +6447,24 @@ mod tests {
 
         #[test]
         fn over_schedule_needs_a_usable_schedule_and_a_start() {
-            // No duration parameter, an unparsable one, and a zero schedule
-            // (which would flag every run that has run at all) never warn.
-            assert_eq!(over_schedule_warning(&active_run(None), at(1000)), None);
+            let far_out = minutes_after_start(1000);
+            assert_eq!(over_schedule_warning(&active_run(None), far_out), None);
             assert_eq!(
-                over_schedule_warning(&active_run(Some("bogus")), at(1000)),
+                over_schedule_warning(&active_run(Some("bogus")), far_out),
                 None
             );
-            assert_eq!(
-                over_schedule_warning(&active_run(Some("0")), at(1000)),
-                None
-            );
+            assert_eq!(over_schedule_warning(&active_run(Some("0")), far_out), None);
 
             // A run that hasn't started has no elapsed time to compare.
             let unstarted: RunDetail = serde_json::from_value(json!({
                 "run_id": "run-w",
                 "status": "starting",
-                "created_at": "2025-03-20T02:00:00Z",
+                "created_at": STARTED_AT,
                 "launcher": "nightly",
                 "parameters": {"antithesis.duration": "30"}
             }))
             .unwrap();
-            assert_eq!(over_schedule_warning(&unstarted, at(1000)), None);
+            assert_eq!(over_schedule_warning(&unstarted, far_out), None);
         }
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -442,24 +442,20 @@ async fn wait_for_run(
             Err(err) => return Err(explain_run_not_found(run_id, err)),
         };
 
-        match run.status {
-            RunStatus::Starting | RunStatus::InProgress => {}
-            ref status if status.is_terminal() => return Ok(run),
-            // `unknown`, or a status this snouty predates: either way snouty
-            // cannot tell whether the run will still make progress, so the
-            // caller decides what to do.
-            ref status => {
-                return Err(
-                    user_error(format!("run {run_id} reported status \"{status}\""))
-                        .note("snouty cannot tell whether this run will still make progress")
-                        .suggestion(format!("inspect the run with `snouty runs show {run_id}`")),
-                );
-            }
+        if run.status == RunStatus::Unknown {
+            return Err(
+                user_error(format!("run {run_id} reported status \"unknown\""))
+                    .note("snouty cannot tell whether this run will still make progress")
+                    .suggestion(format!("inspect the run with `snouty runs show {run_id}`")),
+            );
+        }
+        if run.status.is_terminal() {
+            return Ok(run);
         }
 
-        if last_status.as_ref() != Some(&run.status) {
+        if last_status != Some(run.status) {
             eprintln!("run {run_id} is {}", run.status);
-            last_status = Some(run.status.clone());
+            last_status = Some(run.status);
         }
 
         if !warned_over_schedule && let Some(warning) = over_schedule_warning(&run, Utc::now()) {
@@ -6344,18 +6340,6 @@ mod tests {
             let report = format!("{err:?}");
             assert!(report.contains("snouty runs show run-w"), "got: {report}");
             assert!(!report.contains("snouty runs wait"), "got: {report}");
-        }
-
-        #[tokio::test]
-        async fn wait_fails_on_a_status_snouty_predates() {
-            let server = MockServer::start().await;
-            mount_get_run_statuses(&server, &["in_progress", "paused"]).await;
-            let api = test_api(&server.uri());
-
-            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
-
-            let msg = format!("{err:#}");
-            assert_eq!(msg, "run run-w reported status \"paused\"", "got: {msg}");
         }
 
         #[tokio::test]

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -105,17 +105,7 @@ pub async fn cmd_runs(
             run_id,
             poll_interval,
             timeout,
-        }) => {
-            cmd_runs_wait(
-                &run_id,
-                std::time::Duration::from_secs(poll_interval),
-                timeout.map(std::time::Duration::from_secs),
-                settings,
-                json,
-                verbose,
-            )
-            .await
-        }
+        }) => cmd_runs_wait(&run_id, poll_interval, timeout, settings, json, verbose).await,
         Some(RunsCommands::Properties {
             run_id,
             passing,
@@ -257,13 +247,6 @@ fn terminal_width() -> usize {
     term.size().1 as usize
 }
 
-/// Short human-readable run status word (e.g. `completed`, `in_progress`),
-/// reusing the canonical `RunStatus` display string so the term matches the
-/// API and `snouty runs show`.
-fn status_label(status: RunStatus) -> String {
-    status.to_string()
-}
-
 /// Compact relative age for the runs table ("21h ago", "2d ago"), trading
 /// prose ("21 hours ago") for column width. Rough by design: largest whole
 /// unit only. Future timestamps (clock skew) clamp to "0s ago".
@@ -379,13 +362,13 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// `runs wait`: poll the run until it reaches a terminal state, then print its
-/// detail exactly as `runs show` would. The client is uncached (see
+/// `runs wait`: poll the run until it reaches a terminal state, then report
+/// the final status. The client is uncached (see
 /// [`crate::api::ResponseCache::Disabled`]) so every poll observes fresh state.
 async fn cmd_runs_wait(
     run_id: &str,
-    poll_interval: std::time::Duration,
-    timeout: Option<std::time::Duration>,
+    poll_interval: HumanDuration,
+    timeout: Option<HumanDuration>,
     settings: &Settings,
     json: bool,
     verbose: bool,
@@ -393,35 +376,65 @@ async fn cmd_runs_wait(
     debug!("waiting for run: {}", run_id);
 
     let api = AntithesisApi::new_uncached(settings, verbose)?;
-    let run = wait_for_run(&api, run_id, poll_interval, timeout).await?;
+    let run = wait_with_timeout(&api, run_id, poll_interval, timeout).await?;
 
     if json {
-        outln!("{}", serde_json::to_string_pretty(&run)?)?;
+        outln!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "run_id": run.run_id,
+                "status": run.status,
+            }))?
+        )?;
     } else {
-        print_run_detail(&run)?;
+        outln!("run {} is {}", run.run_id, run.status)?;
     }
 
     Ok(())
 }
 
+/// [`wait_for_run`] bounded by `timeout`. The timeout wraps the whole wait —
+/// including any in-flight request, since the HTTP client has no read timeout
+/// (see `CONNECT_TIMEOUT` in api.rs) — so a hung request cannot outlive it.
+async fn wait_with_timeout(
+    api: &AntithesisApi,
+    run_id: &str,
+    poll_interval: HumanDuration,
+    timeout: Option<HumanDuration>,
+) -> Result<RunDetail> {
+    let wait = wait_for_run(api, run_id, poll_interval);
+    match timeout {
+        Some(limit) => match tokio::time::timeout(limit.as_duration(), wait).await {
+            Ok(result) => result,
+            Err(_) => Err(user_error(format!(
+                "timed out waiting for run {run_id} after {limit}"
+            ))),
+        },
+        None => wait.await,
+    }
+}
+
 /// Poll `get_run` every `poll_interval` until the run reaches a terminal
 /// state. Status changes and warnings go to stderr; stdout stays reserved for
-/// the final result.
+/// the final result. A run that reports `unknown` fails the wait (see
+/// [`RunStatus::is_terminal`]).
 ///
-/// A run that reports `unknown` fails the wait (see
-/// [`RunStatus::is_terminal`]). When `timeout` elapses, one final poll still
-/// runs before the wait fails.
+/// Never returns on its own — callers bound it with [`wait_with_timeout`].
 async fn wait_for_run(
     api: &AntithesisApi,
     run_id: &str,
-    poll_interval: std::time::Duration,
-    timeout: Option<std::time::Duration>,
+    poll_interval: HumanDuration,
 ) -> Result<RunDetail> {
-    let deadline = timeout.map(|t| tokio::time::Instant::now() + t);
+    let mut poll = tokio::time::interval(poll_interval.as_duration());
+    // A poll delayed by a slow response schedules the next one a full
+    // interval later, instead of firing early to catch up.
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last_status = None;
     let mut warned_over_schedule = false;
 
     loop {
+        poll.tick().await;
+
         let run = match api.get_run(run_id).await {
             Ok(run) => run,
             // A 404 here is unambiguous, exactly as in `runs show`: the run id
@@ -429,44 +442,29 @@ async fn wait_for_run(
             Err(err) => return Err(explain_run_not_found(run_id, err)),
         };
 
-        if last_status != Some(run.status) {
-            eprintln!("run {run_id} is {}", status_label(run.status));
-            last_status = Some(run.status);
+        match run.status {
+            RunStatus::Starting | RunStatus::InProgress => {}
+            ref status if status.is_terminal() => return Ok(run),
+            // `unknown`, or a status this snouty predates: either way snouty
+            // cannot tell whether the run will still make progress, so the
+            // caller decides what to do.
+            ref status => {
+                return Err(
+                    user_error(format!("run {run_id} reported status \"{status}\""))
+                        .note("snouty cannot tell whether this run will still make progress")
+                        .suggestion(format!("inspect the run with `snouty runs show {run_id}`")),
+                );
+            }
         }
 
-        if run.status == RunStatus::Unknown {
-            return Err(user_error(format!(
-                "run {run_id} reported status \"{}\"",
-                status_label(run.status)
-            ))
-            .note("snouty cannot tell whether this run will still make progress")
-            .suggestion(format!(
-                "inspect the run with `snouty runs show {run_id}`, or resume waiting with \
-                 `snouty runs wait {run_id}`"
-            )));
-        }
-        if run.status.is_terminal() {
-            return Ok(run);
+        if last_status.as_ref() != Some(&run.status) {
+            eprintln!("run {run_id} is {}", run.status);
+            last_status = Some(run.status.clone());
         }
 
         if !warned_over_schedule && let Some(warning) = over_schedule_warning(&run, Utc::now()) {
             eprintln!("warning: {warning}");
             warned_over_schedule = true;
-        }
-
-        let now = tokio::time::Instant::now();
-        match deadline {
-            Some(deadline) if now >= deadline => {
-                return Err(user_error(format!(
-                    "timed out waiting for run {run_id}; it is still {}",
-                    status_label(run.status)
-                ))
-                .suggestion(format!("resume waiting with `snouty runs wait {run_id}`")));
-            }
-            // Clip the final sleep so the last poll lands at the deadline,
-            // not up to a full interval later.
-            Some(deadline) => tokio::time::sleep(poll_interval.min(deadline - now)).await,
-            None => tokio::time::sleep(poll_interval).await,
         }
     }
 }
@@ -476,7 +474,7 @@ async fn wait_for_run(
 /// setup, and teardown, so some overshoot is normal. Runs that haven't started
 /// or record no usable scheduled duration never warn.
 fn over_schedule_warning(run: &RunDetail, now: DateTime<Utc>) -> Option<String> {
-    let scheduled = run.requested_duration()?.parse::<ReportDuration>().ok()?;
+    let scheduled = run.requested_duration()?.parse::<HumanDuration>().ok()?;
     let elapsed = elapsed_duration(run.started_at?, run.completed_at.unwrap_or(now))?;
     // A zero schedule would flag every run that has run at all.
     if scheduled.seconds() > 0 && elapsed.seconds() > 2 * scheduled.seconds() {
@@ -642,7 +640,7 @@ async fn explain_empty_properties(
     {
         return format!(
             "No properties found — this run is {}; properties are generated when a run completes.",
-            status_label(run.status)
+            run.status
         );
     }
     no_properties_message(filter)
@@ -762,7 +760,7 @@ async fn explain_properties_error(
             let report = user_error(format!("no properties for run {run_id}"))
                 .note(format!(
                     "properties are generated when a run completes; this run is {}",
-                    status_label(run.status)
+                    run.status
                 ))
                 .note(format!("inspect the run with `snouty runs show {run_id}`"));
             // A placeholder 0/0 moment streams no logs, so skip the "view logs"
@@ -1252,7 +1250,7 @@ fn print_run_detail(run: &RunDetail) -> Result<()> {
         rows.push(("Test Name", name.to_string()));
     }
 
-    rows.push(("Status", status_label(run.status)));
+    rows.push(("Status", run.status.to_string()));
     rows.push(("Created", format_local(run.created_at)));
 
     if let Some(t) = run.started_at {
@@ -1342,7 +1340,7 @@ fn render_runs_detail(runs: &[RunSummary]) -> String {
         .map(|run| {
             let mut rows: Vec<(&str, String)> = vec![
                 ("Run ID", run.run_id.clone()),
-                ("Status", status_label(run.status)),
+                ("Status", run.status.to_string()),
                 ("Created", format_local(run.created_at)),
                 ("Launcher", run.launcher.clone()),
             ];
@@ -3123,7 +3121,7 @@ fn render_runs_table(runs: &[RunSummary], width: usize) -> String {
             let test_name = run.test_name().map(sanitize).unwrap_or_else(|| "-".into());
             vec![
                 sanitize(&run.run_id),
-                status_label(run.status),
+                run.status.to_string(),
                 relative_time(run.created_at),
                 test_name,
             ]
@@ -5724,13 +5722,13 @@ mod tests {
     }
 
     #[test]
-    fn status_label_covers_every_variant() {
-        assert_eq!(status_label(RunStatus::Completed), "completed");
-        assert_eq!(status_label(RunStatus::Incomplete), "incomplete");
-        assert_eq!(status_label(RunStatus::InProgress), "in_progress");
-        assert_eq!(status_label(RunStatus::Starting), "starting");
-        assert_eq!(status_label(RunStatus::Cancelled), "cancelled");
-        assert_eq!(status_label(RunStatus::Unknown), "unknown");
+    fn run_status_display_covers_every_variant() {
+        assert_eq!(RunStatus::Completed.to_string(), "completed");
+        assert_eq!(RunStatus::Incomplete.to_string(), "incomplete");
+        assert_eq!(RunStatus::InProgress.to_string(), "in_progress");
+        assert_eq!(RunStatus::Starting.to_string(), "starting");
+        assert_eq!(RunStatus::Cancelled.to_string(), "cancelled");
+        assert_eq!(RunStatus::Unknown.to_string(), "unknown");
     }
 
     fn summary(
@@ -6300,7 +6298,11 @@ mod tests {
             }
         }
 
-        const FAST_POLL: Duration = Duration::from_millis(10);
+        /// Sub-minute polling is fine below the CLI: the 1-minute floor is
+        /// clap's, `wait_for_run` takes any interval.
+        fn fast_poll() -> HumanDuration {
+            "1s".parse().unwrap()
+        }
 
         #[tokio::test]
         async fn wait_polls_until_the_run_completes() {
@@ -6308,7 +6310,7 @@ mod tests {
             mount_get_run_statuses(&server, &["starting", "in_progress", "completed"]).await;
             let api = test_api(&server.uri());
 
-            let run = wait_for_run(&api, "run-w", FAST_POLL, None).await.unwrap();
+            let run = wait_for_run(&api, "run-w", fast_poll()).await.unwrap();
 
             assert_eq!(run.status, RunStatus::Completed);
             // One poll per status: the loop stopped at the first terminal one.
@@ -6323,7 +6325,7 @@ mod tests {
                 mount_get_run_statuses(&server, &["in_progress", status]).await;
                 let api = test_api(&server.uri());
 
-                let run = wait_for_run(&api, "run-w", FAST_POLL, None).await.unwrap();
+                let run = wait_for_run(&api, "run-w", fast_poll()).await.unwrap();
                 assert_eq!(run.status.to_string(), status);
             }
         }
@@ -6334,16 +6336,26 @@ mod tests {
             mount_get_run_statuses(&server, &["in_progress", "unknown"]).await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", FAST_POLL, None)
-                .await
-                .unwrap_err();
+            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
 
             let msg = format!("{err:#}");
             assert_eq!(msg, "run run-w reported status \"unknown\"", "got: {msg}");
             // The next steps ride along as notes on the full report.
             let report = format!("{err:?}");
             assert!(report.contains("snouty runs show run-w"), "got: {report}");
-            assert!(report.contains("snouty runs wait run-w"), "got: {report}");
+            assert!(!report.contains("snouty runs wait"), "got: {report}");
+        }
+
+        #[tokio::test]
+        async fn wait_fails_on_a_status_snouty_predates() {
+            let server = MockServer::start().await;
+            mount_get_run_statuses(&server, &["in_progress", "paused"]).await;
+            let api = test_api(&server.uri());
+
+            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
+
+            let msg = format!("{err:#}");
+            assert_eq!(msg, "run run-w reported status \"paused\"", "got: {msg}");
         }
 
         #[tokio::test]
@@ -6352,29 +6364,49 @@ mod tests {
             mount_get_run_statuses(&server, &["in_progress"]).await;
             let api = test_api(&server.uri());
 
-            // A poll interval far past the timeout pins the poll count at two
-            // (the initial poll and the final one at the clipped deadline):
-            // jitter can only delay the final poll, never add a third.
-            let err = wait_for_run(
+            let err = wait_with_timeout(
                 &api,
                 "run-w",
-                Duration::from_secs(3600),
-                Some(Duration::from_millis(25)),
+                "1h".parse().unwrap(),
+                Some("1s".parse().unwrap()),
             )
             .await
             .unwrap_err();
 
             let msg = format!("{err:#}");
             assert_eq!(
-                msg, "timed out waiting for run run-w; it is still in_progress",
+                msg, "timed out waiting for run run-w after 1s",
                 "got: {msg}"
             );
-            assert!(
-                format!("{err:?}").contains("snouty runs wait run-w"),
-                "the timeout must hand back the resume command"
-            );
+            // One immediate poll, then a one-hour tick the timeout cuts short.
             let requests = server.received_requests().await.unwrap();
-            assert_eq!(requests.len(), 2);
+            assert_eq!(requests.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn wait_timeout_cuts_off_a_hung_request() {
+            // The HTTP client has no read timeout, so only the wrapping
+            // tokio::time::timeout keeps a never-answering server from
+            // hanging the command forever.
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v0/runs/run-w"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(run_body("in_progress"))
+                        .set_delay(Duration::from_secs(3600)),
+                )
+                .mount(&server)
+                .await;
+            let api = test_api(&server.uri());
+
+            let err = wait_with_timeout(&api, "run-w", fast_poll(), Some("1s".parse().unwrap()))
+                .await
+                .unwrap_err();
+            assert!(
+                format!("{err:#}").contains("timed out waiting for run run-w"),
+                "got: {err:#}"
+            );
         }
 
         #[tokio::test]
@@ -6387,9 +6419,7 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "BAD-ID", FAST_POLL, None)
-                .await
-                .unwrap_err();
+            let err = wait_for_run(&api, "BAD-ID", fast_poll()).await.unwrap_err();
             assert_eq!(format!("{err:#}"), "run not found: BAD-ID");
         }
 
@@ -6404,9 +6434,7 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", FAST_POLL, None)
-                .await
-                .unwrap_err();
+            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
             assert_eq!(api_error_status(&err), Some(500));
         }
 

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -101,6 +101,21 @@ pub async fn cmd_runs(
         Some(RunsCommands::Show { run_id, web }) => {
             cmd_runs_show(&run_id, web, settings, json, verbose).await
         }
+        Some(RunsCommands::Wait {
+            run_id,
+            poll_interval,
+            timeout,
+        }) => {
+            cmd_runs_wait(
+                &run_id,
+                std::time::Duration::from_secs(poll_interval),
+                timeout.map(std::time::Duration::from_secs),
+                settings,
+                json,
+                verbose,
+            )
+            .await
+        }
         Some(RunsCommands::Properties {
             run_id,
             passing,
@@ -362,6 +377,121 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
         outln!("  {url}")?;
     }
     Ok(())
+}
+
+/// `runs wait`: poll the run until it reaches a terminal state, then print its
+/// detail exactly as `runs show` would. The poll uses an uncached API client —
+/// the server marks run detail cacheable for an hour, and a wait that re-reads
+/// a cached status would sleep through the very transition it exists to see.
+async fn cmd_runs_wait(
+    run_id: &str,
+    poll_interval: std::time::Duration,
+    timeout: Option<std::time::Duration>,
+    settings: &Settings,
+    json: bool,
+    verbose: bool,
+) -> Result<()> {
+    debug!("waiting for run: {}", run_id);
+
+    let api = AntithesisApi::new_uncached(settings, verbose)?;
+    let run = wait_for_run(&api, run_id, poll_interval, timeout).await?;
+
+    if json {
+        outln!("{}", serde_json::to_string_pretty(&run)?)?;
+    } else {
+        print_run_detail(&run)?;
+    }
+
+    Ok(())
+}
+
+/// Poll `get_run` every `poll_interval` until the run reaches a terminal
+/// state, and return that final detail. Progress goes to stderr — one line per
+/// status change, plus a one-time warning when the run overshoots twice its
+/// scheduled duration — so stdout stays reserved for the final result.
+///
+/// A run that reports status `unknown` fails the wait: the server is saying it
+/// cannot classify the run, so waiting further could mean waiting forever, and
+/// the caller decides what to do instead. When `timeout` elapses, one final
+/// poll still runs before the wait fails.
+async fn wait_for_run(
+    api: &AntithesisApi,
+    run_id: &str,
+    poll_interval: std::time::Duration,
+    timeout: Option<std::time::Duration>,
+) -> Result<RunDetail> {
+    let deadline = timeout.map(|t| tokio::time::Instant::now() + t);
+    let mut last_status = None;
+    let mut warned_over_schedule = false;
+
+    loop {
+        let run = match api.get_run(run_id).await {
+            Ok(run) => run,
+            // A 404 here is unambiguous, exactly as in `runs show`: the run id
+            // is bad, so fail now rather than poll a typo until the timeout.
+            Err(err) => return Err(explain_run_not_found(run_id, err)),
+        };
+
+        if last_status != Some(run.status) {
+            eprintln!("run {run_id} is {}", status_label(run.status));
+            last_status = Some(run.status);
+        }
+
+        if run.status == RunStatus::Unknown {
+            return Err(user_error(format!(
+                "run {run_id} reported status \"{}\"",
+                status_label(run.status)
+            ))
+            .note("snouty cannot tell whether this run will still make progress")
+            .suggestion(format!(
+                "inspect the run with `snouty runs show {run_id}`, or resume waiting with \
+                 `snouty runs wait {run_id}`"
+            )));
+        }
+        if run.status.is_terminal() {
+            return Ok(run);
+        }
+
+        if !warned_over_schedule && let Some(warning) = over_schedule_warning(&run, Utc::now()) {
+            eprintln!("warning: {warning}");
+            warned_over_schedule = true;
+        }
+
+        let now = tokio::time::Instant::now();
+        match deadline {
+            Some(deadline) if now >= deadline => {
+                return Err(user_error(format!(
+                    "timed out waiting for run {run_id}; it is still {}",
+                    status_label(run.status)
+                ))
+                .suggestion(format!("resume waiting with `snouty runs wait {run_id}`")));
+            }
+            // Never sleep past the deadline: the last poll lands at the
+            // deadline instead of up to a full interval later.
+            Some(deadline) => tokio::time::sleep(poll_interval.min(deadline - now)).await,
+            None => tokio::time::sleep(poll_interval).await,
+        }
+    }
+}
+
+/// The warning line for a run that has been active for more than twice its
+/// scheduled duration (`antithesis.duration`), or `None` while it hasn't. The
+/// wall clock also spans provisioning, setup, and teardown, so some overshoot
+/// is normal; twice the schedule is far enough out to be worth flagging once.
+/// Runs that haven't started or record no usable scheduled duration never warn.
+fn over_schedule_warning(run: &RunDetail, now: DateTime<Utc>) -> Option<String> {
+    let scheduled = run.requested_duration()?.parse::<ReportDuration>().ok()?;
+    let elapsed = elapsed_duration(run.started_at?, run.completed_at.unwrap_or(now))?;
+    // A zero schedule would flag every run that has run at all.
+    if scheduled.seconds() > 0 && elapsed.seconds() > 2 * scheduled.seconds() {
+        Some(format!(
+            "run {} has been active for {elapsed}, more than twice its scheduled duration of \
+             {scheduled}",
+            run.run_id
+        ))
+    } else {
+        None
+    }
 }
 
 fn launch_browser(url: &str) -> bool {
@@ -5942,7 +6072,7 @@ mod tests {
                     password: "pass".to_string(),
                 },
                 false,
-                None,
+                crate::api::ResponseCache::Disabled,
             )
             .unwrap()
         }
@@ -6120,6 +6250,220 @@ mod tests {
             assert_eq!(api_error_status(&result), Some(500));
             assert!(!format!("{result:#}").contains("run not found"));
             assert!(!format!("{result:#}").contains("no properties for run"));
+        }
+    }
+
+    /// `runs wait`: the status transitions the specs can't exercise against a
+    /// static mock. Each test mounts a sequence of `get_run` responses —
+    /// wiremock matches mocks in mount order, and a mock whose `up_to_n_times`
+    /// budget is spent stops matching — so the run's status changes between
+    /// polls, exactly like a live run. Sub-30s intervals are fine here: the
+    /// CLI enforces the floor, `wait_for_run` takes any `Duration`.
+    mod wait {
+        use super::*;
+        use crate::auth::AuthenticationInfo;
+        use crate::error::api_error_status;
+        use crate::settings::Settings;
+        use std::time::Duration;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn test_api(base_url: &str) -> AntithesisApi {
+            AntithesisApi::build(
+                &Settings::for_test_base_url(base_url.to_owned()),
+                AuthenticationInfo::ApiKey {
+                    api_key: "test-key".to_owned(),
+                },
+                false,
+                crate::api::ResponseCache::Disabled,
+            )
+            .unwrap()
+        }
+
+        fn run_body(status: &str) -> serde_json::Value {
+            json!({
+                "run_id": "run-w",
+                "status": status,
+                "created_at": "2025-03-20T02:00:00Z",
+                "launcher": "nightly"
+            })
+        }
+
+        /// Mount `get_run` responses that serve each status in order, the last
+        /// one indefinitely.
+        async fn mock_status_sequence(server: &MockServer, statuses: &[&str]) {
+            for (i, status) in statuses.iter().enumerate() {
+                let mock = Mock::given(method("GET"))
+                    .and(path("/api/v0/runs/run-w"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(run_body(status)));
+                let mock = if i + 1 < statuses.len() {
+                    mock.up_to_n_times(1)
+                } else {
+                    mock
+                };
+                mock.mount(server).await;
+            }
+        }
+
+        const FAST: Duration = Duration::from_millis(10);
+
+        #[tokio::test]
+        async fn wait_polls_until_the_run_completes() {
+            let server = MockServer::start().await;
+            mock_status_sequence(&server, &["starting", "in_progress", "completed"]).await;
+            let api = test_api(&server.uri());
+
+            let run = wait_for_run(&api, "run-w", FAST, None).await.unwrap();
+
+            assert_eq!(run.status, RunStatus::Completed);
+            // One poll per status: the loop stopped at the first terminal one.
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 3);
+        }
+
+        #[tokio::test]
+        async fn wait_treats_every_terminal_state_as_success() {
+            for status in ["completed", "cancelled", "incomplete"] {
+                let server = MockServer::start().await;
+                mock_status_sequence(&server, &["in_progress", status]).await;
+                let api = test_api(&server.uri());
+
+                let run = wait_for_run(&api, "run-w", FAST, None).await.unwrap();
+                assert_eq!(run.status.to_string(), status);
+            }
+        }
+
+        #[tokio::test]
+        async fn wait_fails_when_the_run_turns_unknown() {
+            let server = MockServer::start().await;
+            mock_status_sequence(&server, &["in_progress", "unknown"]).await;
+            let api = test_api(&server.uri());
+
+            let err = wait_for_run(&api, "run-w", FAST, None).await.unwrap_err();
+
+            let msg = format!("{err:#}");
+            assert_eq!(msg, "run run-w reported status \"unknown\"", "got: {msg}");
+            // The next steps ride along as notes on the full report.
+            let report = format!("{err:?}");
+            assert!(report.contains("snouty runs show run-w"), "got: {report}");
+            assert!(report.contains("snouty runs wait run-w"), "got: {report}");
+        }
+
+        #[tokio::test]
+        async fn wait_times_out_on_a_run_that_never_finishes() {
+            let server = MockServer::start().await;
+            mock_status_sequence(&server, &["in_progress"]).await;
+            let api = test_api(&server.uri());
+
+            let err = wait_for_run(&api, "run-w", FAST, Some(Duration::from_millis(25)))
+                .await
+                .unwrap_err();
+
+            let msg = format!("{err:#}");
+            assert_eq!(
+                msg, "timed out waiting for run run-w; it is still in_progress",
+                "got: {msg}"
+            );
+            assert!(
+                format!("{err:?}").contains("snouty runs wait run-w"),
+                "the timeout must hand back the resume command"
+            );
+            // Polls at 0ms and 10ms, then a final one at the 25ms deadline
+            // (the last sleep is clipped to the deadline, not a full interval).
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 3);
+        }
+
+        #[tokio::test]
+        async fn wait_reports_a_missing_run_immediately() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v0/runs/BAD-ID"))
+                .respond_with(ResponseTemplate::new(404).set_body_json(json!({"message": "nope"})))
+                .mount(&server)
+                .await;
+            let api = test_api(&server.uri());
+
+            let err = wait_for_run(&api, "BAD-ID", FAST, None).await.unwrap_err();
+            assert_eq!(format!("{err:#}"), "run not found: BAD-ID");
+        }
+
+        #[tokio::test]
+        async fn wait_passes_through_a_server_fault() {
+            // A 500 mid-wait is a genuine fault, not a missing run: it fails the
+            // wait with the API error intact so nothing masks a broken server.
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v0/runs/run-w"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+                .mount(&server)
+                .await;
+            let api = test_api(&server.uri());
+
+            let err = wait_for_run(&api, "run-w", FAST, None).await.unwrap_err();
+            assert_eq!(api_error_status(&err), Some(500));
+        }
+
+        /// A `RunDetail` as the over-schedule check sees it: started at
+        /// 2025-03-20T02:00:00Z, still running, with the given
+        /// `antithesis.duration` (minutes, or absent).
+        fn active_run(duration_minutes: Option<&str>) -> RunDetail {
+            let mut parameters = serde_json::Map::new();
+            if let Some(d) = duration_minutes {
+                parameters.insert("antithesis.duration".into(), json!(d));
+            }
+            serde_json::from_value(json!({
+                "run_id": "run-w",
+                "status": "in_progress",
+                "created_at": "2025-03-20T02:00:00Z",
+                "started_at": "2025-03-20T02:00:00Z",
+                "launcher": "nightly",
+                "parameters": parameters
+            }))
+            .unwrap()
+        }
+
+        fn at(minutes_after_start: i64) -> DateTime<Utc> {
+            "2025-03-20T02:00:00Z".parse::<DateTime<Utc>>().unwrap()
+                + chrono::Duration::minutes(minutes_after_start)
+        }
+
+        #[test]
+        fn over_schedule_warns_past_twice_the_scheduled_duration() {
+            let run = active_run(Some("30"));
+            // At exactly twice the schedule there is no warning yet …
+            assert_eq!(over_schedule_warning(&run, at(60)), None);
+            // … one minute past it, the warning names both durations.
+            let warning = over_schedule_warning(&run, at(61)).unwrap();
+            assert!(warning.contains("run run-w"), "got: {warning}");
+            assert!(warning.contains("1h1m"), "got: {warning}");
+            assert!(warning.contains("30m"), "got: {warning}");
+        }
+
+        #[test]
+        fn over_schedule_needs_a_usable_schedule_and_a_start() {
+            // No duration parameter, an unparsable one, and a zero schedule
+            // (which would flag every run that has run at all) never warn.
+            assert_eq!(over_schedule_warning(&active_run(None), at(1000)), None);
+            assert_eq!(
+                over_schedule_warning(&active_run(Some("bogus")), at(1000)),
+                None
+            );
+            assert_eq!(
+                over_schedule_warning(&active_run(Some("0")), at(1000)),
+                None
+            );
+
+            // A run that hasn't started has no elapsed time to compare.
+            let unstarted: RunDetail = serde_json::from_value(json!({
+                "run_id": "run-w",
+                "status": "starting",
+                "created_at": "2025-03-20T02:00:00Z",
+                "launcher": "nightly",
+                "parameters": {"antithesis.duration": "30"}
+            }))
+            .unwrap();
+            assert_eq!(over_schedule_warning(&unstarted, at(1000)), None);
         }
     }
 }

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -105,7 +105,17 @@ pub async fn cmd_runs(
             run_id,
             poll_interval,
             timeout,
-        }) => cmd_runs_wait(&run_id, poll_interval, timeout, settings, json, verbose).await,
+        }) => {
+            cmd_runs_wait(
+                &run_id,
+                poll_interval.as_duration(),
+                timeout,
+                settings,
+                json,
+                verbose,
+            )
+            .await
+        }
         Some(RunsCommands::Properties {
             run_id,
             passing,
@@ -364,10 +374,13 @@ fn open_run_report(run: &RunDetail, json: bool) -> Result<()> {
 
 /// `runs wait`: poll the run until it reaches a terminal state, then report
 /// the final status. The client is uncached (see
-/// [`crate::api::ResponseCache::Disabled`]) so every poll observes fresh state.
+/// [`crate::api::ResponseCache::Disabled`]) so every poll observes fresh
+/// state, and `timeout` bounds the whole wait — including any in-flight
+/// request, since the HTTP client has no read timeout (see `CONNECT_TIMEOUT`
+/// in api.rs) — so a hung request cannot outlive it.
 async fn cmd_runs_wait(
     run_id: &str,
-    poll_interval: HumanDuration,
+    poll_interval: std::time::Duration,
     timeout: Option<HumanDuration>,
     settings: &Settings,
     json: bool,
@@ -376,7 +389,18 @@ async fn cmd_runs_wait(
     debug!("waiting for run: {}", run_id);
 
     let api = AntithesisApi::new_uncached(settings, verbose)?;
-    let run = wait_with_timeout(&api, run_id, poll_interval, timeout).await?;
+    let wait = wait_for_run(&api, run_id, poll_interval);
+    let run = match timeout {
+        Some(limit) => match tokio::time::timeout(limit.as_duration(), wait).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(user_error(format!(
+                    "timed out waiting for run {run_id} after {limit}"
+                )));
+            }
+        },
+        None => wait.await?,
+    };
 
     if json {
         outln!(
@@ -393,39 +417,18 @@ async fn cmd_runs_wait(
     Ok(())
 }
 
-/// [`wait_for_run`] bounded by `timeout`. The timeout wraps the whole wait —
-/// including any in-flight request, since the HTTP client has no read timeout
-/// (see `CONNECT_TIMEOUT` in api.rs) — so a hung request cannot outlive it.
-async fn wait_with_timeout(
-    api: &AntithesisApi,
-    run_id: &str,
-    poll_interval: HumanDuration,
-    timeout: Option<HumanDuration>,
-) -> Result<RunDetail> {
-    let wait = wait_for_run(api, run_id, poll_interval);
-    match timeout {
-        Some(limit) => match tokio::time::timeout(limit.as_duration(), wait).await {
-            Ok(result) => result,
-            Err(_) => Err(user_error(format!(
-                "timed out waiting for run {run_id} after {limit}"
-            ))),
-        },
-        None => wait.await,
-    }
-}
-
 /// Poll `get_run` every `poll_interval` until the run reaches a terminal
 /// state. Status changes and warnings go to stderr; stdout stays reserved for
 /// the final result. A run that reports `unknown` fails the wait (see
 /// [`RunStatus::is_terminal`]).
 ///
-/// Never returns on its own — callers bound it with [`wait_with_timeout`].
+/// Never returns on its own — the caller bounds it with `tokio::time::timeout`.
 async fn wait_for_run(
     api: &AntithesisApi,
     run_id: &str,
-    poll_interval: HumanDuration,
+    poll_interval: std::time::Duration,
 ) -> Result<RunDetail> {
-    let mut poll = tokio::time::interval(poll_interval.as_duration());
+    let mut poll = tokio::time::interval(poll_interval);
     // A poll delayed by a slow response schedules the next one a full
     // interval later, instead of firing early to catch up.
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -5717,16 +5720,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_status_display_covers_every_variant() {
-        assert_eq!(RunStatus::Completed.to_string(), "completed");
-        assert_eq!(RunStatus::Incomplete.to_string(), "incomplete");
-        assert_eq!(RunStatus::InProgress.to_string(), "in_progress");
-        assert_eq!(RunStatus::Starting.to_string(), "starting");
-        assert_eq!(RunStatus::Cancelled.to_string(), "cancelled");
-        assert_eq!(RunStatus::Unknown.to_string(), "unknown");
-    }
-
     fn summary(
         run_id: &str,
         status: RunStatus,
@@ -6296,9 +6289,7 @@ mod tests {
 
         /// Sub-minute polling is fine below the CLI: the 1-minute floor is
         /// clap's, `wait_for_run` takes any interval.
-        fn fast_poll() -> HumanDuration {
-            "1s".parse().unwrap()
-        }
+        const FAST_POLL: Duration = Duration::from_millis(10);
 
         #[tokio::test]
         async fn wait_polls_until_the_run_completes() {
@@ -6306,7 +6297,7 @@ mod tests {
             mount_get_run_statuses(&server, &["starting", "in_progress", "completed"]).await;
             let api = test_api(&server.uri());
 
-            let run = wait_for_run(&api, "run-w", fast_poll()).await.unwrap();
+            let run = wait_for_run(&api, "run-w", FAST_POLL).await.unwrap();
 
             assert_eq!(run.status, RunStatus::Completed);
             // One poll per status: the loop stopped at the first terminal one.
@@ -6321,7 +6312,7 @@ mod tests {
                 mount_get_run_statuses(&server, &["in_progress", status]).await;
                 let api = test_api(&server.uri());
 
-                let run = wait_for_run(&api, "run-w", fast_poll()).await.unwrap();
+                let run = wait_for_run(&api, "run-w", FAST_POLL).await.unwrap();
                 assert_eq!(run.status.to_string(), status);
             }
         }
@@ -6332,7 +6323,7 @@ mod tests {
             mount_get_run_statuses(&server, &["in_progress", "unknown"]).await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
+            let err = wait_for_run(&api, "run-w", FAST_POLL).await.unwrap_err();
 
             let msg = format!("{err:#}");
             assert_eq!(msg, "run run-w reported status \"unknown\"", "got: {msg}");
@@ -6343,25 +6334,17 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn wait_times_out_on_a_run_that_never_finishes() {
+        async fn wait_never_returns_while_the_run_is_in_progress() {
             let server = MockServer::start().await;
             mount_get_run_statuses(&server, &["in_progress"]).await;
             let api = test_api(&server.uri());
 
-            let err = wait_with_timeout(
-                &api,
-                "run-w",
-                "1h".parse().unwrap(),
-                Some("1s".parse().unwrap()),
-            )
-            .await
-            .unwrap_err();
+            // cmd_runs_wait bounds the wait exactly like this.
+            let wait = wait_for_run(&api, "run-w", Duration::from_secs(3600));
+            tokio::time::timeout(Duration::from_secs(1), wait)
+                .await
+                .expect_err("a non-terminal run must keep the wait pending");
 
-            let msg = format!("{err:#}");
-            assert_eq!(
-                msg, "timed out waiting for run run-w after 1s",
-                "got: {msg}"
-            );
             // One immediate poll, then a one-hour tick the timeout cuts short.
             let requests = server.received_requests().await.unwrap();
             assert_eq!(requests.len(), 1);
@@ -6384,13 +6367,10 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_with_timeout(&api, "run-w", fast_poll(), Some("1s".parse().unwrap()))
+            let wait = wait_for_run(&api, "run-w", FAST_POLL);
+            tokio::time::timeout(Duration::from_secs(1), wait)
                 .await
-                .unwrap_err();
-            assert!(
-                format!("{err:#}").contains("timed out waiting for run run-w"),
-                "got: {err:#}"
-            );
+                .expect_err("a hung request must not outlive the timeout");
         }
 
         #[tokio::test]
@@ -6403,7 +6383,7 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "BAD-ID", fast_poll()).await.unwrap_err();
+            let err = wait_for_run(&api, "BAD-ID", FAST_POLL).await.unwrap_err();
             assert_eq!(format!("{err:#}"), "run not found: BAD-ID");
         }
 
@@ -6418,7 +6398,7 @@ mod tests {
                 .await;
             let api = test_api(&server.uri());
 
-            let err = wait_for_run(&api, "run-w", fast_poll()).await.unwrap_err();
+            let err = wait_for_run(&api, "run-w", FAST_POLL).await.unwrap_err();
             assert_eq!(api_error_status(&err), Some(500));
         }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -766,9 +766,8 @@ fn mock_run_not_found(run_id: &str) -> (u16, String) {
 }
 
 fn mock_route_get_run(run_id: &str) -> (u16, String) {
-    // `run-unknown-status` models a run the server cannot classify: `runs wait`
-    // must fail on it instead of polling forever. Kept out of MOCK_RUNS so the
-    // list-oriented specs don't see it.
+    // `run-unknown-status` is kept out of MOCK_RUNS so the list-oriented specs
+    // don't see it.
     if run_id == "run-unknown-status" {
         return (
             200,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -766,6 +766,16 @@ fn mock_run_not_found(run_id: &str) -> (u16, String) {
 }
 
 fn mock_route_get_run(run_id: &str) -> (u16, String) {
+    // `run-unknown-status` models a run the server cannot classify: `runs wait`
+    // must fail on it instead of polling forever. Kept out of MOCK_RUNS so the
+    // list-oriented specs don't see it.
+    if run_id == "run-unknown-status" {
+        return (
+            200,
+            r#"{"run_id":"run-unknown-status","status":"unknown","created_at":"2025-03-20T02:00:00Z","launcher":"nightly"}"#
+                .to_string(),
+        );
+    }
     let Some(&(_, status, created, launcher, description)) =
         MOCK_RUNS.iter().find(|(id, ..)| *id == run_id)
     else {


### PR DESCRIPTION
This adds `snouty runs wait RUN_ID`: poll a run until it reaches a terminal state (completed, cancelled, or incomplete), then print the run's details — the same output as `runs show`, and the same JSON under `--json`. The command exits 0 for every terminal state; the run's outcome is in the output, not the exit code. Progress goes to stderr: one line per status change, plus a one-time warning when a run has been active for more than twice its `antithesis.duration`. The wait holds no state beyond the run id, so an interrupted wait resumes with a re-run of the same command. `snouty launch --json | jq -r .runId | xargs snouty runs wait --json` is now a complete launch-to-report pipeline.

The poll bypasses snouty's response cache. The live API serves run detail with `Cache-Control: private, max-age=3600`, so a wait that polled through the cache could re-read a stale status for up to an hour. A new `AntithesisApi::new_uncached` constructor disables the cache for this command, and `build`'s cache parameter becomes an explicit `ResponseCache::{Default, Disabled, Dir}` enum — its old `Option<PathBuf>` doc claimed `None` disables caching, but `None` actually enabled the XDG default.

Decisions from the issue discussion:

- A run that reports status `unknown` fails the command and names the status the server sent; the caller decides what to do. A novel status string also fails, because the closed `RunStatus` enum rejects it at parse time.
- `--poll-interval` defaults to 60 seconds with a 30-second floor, enforced by clap.
- The wait is unbounded unless `--timeout SECONDS` is given. The final poll lands at the deadline instead of up to a full interval later, and the timeout error names the last status and the resume command.
- No `launch --block-until-complete` flag: a separate command resumes after interruption, which a launch flag cannot.

Tests split per the issue discussion: `specs/wait.txt` pins the static behavior against the static mock (terminal states, `unknown`, run-not-found, `--timeout 0`, help text, argument validation), and Rust integration tests in `src/runs.rs` transition a wiremock server between polls (starting → in_progress → completed, `unknown` mid-wait, timeout, 500 pass-through) at millisecond intervals. A new `run-unknown-status` mock fixture backs the spec. `RunStatus` gains an `is_terminal` helper. The gallery gains `runs-wait` and `help-runs-wait` stories. The staging spec suite passes against a live tenant, and a manual smoke test on a real completed run prints the detail card and exits 0.

fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
