### PR TITLE
Fix the gallery harness, and restore the API-key default in login

### DIFF
--- a/.claude/skills/satisfaction-review/SKILL.md
+++ b/.claude/skills/satisfaction-review/SKILL.md
@@ -120,8 +120,8 @@ content, not the exact path.
 
 Read every story file. For the **large** outputs (e.g. `runs-build-logs`,
 `runs-logs-incomplete` can be tens/hundreds of KB) do **not** read the whole
-file — measure its width with the tool below and read only the head and tail to
-judge structure. For everything else, read the full file.
+file — read the head and tail and judge the structure from those. For everything
+else, read the full file.
 
 ## Step 3 — Judge each story on three axes
 
@@ -158,26 +158,27 @@ command**? Concretely:
 If a needed coordinate is truncated, omitted, or buried, that's a follow-up
 failure even if the command "worked".
 
-### Axis C — Terminal rendering at ~140 columns
-Assume an average terminal is **140 characters wide**. Measure the widest line
-of actual command output per story:
+### Axis C — Terminal rendering
+Judge how the output reads in a terminal. There is no width threshold to check
+against and no measurement to run: a number tells you a line is long, not
+whether that hurts. Read the output and decide.
 
-```bash
-for f in "$GALLERY"/*.md; do
-  awk -v fn="$(basename "$f")" '
-    /^```/        { infence = !infence; next }
-    infence       { n++; if (length($0) > max) max = length($0) }
-    END           { printf "%-34s width=%-4d lines=%d\n", fn, max+0, n+0 }
-  ' "$f"
-done | sort -t= -k2 -rn
-```
+**Long lines.** A line longer than the terminal wraps, and wrapping is only
+sometimes a problem. Ask what the wrap does to the reader:
+- A wrapped **table row** is the bad case: continuation text lands under the
+  wrong columns and every row after it is harder to scan. Flag it.
+- A wrapped **prose field** (a run description, a `Details` paragraph) is worse
+  when it runs under the label column with no indent, and fine when snouty
+  wraps and indents it itself. Flag the first, not the second.
+- A long **opaque token** — a signed report URL, an image digest, a log line
+  from the tested system — has to be long. Do not flag it; snouty cannot
+  shorten it and truncating it would be worse.
+- Output behind a **debugging flag** (`--verbose`) is meant to be bulky. Do not
+  flag width there.
+Say what the wrap breaks and roughly how wide the line is, rather than quoting a
+threshold.
 
-Interpret the widest-line width:
-- **≤ 140** → fits cleanly (✅).
-- **141–160** → wraps a little; usually ⚠️ unless the wrap mangles a table.
-- **> 160** → likely wraps badly; tables become unreadable, columns desync (❌).
-
-Also judge rendering quality beyond raw width:
+**Also judge rendering quality beyond line length:**
 - **Wasted width**: mostly-empty columns padded to a huge fixed width (e.g. a
   `GROUP` column padded ~45 chars when most rows are blank), or full-precision
   floats (e.g. `vtime` printed as `18.310608921106905`) eating horizontal space.
@@ -187,6 +188,8 @@ Also judge rendering quality beyond raw width:
 - **Truncation**: is `…`-truncation hiding information the user needs (Axis B
   overlap), or is it reasonable?
 - **Density**: walls of near-identical lines, redundant repetition, no grouping.
+- **Stray control characters**: raw escape sequences (e.g. a literal `[K`) that
+  a terminal would hide but a piped or CI-captured log shows.
 
 ### TTY stories (`login-*`)
 These are `snouty login` runs, so reinterpret the axes — the deliverable is a
@@ -202,7 +205,7 @@ prompt conversation plus files written, not a table:
   verify")? A login that exits `0` in silence — never confirming what it wrote —
   is an Axis B failure even though the file is correct. For the error/repair
   paths, does the message say what went wrong *and* how to recover?
-- **Axis C (rendering):** less about 140-col tables, more about **prompt clarity
+- **Axis C (rendering):** less about tables, more about **prompt clarity
   and secret hygiene** — is the menu readable, are previous-value defaults shown
   legibly, and is a secret never echoed into any frame? A stored secret should
   appear only as a masked hint, never whole.
@@ -243,9 +246,9 @@ Reviewed by: Claude (<model>), <date>
 
 ## Summary table
 
-| Story (slug) | Correct | Follow-up | Render (width) | Verdict | Top issue |
+| Story (slug) | Correct | Follow-up | Render | Verdict | Top issue |
 |---|---|---|---|---|---|
-| runs-list | ✅ | ⚠️ | ✅ (98) | partial | desc truncated with … |
+| runs-list | ✅ | ⚠️ | ✅ | partial | desc truncated with … |
 | ... |
 
 ## Per-story detail
@@ -254,7 +257,7 @@ Reviewed by: Claude (<model>), <date>
 `$ snouty <args>`
 - **Correct:** <✅/⚠️/❌> — <rationale>
 - **Follow-up:** <✅/⚠️/❌> — <rationale>
-- **Render:** <✅/⚠️/❌> (widest <N> cols) — <rationale>
+- **Render:** <✅/⚠️/❌> — <rationale; name what a wrap breaks, if anything>
 - **Fix:** <concrete suggestion, or "none — satisfied">
 ```
 
@@ -280,10 +283,10 @@ Guidance for a high-signal report:
 - The gallery is pinned to whatever live run IDs were fresh at generation time,
   so exact IDs/values differ between runs. Judge the *shape and quality* of the
   output, not the specific data.
-- Width and rendering are judged for a plain ~140-col terminal; snouty may
-  detect a wider TTY when run interactively, but the gallery captures
-  non-interactive output, which is the conservative case worth reviewing. The
-  TTY stories are the exception: they run on a real 120-col terminal, so a line
+- Rendering is judged for an ordinary terminal, without a fixed width to check
+  against. The gallery captures non-interactive output, which is the
+  conservative case: snouty may detect a wider TTY when run by hand. The TTY
+  stories are the exception — they run on a real 120-column terminal, so a line
   that wraps there wraps for the user too.
 - The `login-*` stories run in a throwaway `$HOME` that is removed after capture,
   and are fed fake secrets that are redacted again in the file — so the "Persisted

--- a/.claude/skills/satisfaction-review/SKILL.md
+++ b/.claude/skills/satisfaction-review/SKILL.md
@@ -71,19 +71,31 @@ _Automated check: PASS|FAIL — <detail>_
 (Help stories show an `Exit code:` line under each command block — the `--help`,
 the default output, and every variant.)
 
-**Interactive / stateful stories** (the `login-*` slugs) have a different shape.
-`snouty login` reads answers from stdin and *writes files*, so instead of a
-single output block these stories show:
+**TTY stories** (the `login-*` slugs) have a different shape. `snouty login`
+holds a conversation on a terminal and *writes files*, so instead of a single
+output block these stories show one **frame** per prompt — the screen exactly as
+the user saw it at that moment — then the persisted files:
 
 ```
-## Transcript
+## Conversation
 ```shell
 $ snouty login
-# stdin> acme                     ← the answers fed to each prompt, in order
-# stdin> registry.example.com/...
-<the prompt transcript snouty printed>
+```
+
+### At `What kind of credentials`   ← one frame per prompt, in order
+```
+> What Antithesis tenant would you like to use? acme
+? What kind of credentials would you like to use? (Hit Esc to skip)
+> API Key
+  Username & password (deprecated)
+```
+
+### At `[after it exits]`           ← the closing screen
+```
+...
 ```
 Exit code: `<n>`
+_Replay the session: `asciinema play login-fresh-apikey.cast`_
 
 ## Persisted state
 `~/.config/snouty/settings.toml`      ← the files login actually wrote,
@@ -92,7 +104,17 @@ Exit code: `<n>`
 ```                                      deliberately not created
 ```
 
-Judge these on the transcript **and** the persisted state together (see Step 3).
+Read the frames in order — they are the conversation. A menu is erased once
+chosen, so its options appear only in the frame taken while it was on screen;
+the closing frame shows just the answer that won. A frame headed
+`[gallery] waiting for …` means the harness stalled, not that snouty misbehaved:
+report it as a harness problem rather than judging the story.
+
+Each story also ships a `.cast` beside it. Run `asciinema play <slug>.cast` when
+a frame leaves you unsure how something felt to type — pacing and redraws show
+up there and nowhere else.
+
+Judge these on the frames **and** the persisted state together (see Step 3).
 They run in a throwaway `$HOME`, so the paths are temp dirs — judge the shape and
 content, not the exact path.
 
@@ -166,14 +188,15 @@ Also judge rendering quality beyond raw width:
   overlap), or is it reasonable?
 - **Density**: walls of near-identical lines, redundant repetition, no grouping.
 
-### Interactive / stateful stories (`login-*`)
+### TTY stories (`login-*`)
 These are `snouty login` runs, so reinterpret the axes — the deliverable is a
 prompt conversation plus files written, not a table:
 - **Axis A (correctness):** were the prompts the right ones, in a sensible order,
   and *only* for values not already known (a flag or a stored previous value
   shouldn't be re-prompted)? Was invalid input rejected? And — judged against the
-  **Persisted state** section, not just stdout — did it write the *correct*
-  result (right tenant/repo, right credential type, right `[profile.x]` scope)?
+  **Persisted state** section, not just the closing frame — did it write the
+  *correct* result (right tenant/repo, right credential type, right
+  `[profile.x]` scope)?
 - **Axis B (follow-up readiness):** after it finishes, does the user know **what
   was saved, where, and the obvious next step** (e.g. "run `snouty doctor` to
   verify")? A login that exits `0` in silence — never confirming what it wrote —
@@ -181,8 +204,9 @@ prompt conversation plus files written, not a table:
   paths, does the message say what went wrong *and* how to recover?
 - **Axis C (rendering):** less about 140-col tables, more about **prompt clarity
   and secret hygiene** — is the menu readable, are previous-value defaults shown
-  legibly, and is the password never echoed into the transcript?
-- **Axis D — safety of a mutating command** (interactive/stateful stories only):
+  legibly, and is a secret never echoed into any frame? A stored secret should
+  appear only as a masked hint, never whole.
+- **Axis D — safety of a mutating command** (TTY stories only):
   before overwriting or discarding existing state, does it warn and/or back up
   (e.g. `settings.toml.bak`)? Does it scope writes to the intended profile? Does a
   rejected/aborted run leave nothing half-written? A mutating command that
@@ -258,9 +282,15 @@ Guidance for a high-signal report:
   output, not the specific data.
 - Width and rendering are judged for a plain ~140-col terminal; snouty may
   detect a wider TTY when run interactively, but the gallery captures
-  non-interactive output, which is the conservative case worth reviewing.
+  non-interactive output, which is the conservative case worth reviewing. The
+  TTY stories are the exception: they run on a real 120-col terminal, so a line
+  that wraps there wraps for the user too.
 - The `login-*` stories run in a throwaway `$HOME` that is removed after capture,
   and are fed fake secrets that are redacted again in the file — so the "Persisted
   state" you review never contains a real credential or touches real config. On
   Linux these exercise the file-backed credential store (the keychain is a no-op
   there), which is the realistic default for a CI/gallery run.
+- The `login-*` stories contact the tenant for real: snouty asks it whether
+  single sign-on is available before drawing the credential menu. The menu you
+  see is therefore the menu that tenant gives, and it may differ between runs —
+  judge the menu you were shown, not the one you expected.

--- a/.claude/skills/satisfaction-review/SKILL.md
+++ b/.claude/skills/satisfaction-review/SKILL.md
@@ -106,9 +106,11 @@ _Replay the session: `asciinema play login-fresh-apikey.cast`_
 
 Read the frames in order — they are the conversation. A menu is erased once
 chosen, so its options appear only in the frame taken while it was on screen;
-the closing frame shows just the answer that won. A frame headed
-`[gallery] waiting for …` means the harness stalled, not that snouty misbehaved:
-report it as a harness problem rather than judging the story.
+the closing frame shows just the answer that won. Any frame whose heading starts
+with `[gallery]` marks a harness problem, not a snouty defect — report it as
+such rather than judging the story. There are two: `[gallery] waiting for …`
+means a prompt never arrived, and `[gallery] answering …` means the screen did
+not offer what the step meant to choose (usually a changed menu).
 
 Each story also ships a `.cast` beside it. Run `asciinema play <slug>.cast` when
 a frame leaves you unsure how something felt to type — pacing and redraws show

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,8 @@ After changing `gen-gallery.py`, type-check it with pyright and confirm it
 reports 0 errors before considering the change done:
 
 ```
-uvx pyright scripts/gen-gallery.py
+uv sync                             # so ./.venv holds the dependencies
+uvx pyright scripts/gen-gallery.py  # `[tool.pyright]` points it at ./.venv
 ```
 
 ## AI Coding Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `snouty login` offers a stored API key back at the prompt, shown as a masked hint, so hitting enter keeps it instead of saving an empty key ([#219](https://github.com/antithesishq/snouty/issues/219))
 - `snouty validate` reads the SDK output file from the start instead of tailing it, so a setup-complete event written over bytes snouty had already read is still detected ([#218](https://github.com/antithesishq/snouty/pull/218))
 - Add `snouty runs exec`: run a bash script in a run's live session at a given moment, on a fresh branch of the multiverse. The command is gated behind the `runs-exec` unstable feature (`SNOUTY_UNSTABLE_FEATURES=runs-exec`), because the API it calls is unstable and unavailable on most tenants ([#208](https://github.com/antithesishq/snouty/pull/208))
 - snouty now requires Docker Compose v2.24.7 or newer, checked up front ([#214](https://github.com/antithesishq/snouty/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
 
-- `snouty login` offers a stored API key back at the prompt, shown as a masked hint, so hitting enter keeps it instead of saving an empty key ([#219](https://github.com/antithesishq/snouty/issues/219))
 - `snouty validate` reads the SDK output file from the start instead of tailing it, so a setup-complete event written over bytes snouty had already read is still detected ([#218](https://github.com/antithesishq/snouty/pull/218))
 - Add `snouty runs exec`: run a bash script in a run's live session at a given moment, on a fresh branch of the multiverse. The command is gated behind the `runs-exec` unstable feature (`SNOUTY_UNSTABLE_FEATURES=runs-exec`), because the API it calls is unstable and unavailable on most tenants ([#208](https://github.com/antithesishq/snouty/pull/208))
 - snouty now requires Docker Compose v2.24.7 or newer, checked up front ([#214](https://github.com/antithesishq/snouty/pull/214))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,28 @@
 #
 # These scripts are run with `uv` (e.g. `uv run scripts/gen-gallery.py`), which
 # uses this file to pin a consistent Python version and to manage dependencies
-# in one place rather than per-script inline metadata. No third-party
-# dependencies are needed today; add them to `dependencies` below as required.
+# in one place rather than per-script inline metadata.
 [project]
 name = "snouty-scripts"
 version = "0.0.0"
 description = "Python helper scripts for snouty, run via uv."
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    # The gallery's TTY stories drive an interactive snouty command on a real
+    # pseudo-terminal and replay what it drew. `pexpect` runs the dialogue;
+    # `pyte` emulates the terminal, turning the raw byte stream (ANSI escapes
+    # and one re-render per keystroke) back into the screen the user saw.
+    "pexpect>=4.9",
+    "pyte>=0.8.2",
+]
 
 [tool.uv]
 # Scripts only — there is no installable package to build here.
 package = false
+
+[tool.pyright]
+# `uv run` installs the dependencies above into `./.venv`. Name it here so
+# `uvx pyright scripts/…` — which runs pyright in an environment of its own —
+# resolves those imports rather than reporting every one as missing.
+venvPath = "."
+venv = ".venv"

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -371,6 +371,9 @@ class TtySession:
         try:
             self.child.expect(pexpect.EOF)
         except pexpect.TIMEOUT:
+            # The child is still up after a dialogue that should have ended it —
+            # a stalled story, already recorded as a marker frame. Fall through
+            # to the forced close, which is what ends it.
             pass
         self.child.close(force=True)
         # A child killed after a stall has no exit status of its own; report it
@@ -426,9 +429,12 @@ def drive_tty(
             frames.append((f"[gallery] answering {prompt!r}: {e}", session.frame()))
             break
     returncode = session.finish()
-    frames.append(("[after it exits]", session.frame()))
+    # The child has exited, so nothing can feed the emulator from here: one
+    # closing screen serves as both the last frame and the story's output.
+    closing = session.frame()
+    frames.append(("[after it exits]", closing))
     return (
-        Result(args, session.frame(), "", returncode),
+        Result(args, closing, "", returncode),
         frames,
         session.cast(_command_line(args)),
     )

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -2239,9 +2239,9 @@ def build_validate_stories(ephemeral: Path | None) -> list[Story]:
 
 # Fake, obviously-not-real secrets typed at the prompts — never a real
 # credential, and redacted again before embedding (see `_redact_secrets`).
-_FAKE_KEY = "sk-FAKE-not-a-real-key"
+_FAKE_KEY = "antithesis_api_key_v2_NOTAREALKEY_7Qxz"
 _FAKE_PASS = "FAKE-not-a-real-password"
-_SEED_KEY = "sk-SEED-not-a-real-key"
+_SEED_KEY = "antithesis_api_key_v2_NOTAREALSEED_9Pgw"
 _TENANT = "acme"
 _REPO = "registry.example.com/acme/app"
 _SETTINGS = ".config/snouty/settings.toml"

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -9,7 +9,7 @@ story is also gated by a programmatic check; a degenerate example (an empty
 table, an unintended error, a filter that didn't narrow) fails the run rather
 than being silently emitted.
 
-There are two kinds of story:
+There are three kinds of story:
 
   * goal stories — capture one command's output and judge it against a user goal
     (the bulk of the gallery; slugs like `runs-events-single`).
@@ -19,6 +19,10 @@ There are two kinds of story:
     prints. Commands that mutate state or need an interactive arg (launch,
     debug, validate, update, completions) are help-only. An automated check
     verifies any column/field the help names actually appears in the output.
+  * TTY stories — drive an interactive command (today only `snouty login`) on a
+    real pseudo-terminal and record the conversation: one *frame* per prompt,
+    an asciinema recording to replay, and the files the command persisted. See
+    "TTY stories" below.
 
 Credentials come from the usual ANTITHESIS_* environment variables (snouty reads
 them). Behaviour is controlled with flags, not env vars:
@@ -43,11 +47,15 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
+
+import pexpect
+import pyte
 
 # A syntactically-valid but nonexistent run id, for clean-error stories.
 UNKNOWN_RUN = "ffffffffffffffffffffffffffffffff-54-5"
@@ -124,46 +132,29 @@ class Snouty:
     def cleanup(self) -> None:
         shutil.rmtree(self._shim, ignore_errors=True)
 
+    def env_with(self, overrides: dict[str, str | None]) -> dict[str, str]:
+        """The environment a snouty child inherits, with `overrides` applied: a
+        string sets a var, None removes it (so a story can model an environment
+        missing some credential). Everything else inherits the live
+        ANTITHESIS_* env."""
+        env = dict(self._env)
+        for key, value in overrides.items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value
+        return env
+
     def run(
         self,
         args: list[str],
         env: dict[str, str | None] | None = None,
-        stdin: str | None = None,
-        merge_streams: bool = False,
     ) -> Result:
-        # `env` overrides individual vars for this call only: a string sets the
-        # var, None unsets it (so a story can model an environment missing some
-        # credential). Everything else inherits the live ANTITHESIS_* env.
-        # `stdin`, when given, is fed to the process's standard input — used by the
-        # interactive stories (`snouty login`) that read answers line-by-line.
-        # `merge_streams` interleaves stderr into stdout at capture time, which
-        # preserves interaction order for prompt transcripts: login prints its
-        # prompts and warnings on different streams, and capturing them apart
-        # reorders the conversation.
-        run_env = self._env
-        if env is not None:
-            run_env = dict(self._env)
-            for key, value in env.items():
-                if value is None:
-                    run_env.pop(key, None)
-                else:
-                    run_env[key] = value
-        if merge_streams:
-            proc = subprocess.run(
-                [str(self.binary), *args],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=run_env,
-                input=stdin,
-            )
-            return Result(args, proc.stdout, "", proc.returncode)
         proc = subprocess.run(
             [str(self.binary), *args],
             capture_output=True,
             text=True,
-            env=run_env,
-            input=stdin,
+            env=self._env if env is None else self.env_with(env),
         )
         return Result(args, proc.stdout, proc.stderr, proc.returncode)
 
@@ -194,6 +185,246 @@ class Snouty:
                 f"{res.stderr.strip() or '<no stderr>'}"
             )
         return json.loads(res.stdout)
+
+
+# ---------------------------------------------------------------------------
+# TTY driver: run an interactive command on a real pseudo-terminal.
+#
+# `snouty login` prompts through `inquire`, which engages only when stdin is a
+# terminal — piping answers at it takes the non-interactive path instead. A TTY
+# story therefore spawns snouty on a pseudo-terminal and types at it.
+#
+# What the terminal receives is not readable as it stands: `inquire` redraws the
+# whole prompt on every keystroke, in ANSI escapes. `pyte` replays that stream
+# the way a terminal would, so a *frame* is the screen exactly as it stood at
+# one moment. The same stream is written out as an asciinema v2 recording, which
+# `asciinema play` replays at its original speed.
+# ---------------------------------------------------------------------------
+
+
+# The keys a dialogue step types: either a literal string, or — when they depend
+# on what snouty drew — a function of the settled screen (see `pick`).
+Keys = str | Callable[[list[str]], str]
+
+# One step of a dialogue: text to wait for on screen, then the keys to type once
+# it is there. Every send is gated on its prompt being rendered, so no keystroke
+# can race ahead of the prompt meant to read it.
+Step = tuple[str, Keys]
+
+# One frame: the prompt that was waiting, and the screen at that moment.
+Frame = tuple[str, str]
+
+# Keys a step can send. `inquire` holds the terminal in raw mode for a prompt's
+# whole lifetime, so these arrive as key events rather than line-edited text.
+ENTER = "\r"
+DOWN = "\x1b[B"
+UP = "\x1b[A"
+
+# The pseudo-terminal's size. 120 columns keeps snouty's own lines — which carry
+# absolute paths under the throwaway `$HOME` — clear of the wrap boundary, so a
+# reviewer judges snouty's wording rather than the sandbox's path length. 40
+# rows fits a whole login on one screen.
+TTY_COLS = 120
+TTY_ROWS = 40
+
+# How long to wait for one prompt. Generous: a healthy exchange completes in
+# milliseconds, but the credential menu waits on snouty probing the tenant for
+# its OAuth configuration first.
+PROMPT_TIMEOUT = 30
+
+# How long the output must stay quiet before a frame is taken. A prompt matches
+# mid-stream, so without this the frame would catch a half-drawn screen.
+SETTLE = 0.2
+
+# `inquire`'s row prefixes (see its RenderConfig defaults): the prompt still
+# being answered leads with `?`, one already answered with `>`, the highlighted
+# menu row with `>`, and every other menu row with a space. Each is followed by
+# one more space.
+LIVE_PROMPT = "? "
+HIGHLIGHTED = "> "
+UNHIGHLIGHTED = "  "
+
+
+def pick(prompt: str, label: str) -> Step:
+    """A step that chooses `label` from an `inquire` menu: move the highlight
+    onto that row, then select it.
+
+    The keys are read off the screen rather than fixed, because the menu's
+    contents depend on the tenant — `snouty login` offers single sign-on only
+    where the tenant enables it — so a fixed count of arrow presses would land
+    on the wrong row."""
+
+    def keys(screen: list[str]) -> str:
+        options = _menu_options(screen)
+        labels = [text for text, _ in options]
+        if label not in labels:
+            raise GalleryError(f"menu has no {label!r} option; it offers {labels}")
+        highlighted = next((i for i, (_, on) in enumerate(options) if on), 0)
+        distance = labels.index(label) - highlighted
+        arrow = DOWN if distance > 0 else UP
+        return arrow * abs(distance) + ENTER
+
+    return (prompt, keys)
+
+
+def _menu_options(screen: list[str]) -> list[tuple[str, bool]]:
+    """Every option of the `inquire` menu on `screen`: its label, and whether it
+    is the highlighted one.
+
+    The menu sits under the prompt still being answered — the last line leading
+    with `?`, since an answered prompt is redrawn with `>`. Its options are the
+    rows below that, up to the first row that is neither highlighted nor
+    indented (the help line, or a blank row past the end of the menu)."""
+    live = [i for i, line in enumerate(screen) if line.startswith(LIVE_PROMPT)]
+    if not live:
+        return []
+    options: list[tuple[str, bool]] = []
+    for line in screen[live[-1] + 1 :]:
+        if line.startswith(HIGHLIGHTED):
+            options.append((line[2:].strip(), True))
+        elif line.startswith(UNHIGHLIGHTED) and line.strip():
+            options.append((line[2:].strip(), False))
+        else:
+            break
+    return options
+
+
+class _Recorder:
+    """Sink for everything the child writes.
+
+    `pexpect` hands its `logfile_read` every byte it reads, once and in order —
+    unlike `before`/`after`, which repeat whatever is still in its buffer. Each
+    chunk is timestamped for the recording and fed to the terminal emulator for
+    the frames."""
+
+    def __init__(self, screen: pyte.Screen):
+        self.started = time.monotonic()
+        self.events: list[tuple[float, bytes]] = []
+        self.stream = pyte.ByteStream(screen)
+
+    def write(self, data: bytes) -> None:
+        if data:
+            self.events.append((time.monotonic() - self.started, data))
+            self.stream.feed(data)
+
+    def flush(self) -> None:
+        pass
+
+
+class TtySession:
+    """One interactive snouty run on a pseudo-terminal.
+
+    Holds the child, the bytes it has written (kept whole, for the recording),
+    and a terminal emulator fed the same bytes (for the frames)."""
+
+    def __init__(self, binary: Path, args: list[str], env: dict[str, str]):
+        self.screen = pyte.Screen(TTY_COLS, TTY_ROWS)
+        self.recorder = _Recorder(self.screen)
+        # `echo=False` stops the terminal driver echoing what we type, so a
+        # secret can only reach the screen if snouty itself renders it — which
+        # is exactly what the `secrets_absent` check asserts.
+        self.child = pexpect.spawn(
+            str(binary),
+            args,
+            env=env,
+            dimensions=(TTY_ROWS, TTY_COLS),
+            timeout=PROMPT_TIMEOUT,
+            echo=False,
+            encoding=None,
+        )
+        # `logfile_read` is an attribute rather than a constructor argument.
+        # Setting it here still catches every byte: pexpect reads the child only
+        # when asked to, and nothing has asked yet.
+        self.child.logfile_read = self.recorder
+
+    def wait_for(self, needle: str) -> None:
+        """Consume output through `needle`, then let the prompt finish drawing."""
+        self.child.expect_exact(needle.encode())
+        self.settle()
+
+    def settle(self) -> None:
+        """Wait until the output has stayed quiet for `SETTLE`, so a frame
+        catches a settled screen rather than a half-drawn one. A prompt matches
+        mid-stream, and `inquire` draws a menu's rows after its question.
+        Matching on TIMEOUT is how pexpect waits for silence."""
+        self.child.expect([pexpect.TIMEOUT, pexpect.EOF], timeout=SETTLE)
+
+    def send(self, keys: str) -> None:
+        self.child.send(keys.encode())
+
+    def frame(self) -> str:
+        """The screen as it stands, trailing blank rows dropped."""
+        rows = [row.rstrip() for row in self.screen.display]
+        while rows and not rows[-1]:
+            rows.pop()
+        return "\n".join(rows)
+
+    def finish(self) -> int:
+        """Wait for the child to exit and return its status."""
+        try:
+            self.child.expect(pexpect.EOF)
+        except pexpect.TIMEOUT:
+            pass
+        self.child.close(force=True)
+        # A child killed after a stall has no exit status of its own; report it
+        # as a failure so the story's check fails rather than reading as clean.
+        return 1 if self.child.exitstatus is None else self.child.exitstatus
+
+    def cast(self, command: str) -> str:
+        """The session as an asciinema v2 recording: a header line, then one
+        `[time, "o", data]` line per chunk the terminal received."""
+        header = {
+            "version": 2,
+            "width": TTY_COLS,
+            "height": TTY_ROWS,
+            "timestamp": int(time.time()),
+            "command": command,
+            "env": {"TERM": "xterm-256color"},
+        }
+        lines = [json.dumps(header)]
+        for at, data in self.recorder.events:
+            lines.append(json.dumps([round(at, 6), "o", data.decode("utf-8", "replace")]))
+        return "\n".join(lines) + "\n"
+
+
+def drive_tty(
+    binary: Path,
+    args: list[str],
+    env: dict[str, str],
+    dialogue: tuple[Step, ...],
+) -> tuple[Result, list[Frame], str]:
+    """Run `snouty <args>` on a pseudo-terminal, typing `dialogue` at it.
+
+    Returns the run's result (its output is the final screen), one frame per
+    step — the screen the user faced when that prompt asked for an answer — plus
+    a closing frame, and the asciinema recording.
+
+    A step that cannot be taken — its prompt never arrives, or the screen does
+    not offer what the step meant to choose — is reported in the frames and as a
+    failing exit, so it shows up in that one story rather than aborting the whole
+    gallery."""
+    session = TtySession(binary, args, env)
+    frames: list[Frame] = []
+    for prompt, keys in dialogue:
+        try:
+            session.wait_for(prompt)
+        except (pexpect.TIMEOUT, pexpect.EOF) as e:
+            stalled = "no output" if isinstance(e, pexpect.TIMEOUT) else "snouty exited"
+            frames.append((f"[gallery] waiting for {prompt!r}: {stalled}", session.frame()))
+            break
+        frames.append((prompt, session.frame()))
+        try:
+            session.send(keys if isinstance(keys, str) else keys(session.screen.display))
+        except GalleryError as e:
+            frames.append((f"[gallery] answering {prompt!r}: {e}", session.frame()))
+            break
+    returncode = session.finish()
+    frames.append(("[after it exits]", session.frame()))
+    return (
+        Result(args, session.frame(), "", returncode),
+        frames,
+        session.cast(f"snouty {' '.join(args)}"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -620,16 +851,13 @@ class Story:
     # validate stories require a container runtime (see `ensure_validate_runtime`);
     # this flag just documents which ones spin up live containers.
     needs_docker: bool = False
-    # -- interactive / stateful stories (`snouty login`) -------------------
-    # When `sandbox_home` is set the story is an interactive, stateful story: it
-    # runs in a throwaway `$HOME` so the credentials/settings it persists never
-    # touch the operator's real config, and `post_capture` files are read back
-    # from that HOME and shown as the command's result. `stdin` feeds the
-    # interactive prompts their answers.
-    sandbox_home: bool = False
-    # Scripted answers fed to the command's stdin, one per line (login prompts).
-    stdin: str | None = None
-    # Files to pre-write into the sandbox HOME before running, keyed by
+    # -- TTY stories -------------------------------------------------------
+    # A story with a `dialogue` is a TTY story: snouty is spawned on a real
+    # pseudo-terminal and the dialogue is typed at it, one `(wait for, send)`
+    # step per prompt. It runs in a throwaway `$HOME` so the credentials and
+    # settings it persists never touch the operator's real config.
+    dialogue: tuple[Step, ...] | None = None
+    # Files to pre-write into the throwaway HOME before running, keyed by
     # HOME-relative path — models pre-existing state (a prior login, a broken
     # settings file). Mirrors the spec fixtures' txtar `-- path --` sections.
     seed_files: dict[str, str] | None = None
@@ -646,8 +874,12 @@ class StoryRun:
     help_result: Result | None = None  # `<help_cmd> --help` capture, for help stories
     sample_results: list[tuple[str, Result]] | None = None  # extra labelled captures
     # (rel_path, contents|None) for each `post_capture` file, in order; None means
-    # the file was not written (which some login stories assert on).
+    # the file was not written (which some TTY stories assert on).
     captured_files: list[tuple[str, str | None]] | None = None
+    # TTY stories: the screen at each prompt, and the asciinema recording of the
+    # whole session.
+    frames: list[Frame] | None = None
+    cast: str | None = None
 
 
 class Registry:
@@ -751,7 +983,14 @@ def _captured(sr: StoryRun, rel_path: str) -> str | None:
     return None
 
 
-def login_persisted(
+def _shown(sr: StoryRun) -> str:
+    """Everything a TTY story put on screen: every frame, not just the last one.
+    A menu is erased once chosen, so its options survive only in the frame taken
+    while it was up."""
+    return "\n".join(screen for _, screen in sr.frames or [])
+
+
+def tty_persisted(
     *,
     prompts: tuple[str, ...] = (),
     absent_prompts: tuple[str, ...] = (),
@@ -760,15 +999,15 @@ def login_persisted(
     secrets_absent: tuple[str, ...] = (),
     expect_ok: bool = True,
 ):
-    """Gate an interactive login story. Combines the concerns a single login
-    story cares about: the command exits with the expected success/failure; the
-    expected `prompts` all appear in the transcript and no `absent_prompts` do;
-    each `(rel_path, needles)` in `files` was written and contains every needle;
-    each path in `absent_files` was NOT written; and no raw `secrets_absent` value
-    leaks into the transcript. Any failure lists what went wrong."""
+    """Gate a TTY story. Combines the concerns one such story cares about: the
+    command exits with the expected success/failure; the expected `prompts` all
+    appear on screen and no `absent_prompts` do; each `(rel_path, needles)` in
+    `files` was written and contains every needle; each path in `absent_files`
+    was NOT written; and no raw `secrets_absent` value ever reached the screen.
+    Any failure lists what went wrong."""
 
     def chk(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
-        text = sr.result.combined
+        text = _shown(sr)
         problems: list[str] = []
 
         if sr.result.ok != expect_ok:
@@ -796,7 +1035,7 @@ def login_persisted(
 
         leaked = [s for s in secrets_absent if s in text]
         if leaked:
-            problems.append(f"secret leaked into transcript={leaked!r}")
+            problems.append(f"secret reached the screen={leaked!r}")
 
         return (not problems, "; ".join(problems) or "prompts + persisted state as expected")
 
@@ -1445,14 +1684,14 @@ def build_stories(d: Discovery) -> list[Story]:
             "I only have a legacy username and password",
             "I authenticate with a username/password and no API key; I want doctor to tell me whether that's enough.",
             "doctor warns the API key is missing (so `snouty runs` and other API commands won't work), "
-            "flags username/password as legacy auth limited to `snouty launch`/`snouty debug`, and steers "
-            "me toward setting an API key.",
+            "flags username/password as deprecated and limited to `snouty launch`/`snouty debug`, and "
+            "steers me toward setting an API key.",
             ["doctor"],
             doctor_check(
                 contains=(
                     "API key not provided",
                     "ANTITHESIS_USERNAME",
-                    "legacy",
+                    "deprecated",
                     "snouty launch",
                     "ask Antithesis support",
                 ),
@@ -1918,28 +2157,46 @@ def build_validate_stories(ephemeral: Path | None) -> list[Story]:
 
 
 # ---------------------------------------------------------------------------
-# Login stories: `snouty login` is interactive (reads answers from stdin) and
-# stateful (writes settings.toml/credentials.toml). Each runs in a throwaway
-# `$HOME`, feeds scripted answers, and captures the files it wrote so a reviewer
-# can judge both the prompt transcript AND the persisted result. No API,
-# discovery, or container runtime is needed. On Linux the keychain is a no-op, so
-# credentials land in the file backend — the realistic default here.
+# TTY stories: `snouty login` holds a conversation on a terminal and writes
+# settings.toml/credentials.toml as it goes. Each story runs in a throwaway
+# `$HOME`, types a scripted dialogue at a real pseudo-terminal, and captures both
+# the screens and the files written, so a reviewer judges the conversation AND
+# its result. No API, discovery, or container runtime is needed. On Linux the
+# keychain is a no-op, so credentials land in the file backend — the realistic
+# default here.
+#
+# The tenant is contacted for real: `snouty login` asks it whether single
+# sign-on is available before it draws the credential menu, so the menu a story
+# shows is the menu that tenant gives. That is the point — the gallery shows
+# what a human would see. It also means the menu's contents are not fixed, which
+# is why `pick` finds its row on screen instead of counting keypresses.
 # ---------------------------------------------------------------------------
 
-# Fake, obviously-not-real secrets fed on stdin — never a real credential, and
-# redacted again before embedding (see `_redact_secrets`).
+# Fake, obviously-not-real secrets typed at the prompts — never a real
+# credential, and redacted again before embedding (see `_redact_secrets`).
 _FAKE_KEY = "sk-FAKE-not-a-real-key"
 _FAKE_PASS = "FAKE-not-a-real-password"
+_SEED_KEY = "sk-SEED-not-a-real-key"
 _TENANT = "acme"
 _REPO = "registry.example.com/acme/app"
 _SETTINGS = ".config/snouty/settings.toml"
 _CREDS = ".config/snouty/credentials.toml"
-_SETTINGS_BAK = ".config/snouty/settings.toml.bak"
 
-# Shared satisfaction rubric for the interactive login stories: judge the prompt
-# transcript AND the persisted result, not just the exit code.
-_LOGIN_RUBRIC = (
-    "Judge the prompt transcript and the persisted state together. Are the "
+# Prompts the dialogues wait for, and the credential-menu labels they choose
+# between (these match the `Display` impl on snouty's `AuthSetupType`).
+_ASK_TENANT = "What Antithesis tenant"
+_ASK_REPO = "What container repository"
+_ASK_CREDENTIALS = "What kind of credentials"
+_ASK_KEY = "Please enter your API Key"
+_ASK_USERNAME = "What username"
+_ASK_PASSWORD = "Please enter your password"
+_API_KEY = "API Key"
+_USERNAME_PASSWORD = "Username & password (deprecated)"
+
+# Shared satisfaction rubric for the TTY stories: judge the conversation AND the
+# persisted result, not just the exit code.
+_TTY_RUBRIC = (
+    "Judge the prompt conversation and the persisted state together. Are the "
     "prompts clear, in a sensible order, and only for values not already known? "
     "After it finishes, does the user know WHAT was saved, WHERE, and the next "
     "step (e.g. `snouty doctor`)? Are secrets never echoed? For the error/repair "
@@ -1948,163 +2205,96 @@ _LOGIN_RUBRIC = (
 )
 
 
-def _login_story(
+def _tty_story(
     slug: str,
     title: str,
     goal: str,
     args: list[str],
-    stdin: str,
+    dialogue: tuple[Step, ...],
     check,
     *,
-    pre: list[str] | None = None,
     seed_files: dict[str, str] | None = None,
     post_capture: tuple[str, ...] = (_SETTINGS, _CREDS),
-    env: dict[str, str | None] | None = None,
 ) -> Story:
-    # `pre` holds global flags that must precede the `login` subcommand (e.g.
-    # `--profile`); `args` holds `login`'s own flags.
     return Story(
         slug=slug,
         title=title,
         goal=goal,
-        judge=_LOGIN_RUBRIC,
-        args=[*(pre or []), "login", *args],
+        judge=_TTY_RUBRIC,
+        args=args,
         check=check,
         json_capable=False,
-        sandbox_home=True,
-        stdin=stdin,
+        dialogue=dialogue,
         seed_files=seed_files,
         post_capture=post_capture,
-        env=env,
     )
 
 
-def build_login_stories() -> list[Story]:
+def build_tty_stories() -> list[Story]:
     return [
-        _login_story(
+        _tty_story(
             "login-fresh-apikey",
             "First-time setup with an API key",
             "I just installed snouty and want to configure my tenant, repository, and API key.",
-            [],
-            f"{_TENANT}\n{_REPO}\n2\n{_FAKE_KEY}\n",
-            login_persisted(
-                prompts=(
-                    "What Antithesis tenant",
-                    "What container repository",
-                    "What kind of credentials",
-                ),
+            ["login"],
+            (
+                (_ASK_TENANT, _TENANT + ENTER),
+                (_ASK_REPO, _REPO + ENTER),
+                pick(_ASK_CREDENTIALS, _API_KEY),
+                (_ASK_KEY, _FAKE_KEY + ENTER),
+            ),
+            tty_persisted(
+                prompts=(_ASK_TENANT, _ASK_REPO, _ASK_CREDENTIALS),
                 files=(
                     (_SETTINGS, (f'tenant = "{_TENANT}"', f'repository = "{_REPO}"')),
-                    (_CREDS, ('type = "ApiKey"',)),
+                    (_CREDS, ('type = "ApiKey"', f'api_key = "{_FAKE_KEY}"')),
                 ),
                 secrets_absent=(_FAKE_KEY,),
             ),
         ),
-        _login_story(
+        _tty_story(
             "login-reuse-default",
             "Re-run login and keep my stored values",
-            "I already logged in; re-running should offer my previous tenant/repo/key as defaults so I can just hit enter.",
-            [],
-            "\n\n\n\n",  # blank tenant, repo, auth-menu (default), api key (reuse)
-            login_persisted(
-                prompts=(
-                    f"Hit enter to use the previous value of [{_TENANT}]",
-                    f"Hit enter to use the previous value of [{_REPO}]",
+            "I already logged in; re-running should offer my previous tenant, repository, and key "
+            "back so I can just hit enter.",
+            ["login"],
+            (
+                (_ASK_TENANT, ENTER),
+                (_ASK_REPO, ENTER),
+                pick(_ASK_CREDENTIALS, _API_KEY),
+                (_ASK_KEY, ENTER),
+            ),
+            tty_persisted(
+                prompts=(_TENANT, _REPO),
+                files=(
+                    (_SETTINGS, (f'tenant = "{_TENANT}"', f'repository = "{_REPO}"')),
+                    # Every answer was a bare Enter, so the stored key must survive.
+                    (_CREDS, ('type = "ApiKey"', f'api_key = "{_SEED_KEY}"')),
                 ),
-                files=((_CREDS, ('type = "ApiKey"',)),),
-                secrets_absent=("sk-SEED-not-a-real-key",),
+                secrets_absent=(_SEED_KEY,),
             ),
             seed_files={
                 _SETTINGS: f'tenant = "{_TENANT}"\nrepository = "{_REPO}"\n',
-                _CREDS: '[default]\ntype = "ApiKey"\napi_key = "sk-SEED-not-a-real-key"\n',
+                _CREDS: f'[default]\ntype = "ApiKey"\napi_key = "{_SEED_KEY}"\n',
             },
         ),
-        _login_story(
-            "login-flags",
-            "Supply tenant and repository as flags",
-            "I know my tenant and repository already; I only want to be prompted for credentials.",
-            ["--tenant", _TENANT, "--repository", _REPO],
-            f"2\n{_FAKE_KEY}\n",
-            login_persisted(
-                prompts=("What kind of credentials",),
-                absent_prompts=("What Antithesis tenant", "What container repository"),
-                files=(
-                    (_SETTINGS, (f'tenant = "{_TENANT}"',)),
-                    (_CREDS, ('type = "ApiKey"',)),
-                ),
-                secrets_absent=(_FAKE_KEY,),
-            ),
-        ),
-        _login_story(
+        _tty_story(
             "login-password",
-            "Set up legacy username/password auth",
+            "Set up deprecated username/password auth",
             "I authenticate with a username and password rather than an API key.",
-            [],
-            f"{_TENANT}\n{_REPO}\n3\npuser\n{_FAKE_PASS}\n",
-            login_persisted(
-                prompts=("What kind of credentials",),
+            ["login"],
+            (
+                (_ASK_TENANT, _TENANT + ENTER),
+                (_ASK_REPO, _REPO + ENTER),
+                pick(_ASK_CREDENTIALS, _USERNAME_PASSWORD),
+                (_ASK_USERNAME, "puser" + ENTER),
+                (_ASK_PASSWORD, _FAKE_PASS + ENTER),
+            ),
+            tty_persisted(
+                prompts=(_ASK_CREDENTIALS, _USERNAME_PASSWORD),
                 files=((_CREDS, ('type = "Password"', 'username = "puser"')),),
                 secrets_absent=(_FAKE_PASS,),
             ),
-        ),
-        _login_story(
-            "login-profile",
-            "Scope a login to a named profile",
-            "I keep separate configs per environment and want this login saved under the `prod` profile.",
-            [],
-            f"{_TENANT}\n{_REPO}\n2\n{_FAKE_KEY}\n",
-            login_persisted(
-                files=(
-                    (_SETTINGS, ("[profile.prod]", f'tenant = "{_TENANT}"')),
-                    (_CREDS, ("[profile.prod]", 'type = "ApiKey"')),
-                ),
-                secrets_absent=(_FAKE_KEY,),
-            ),
-            pre=["--profile", "prod"],
-        ),
-        _login_story(
-            "login-skip-creds",
-            "Configure tenant/repo but skip credential storage",
-            "I use environment variables for credentials; I just want snouty to remember my tenant and repository.",
-            [],
-            f"{_TENANT}\n{_REPO}\n1\n",
-            login_persisted(
-                prompts=("What kind of credentials",),
-                files=((_SETTINGS, (f'tenant = "{_TENANT}"',)),),
-                absent_files=(_CREDS,),
-            ),
-        ),
-        _login_story(
-            "login-bad-tenant",
-            "A malformed tenant is rejected safely",
-            "I fat-finger a tenant that isn't a valid hostname; I want a clear error and nothing half-saved.",
-            [],
-            "evil.com/x\n",
-            login_persisted(
-                prompts=("What Antithesis tenant", "invalid tenant"),
-                absent_files=(_SETTINGS, _CREDS),
-                expect_ok=False,
-            ),
-        ),
-        _login_story(
-            "login-repair-broken",
-            "Repair a broken settings file",
-            "My settings.toml got corrupted; I want `snouty login` to fix it without silently destroying the old one.",
-            [],
-            f"1\n{_TENANT}\n{_REPO}\n1\n",  # proceed, tenant, repo, skip creds
-            login_persisted(
-                prompts=(
-                    "The current settings failed to load",
-                    "Would you like to proceed",
-                    "kept as a backup:",
-                ),
-                files=(
-                    (_SETTINGS, (f'tenant = "{_TENANT}"',)),
-                    (_SETTINGS_BAK, ("unparsable-settings-marker",)),
-                ),
-            ),
-            seed_files={_SETTINGS: "this is = = not valid toml unparsable-settings-marker\n"},
-            post_capture=(_SETTINGS, _SETTINGS_BAK),
         ),
     ]
 
@@ -2159,7 +2349,7 @@ def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, d
 
 
 # Redact the secret values from persisted TOML before embedding it in a story —
-# belt-and-suspenders on top of the fake secrets the login stories feed on stdin.
+# belt-and-suspenders on top of the fake secrets the TTY stories type.
 _SECRET_LINE = re.compile(r'^(\s*(?:api_key|password)\s*=\s*)"[^"]*"', re.MULTILINE)
 
 
@@ -2167,24 +2357,25 @@ def _redact_secrets(text: str) -> str:
     return _SECRET_LINE.sub(r'\1"[REDACTED]"', text)
 
 
-def _write_login_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
-    # The `$ snouty ...` block with the scripted answers shown as a comment, so a
-    # reviewer sees exactly what the user typed at each prompt. `splitlines()`
-    # keeps every answer, including blank "just hit enter" ones (a reuse story
-    # feeds several) that `.rstrip("\n").split("\n")` would collapse.
-    answers = (story.stdin or "").splitlines()
-    stdin_note = "".join(f"# stdin> {a}\n" for a in answers)
-    transcript = (
-        f"```shell\n$ snouty {' '.join(story.args)}\n{stdin_note}"
-        f"{sr.result.combined.rstrip(chr(10))}\n```\nExit code: `{sr.result.returncode}`"
-    )
+def _write_tty_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
+    # One frame per prompt, so a reviewer sees the screen the user faced at each
+    # decision — including the menus, which are erased once chosen and so appear
+    # nowhere in the closing screen. The keys typed are not listed separately:
+    # `inquire` draws each answer next to its prompt, and the frames carry that.
     parts = [
         f"# {story.title}",
         f"**User goal:** {story.goal}",
         f"**Judge satisfaction by:** {story.judge}",
-        "## Transcript",
-        transcript,
+        "## Conversation",
+        f"```shell\n$ snouty {' '.join(story.args)}\n```",
     ]
+    for prompt, screen in sr.frames or []:
+        parts.append(f"### At `{prompt}`\n```\n{screen}\n```")
+    parts.append(f"Exit code: `{sr.result.returncode}`")
+    if sr.cast is not None:
+        cast_name = f"{story.slug}.cast"
+        (out_dir / cast_name).write_text(sr.cast)
+        parts.append(f"_Replay the session: `asciinema play {cast_name}`_")
     if story.post_capture:
         parts.append("## Persisted state")
         for rel_path, contents in sr.captured_files or []:
@@ -2202,8 +2393,8 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
     if story.help_cmd is not None:
         _write_help_story(out_dir, story, sr, verdict, detail)
         return
-    if story.sandbox_home:
-        _write_login_story(out_dir, story, sr, verdict, detail)
+    if story.dialogue is not None:
+        _write_tty_story(out_dir, story, sr, verdict, detail)
         return
     md = (
         f"# {story.title}\n\n"
@@ -2215,39 +2406,44 @@ def write_story(out_dir: Path, story: Story, sr: StoryRun, passed: bool, detail:
     (out_dir / f"{story.slug}.md").write_text(md)
 
 
-def run_login_story(sn: Snouty, story: Story) -> StoryRun:
-    """Run an interactive, stateful story in a throwaway `$HOME` so the
-    credentials/settings it persists never touch the operator's real config. The
-    home is seeded with `seed_files`, the answers are piped to stdin, and the
+def run_tty_story(sn: Snouty, story: Story) -> StoryRun:
+    """Run a TTY story in a throwaway `$HOME` so the credentials and settings it
+    persists never touch the operator's real config. The home is seeded with
+    `seed_files`, the dialogue is typed at a pseudo-terminal, and the
     `post_capture` files are read back before the home is removed."""
-    home = Path(tempfile.mkdtemp(prefix="snouty-gallery-login."))
+    # A short prefix on purpose: this path shows up inside snouty's own output,
+    # and a long one would push those lines over the terminal's width for a
+    # reason that belongs to the harness rather than to snouty.
+    home = Path(tempfile.mkdtemp(prefix="snouty-tty."))
+
     try:
         for rel_path, contents in (story.seed_files or {}).items():
             dest = home / rel_path
             dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(contents)
 
-        # Pin HOME, clear XDG_CONFIG_HOME (snouty treats empty as unset), and drop
-        # any ambient ANTITHESIS_* credentials so the "previous value" defaults are
-        # deterministic and no real secret can leak into a captured file.
-        env: dict[str, str | None] = {
-            "HOME": str(home),
-            "XDG_CONFIG_HOME": None,
-            **{k: None for k in os.environ if k.startswith("ANTITHESIS_")},
-        }
-        if story.env:
-            env.update(story.env)
-
-        # Merge stderr into stdout so the transcript preserves interaction
-        # order: login prints prompts on one stream and warnings on the other,
-        # and separate captures reorder the conversation.
-        result = sn.run(story.args, env=env, stdin=story.stdin, merge_streams=True)
+        # Pin HOME, clear XDG_CONFIG_HOME (snouty treats empty as unset), and
+        # drop any ambient ANTITHESIS_* credentials, so the story shows the state
+        # it seeded rather than the operator's own and no real secret can reach a
+        # captured file. TERM names a terminal `inquire` can draw on.
+        env = sn.env_with(
+            {
+                "HOME": str(home),
+                "TERM": "xterm-256color",
+                "XDG_CONFIG_HOME": None,
+                **{k: None for k in os.environ if k.startswith("ANTITHESIS_")},
+                **(story.env or {}),
+            }
+        )
+        result, frames, cast = drive_tty(sn.binary, story.args, env, story.dialogue or ())
 
         captured: list[tuple[str, str | None]] = []
         for rel_path in story.post_capture:
             path = home / rel_path
             captured.append((rel_path, path.read_text() if path.is_file() else None))
-        return StoryRun(story, result, None, captured_files=captured)
+        return StoryRun(
+            story, result, None, captured_files=captured, frames=frames, cast=cast
+        )
     finally:
         shutil.rmtree(home, ignore_errors=True)
 
@@ -2269,8 +2465,8 @@ def _run_isolated_story(sn: Snouty, story: Story) -> StoryRun:
 
 
 def run_story(sn: Snouty, story: Story) -> StoryRun:
-    if story.sandbox_home:
-        return run_login_story(sn, story)
+    if story.dialogue is not None:
+        return run_tty_story(sn, story)
     if story.isolate_config:
         return _run_isolated_story(sn, story)
     # Help-only stories pass no `args`; don't invoke a bare `snouty`.
@@ -2325,7 +2521,7 @@ def main() -> int:
             print(s.slug)
         for s in build_validate_stories(None):
             print(s.slug)
-        for s in build_login_stories():
+        for s in build_tty_stories():
             print(s.slug)
         return 0
 
@@ -2350,7 +2546,7 @@ def main() -> int:
     # manifests/ dir) are synthesized here for this run only.
     fixtures_dir = Path(tempfile.mkdtemp(prefix="snouty-gallery-fixtures."))
 
-    # Which story groups does this run actually need? The login stories need no
+    # Which story groups does this run actually need? The TTY stories need no
     # API, discovery, or container runtime, so `--only login-*` must not drag in
     # (and fail on) live-API discovery or a Docker daemon. Decide up front from
     # cheaply-enumerable slugs which groups are in scope.
@@ -2359,12 +2555,12 @@ def main() -> int:
 
     api_slugs = {s.slug for s in build_stories(Discovery())}
     validate_slugs = {s.slug for s in build_validate_stories(None)}
-    login_slugs = {s.slug for s in build_login_stories()}
+    tty_slugs = {s.slug for s in build_tty_stories()}
     need_api = any(selected(s) for s in api_slugs)
     need_validate = any(selected(s) for s in validate_slugs)
 
     if args.only:
-        known = api_slugs | validate_slugs | login_slugs
+        known = api_slugs | validate_slugs | tty_slugs
         unmatched = [p for p in args.only if not any(fnmatch.fnmatch(s, p) for s in known)]
         if unmatched:
             print(f"error: --only matched no stories: {unmatched}", file=sys.stderr)
@@ -2395,8 +2591,8 @@ def main() -> int:
             )
             stories += validate_stories
 
-        # Login stories need no external dependencies, so they always run.
-        stories += build_login_stories()
+        # TTY stories need no external dependencies, so they always run.
+        stories += build_tty_stories()
 
         if args.only:
             stories = [s for s in stories if selected(s.slug)]

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -43,6 +43,7 @@ import fnmatch
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -83,6 +84,12 @@ EVENT_KEYWORDS = ["the", "info", "test", "start", "error", "client", "setup"]
 # Keyword order probed for an incomplete run's events story: its narrative is
 # "events around the failure", so try "error" before the general needles.
 INCOMPLETE_EVENT_KEYWORDS = ["error", *EVENT_KEYWORDS]
+
+# The `--limit` the two `runs events` search stories pass. Stated rather than
+# left to the server default, so the AND-narrowing check knows the cap it has to
+# reason about (see `event_multi_match`). It matches the server default, so the
+# stories still show what an unadorned search returns.
+EVENT_LIMIT = 50
 
 
 class GalleryError(Exception):
@@ -423,7 +430,7 @@ def drive_tty(
     return (
         Result(args, session.frame(), "", returncode),
         frames,
-        session.cast(f"snouty {' '.join(args)}"),
+        session.cast(_command_line(args)),
     )
 
 
@@ -1101,15 +1108,30 @@ def verbose_api_calls(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
     return (has_get and has_table, f"api_calls={has_get} table={has_table}")
 
 
-def event_multi_match(needle: str, second: str):
+def event_multi_match(needle: str, second: str, limit: int):
+    """Gate the AND-narrowing story: every row must contain both needles, and
+    the result should be strictly smaller than the single-needle search.
+
+    That last comparison only means something when the single-needle search came
+    back under `limit`. `runs events` matches one needle on the server, which
+    returns at most `limit` events, and filters the rest locally — so when the
+    single-needle search is capped, both searches can report `limit` rows while
+    still describing different sets. Rather than fail on that, the check says
+    the comparison was not assertable and gates on the needles alone."""
+
     def chk(sr: StoryRun, reg: Registry) -> tuple[bool, str]:
         rows = sr.rows or []
         n1, n2 = needle.lower(), second.lower()
         bad = [r for r in rows if not (n1 in json.dumps(r).lower() and n2 in json.dumps(r).lower())]
         single = reg.row_counts.get("runs-events-single", 1 << 30)
+        capped = single >= limit
         narrowed = len(rows) < single
-        ok = bool(rows) and not bad and narrowed
-        return (ok, f"{len(rows)} rows w/ both needles, narrowed {single}->{len(rows)}={narrowed}")
+        ok = bool(rows) and not bad and (narrowed or capped)
+        if capped:
+            note = f"narrowing not assertable (single-match hit the {limit}-row cap)"
+        else:
+            note = f"narrowed {single}->{len(rows)}={narrowed}"
+        return (ok, f"{len(rows)} rows w/ both needles, {note}")
 
     return chk
 
@@ -1485,21 +1507,34 @@ def build_stories(d: Discovery) -> list[Story]:
             json_capable=False,
         ),
         # -- events ---------------------------------------------------------
+        # Both searches pass the same explicit --limit, so the AND-narrowing
+        # check can tell a genuinely smaller result from one the server capped.
         Story(
             "runs-events-single",
             f"Find events that mention '{kw}'",
             "I want to find events that mention a particular keyword.",
             f"At least one matching event row, and the keyword '{kw}' appears in the output.",
-            ["runs", "events", d.success, "--match", kw],
+            ["runs", "events", d.success, "--match", kw, "--limit", str(EVENT_LIMIT)],
             event_keyword_present(kw),
         ),
         Story(
             "runs-events-multi-match",
             "AND-narrow with two --match needles",
             "I want to narrow results to events that mention BOTH of two terms.",
-            f"At least one row, every row contains both '{kw}' and '{kw2}', and strictly fewer rows than single-match.",
-            ["runs", "events", d.success, "--match", kw, "--match", kw2],
-            event_multi_match(kw, kw2),
+            f"At least one row, and every row contains both '{kw}' and '{kw2}'. Fewer rows than "
+            "the single-needle search when that search was not capped by --limit.",
+            [
+                "runs",
+                "events",
+                d.success,
+                "--match",
+                kw,
+                "--match",
+                kw2,
+                "--limit",
+                str(EVENT_LIMIT),
+            ],
+            event_multi_match(kw, kw2, EVENT_LIMIT),
         ),
         Story(
             "runs-events-no-results",
@@ -2310,6 +2345,16 @@ def build_tty_stories() -> list[Story]:
 HELP_SAMPLE_MAX_LINES = 18
 
 
+def _command_line(args: list[str]) -> str:
+    """`snouty <args>` as a line a reader can paste into a shell.
+
+    Arguments are quoted where a shell would need it: several stories pass a
+    value that contains spaces (`--launcher 'Basic Test git'`, a multi-word
+    `--match` needle), and joining on a bare space would show a command that
+    means something different from the one that ran."""
+    return f"snouty {shlex.join(args)}"
+
+
 def _shell_block(args: list[str], text: str, returncode: int, cap: int | None = None) -> str:
     """A ```shell block showing `$ snouty <args>`, its output, and the exit code
     on the line below — so a reviewer can judge whether the return code makes
@@ -2321,7 +2366,7 @@ def _shell_block(args: list[str], text: str, returncode: int, cap: int | None = 
         hidden = len(lines) - cap
         lines = lines[:cap] + [f"… ({hidden} more lines)"]
     body = "\n".join(lines)
-    return f"```shell\n$ snouty {' '.join(args)}\n{body}\n```\nExit code: `{returncode}`"
+    return f"```shell\n$ {_command_line(args)}\n{body}\n```\nExit code: `{returncode}`"
 
 
 def _write_help_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, detail: str) -> None:
@@ -2367,7 +2412,7 @@ def _write_tty_story(out_dir: Path, story: Story, sr: StoryRun, verdict: str, de
         f"**User goal:** {story.goal}",
         f"**Judge satisfaction by:** {story.judge}",
         "## Conversation",
-        f"```shell\n$ snouty {' '.join(story.args)}\n```",
+        f"```shell\n$ {_command_line(story.args)}\n```",
     ]
     for prompt, screen in sr.frames or []:
         parts.append(f"### At `{prompt}`\n```\n{screen}\n```")

--- a/scripts/gen-gallery.py
+++ b/scripts/gen-gallery.py
@@ -39,6 +39,7 @@ how snouty changes affect command output.
 from __future__ import annotations
 
 import argparse
+import codecs
 import fnmatch
 import json
 import os
@@ -302,17 +303,29 @@ class _Recorder:
     `pexpect` hands its `logfile_read` every byte it reads, once and in order —
     unlike `before`/`after`, which repeat whatever is still in its buffer. Each
     chunk is timestamped for the recording and fed to the terminal emulator for
-    the frames."""
+    the frames.
+
+    Both outputs decode incrementally, because a read can split a multi-byte
+    character: `pyte.ByteStream` carries the leftover bytes into the next chunk,
+    and the recording's own decoder does the same. Decoding each chunk on its own
+    would turn a split `↑` into replacement characters in the recording while the
+    frames still rendered it correctly."""
 
     def __init__(self, screen: pyte.Screen):
         self.started = time.monotonic()
-        self.events: list[tuple[float, bytes]] = []
+        self.events: list[tuple[float, str]] = []
         self.stream = pyte.ByteStream(screen)
+        self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
 
     def write(self, data: bytes) -> None:
-        if data:
-            self.events.append((time.monotonic() - self.started, data))
-            self.stream.feed(data)
+        if not data:
+            return
+        self.stream.feed(data)
+        text = self._decoder.decode(data)
+        # A chunk that held only the first bytes of a split character decodes to
+        # nothing; its bytes arrive with the next one.
+        if text:
+            self.events.append((time.monotonic() - self.started, text))
 
     def flush(self) -> None:
         pass
@@ -366,10 +379,16 @@ class TtySession:
             rows.pop()
         return "\n".join(rows)
 
-    def finish(self) -> int:
-        """Wait for the child to exit and return its status."""
+    def finish(self, timeout: float) -> int:
+        """Wait up to `timeout` for the child to exit and return its status.
+
+        A dialogue that ran to the end leaves a child that is already exiting, so
+        the wait is short in practice. A story that broke off early leaves one
+        sitting at a prompt no one will answer, and waiting the full prompt
+        budget for an exit that cannot come only adds dead time to a run that has
+        already failed — such a caller passes a short timeout."""
         try:
-            self.child.expect(pexpect.EOF)
+            self.child.expect(pexpect.EOF, timeout=timeout)
         except pexpect.TIMEOUT:
             # The child is still up after a dialogue that should have ended it —
             # a stalled story, already recorded as a marker frame. Fall through
@@ -392,8 +411,8 @@ class TtySession:
             "env": {"TERM": "xterm-256color"},
         }
         lines = [json.dumps(header)]
-        for at, data in self.recorder.events:
-            lines.append(json.dumps([round(at, 6), "o", data.decode("utf-8", "replace")]))
+        for at, text in self.recorder.events:
+            lines.append(json.dumps([round(at, 6), "o", text]))
         return "\n".join(lines) + "\n"
 
 
@@ -415,20 +434,25 @@ def drive_tty(
     gallery."""
     session = TtySession(binary, args, env)
     frames: list[Frame] = []
+    completed = True
     for prompt, keys in dialogue:
         try:
             session.wait_for(prompt)
         except (pexpect.TIMEOUT, pexpect.EOF) as e:
             stalled = "no output" if isinstance(e, pexpect.TIMEOUT) else "snouty exited"
             frames.append((f"[gallery] waiting for {prompt!r}: {stalled}", session.frame()))
+            completed = False
             break
         frames.append((prompt, session.frame()))
         try:
             session.send(keys if isinstance(keys, str) else keys(session.screen.display))
         except GalleryError as e:
             frames.append((f"[gallery] answering {prompt!r}: {e}", session.frame()))
+            completed = False
             break
-    returncode = session.finish()
+    # A story that broke off leaves snouty waiting at a prompt, so give it only
+    # long enough to be sure rather than the whole prompt budget.
+    returncode = session.finish(PROMPT_TIMEOUT if completed else SETTLE)
     # The child has exited, so nothing can feed the emulator from here: one
     # closing screen serves as both the last frame and the story's output.
     closing = session.frame()

--- a/specs/doctor.txt
+++ b/specs/doctor.txt
@@ -6,7 +6,7 @@
 snouty doctor --help
 stdout '.*Check environment configuration.*'
 stdout '.*container runtime.*'
-stdout '.*environment variables.*'
+stdout '(?s)environment\s+variables'
 stdout '.*--json.*'
 
 # With nothing configured, doctor steers the user to an API key only — it must

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,8 +91,8 @@ flags and the README). Environment variables take precedence.
 Environment variables (override any settings file):
   ANTITHESIS_TENANT       Your Antithesis tenant name (required).
   ANTITHESIS_API_KEY      API key authentication (preferred).
-  ANTITHESIS_USERNAME     Username (required when API key is not set).
-  ANTITHESIS_PASSWORD     Password (required when API key is not set).
+  ANTITHESIS_USERNAME     Username (deprecated; required when API key is not set).
+  ANTITHESIS_PASSWORD     Password (deprecated; required when API key is not set).
   ANTITHESIS_REPOSITORY   Container registry for pushing images (required with --config).
   SNOUTY_CONTAINER_ENGINE Force "docker" or "podman" (auto-detected by default)."#)]
     Launch(LaunchArgs),
@@ -194,10 +194,10 @@ Example:
     #[command(long_about = r#"Check environment configuration
 
 Verifies that your environment is properly configured for Antithesis testing.
-Runs health checks — container runtime, docker compose, the ANTITHESIS_*
-environment variables for authentication, and API connectivity — then prints
-the resolved settings (tenant, repository, container engine) so you can confirm
-what snouty will use.
+Runs health checks — container runtime, docker compose, your credentials
+(stored by `snouty login`, or set in the ANTITHESIS_* environment variables),
+and API connectivity — then prints the resolved settings (tenant, repository,
+container engine) so you can confirm what snouty will use.
 
 snouty prefers an API key (full API access); a username and password is
 deprecated auth, accepted only by `snouty launch` and `snouty debug`.
@@ -260,12 +260,13 @@ Examples:
         command: DocsCommands,
     },
 
-    /// Initialize Snouty configuration
-    #[command(long_about = r#"Initialize Snouty configuration and authentication
+    /// Sign in and store your snouty configuration
+    #[command(long_about = r#"Sign in and store your snouty configuration
 
-Provide configuration and authentication information to persist in the global 
-Snouty settings file, optionally under a named profile. Sensitive information and
-information not provided via args will be queried over stdin.
+Provide configuration and authentication information to persist in the global
+snouty settings file, optionally under a named profile. Sensitive information and
+information not provided via args are asked for at the terminal, so this command
+needs an interactive session.
 
 NOTE: `snouty login` will offer to reuse your existing configuration values, including
 any sourced from a local .snouty.toml file or the file specified by --settings or via

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -267,12 +267,11 @@ fn enrich<T>(check: Check, attribution: AttributedValue<T>) -> Check {
         } => check.note(
             Level::Note,
             format!(
-                "read from settings file at [{:?}] {}",
-                settings_file_path,
-                match profile {
-                    Some(profile_name) => format!("under the [{profile_name}] profile"),
-                    None => "defaults".to_owned(),
-                }
+                // `Display`, not `Debug`: `{:?}` on a path adds quotes of its
+                // own, which read as a second set of brackets around the name.
+                "read from the [{}] profile in {}",
+                profile.as_deref().unwrap_or("default"),
+                settings_file_path.display(),
             ),
         ),
         AttributedValue::Keychain {
@@ -521,6 +520,39 @@ mod tests {
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, Status::Ok);
         assert!(checks[0].message.contains("API key provided"));
+    }
+
+    /// A credential read from a file names the profile it came from and the
+    /// path, as a sentence. The path goes through `Display`, so it carries no
+    /// quotes of its own.
+    #[test]
+    fn auth_from_a_file_names_the_profile_and_the_path() {
+        let note = |profile: Option<&str>| {
+            let checks = authn_checks(Ok(AttributedValue::SettingsFile {
+                value: AuthenticationInfo::ApiKey {
+                    api_key: "api_key".to_owned(),
+                },
+                settings_file_path: std::path::PathBuf::from("/tmp/credentials.toml"),
+                profile: profile.map(str::to_owned),
+            }));
+            checks[0]
+                .notes
+                .iter()
+                .map(|n| n.text.clone())
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+        assert!(
+            note(None).contains("read from the [default] profile in /tmp/credentials.toml"),
+            "got: {}",
+            note(None)
+        );
+        assert!(
+            note(Some("prod")).contains("read from the [prod] profile in /tmp/credentials.toml"),
+            "got: {}",
+            note(Some("prod"))
+        );
+        assert!(!note(None).contains('"'), "the path must not be quoted");
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -148,12 +148,16 @@ struct Report<'a> {
 /// The tenant is required by every command, so a missing one fails doctor.
 /// (A broken settings file never reaches here — it fails at startup, before
 /// doctor runs — so the resolved value is simply present or absent.)
+/// `snouty login` sets tenant, repository, and credentials in one pass, so every
+/// check that reports one of them missing points at it. Each says so in its own
+/// words: on an unconfigured machine all three fire at once, and the same
+/// sentence three times reads as noise rather than as advice.
 fn tenant_check(tenant: Option<&str>) -> Check {
     match tenant {
         Some(_) => Check::ok("tenant", "tenant is set"),
         None => Check::fail("tenant", "tenant is not set").note(
             Level::Note,
-            "set ANTITHESIS_TENANT or add it to a settings file",
+            "run `snouty login` to set it, or set ANTITHESIS_TENANT or add it to a settings file",
         ),
     }
 }
@@ -165,7 +169,11 @@ fn repository_check(repository: Option<&str>) -> Check {
     match repository {
         Some(_) => Check::ok("repository", "repository is set"),
         None => Check::warn("repository", "repository is not set")
-            .note(Level::Warning, "repository is needed for `snouty launch`"),
+            .note(Level::Warning, "repository is needed for `snouty launch`")
+            .note(
+                Level::Note,
+                "run `snouty login` to set it, or set ANTITHESIS_REPOSITORY",
+            ),
     }
 }
 
@@ -222,6 +230,10 @@ fn authn_checks(authn_info: Result<AttributedValue<AuthenticationInfo>>) -> Vec<
                 .note(
                     Level::Error,
                     "snouty requires an API key to authenticate with Antithesis",
+                )
+                .note(
+                    Level::Note,
+                    "run `snouty login` to sign in and store credentials",
                 )
                 .note(
                     Level::Note,
@@ -554,6 +566,13 @@ mod tests {
                 .iter()
                 .any(|n| n.text.contains("ask Antithesis support"))
         );
+        assert!(
+            checks[0]
+                .notes
+                .iter()
+                .any(|n| n.text.contains("snouty login")),
+            "an unconfigured machine must be told the command that configures it"
+        );
         let all = format!(
             "{} {}",
             checks[0].message,
@@ -586,6 +605,10 @@ mod tests {
                 .iter()
                 .any(|n| n.text.contains("ANTITHESIS_TENANT"))
         );
+        assert!(
+            check.notes.iter().any(|n| n.text.contains("snouty login")),
+            "an unset tenant must point at the command that sets it"
+        );
     }
 
     #[test]
@@ -601,6 +624,7 @@ mod tests {
         let check = repository_check(None);
         assert_eq!(check.status, Status::Warn);
         assert!(check.notes.iter().any(|n| n.text.contains("snouty launch")));
+        assert!(check.notes.iter().any(|n| n.text.contains("snouty login")));
     }
 
     // ---- resolved-settings table (informational, no status) ------------

--- a/src/login.rs
+++ b/src/login.rs
@@ -161,10 +161,15 @@ async fn do_cmd_login(
         )?,
     };
 
+    // Whatever credentials are already in reach, so the menu can default to the
+    // kind last used and the key prompt can offer the stored key back. The error
+    // is discarded on purpose: nothing reads it, and having none is the ordinary
+    // state on a first login rather than a failure.
     let current_credentials = AuthenticationInfo::for_ambient_configuration_with_attribution(
         profile_to_use.as_deref(),
         PasswordPolicy::Inspect,
-    );
+    )
+    .ok();
 
     // Capture the credential kind and where it was stored so the summary can name
     // both; `None` when the user chose to skip credential setup.
@@ -215,7 +220,7 @@ fn print_login_summary(
     profile: Option<&str>,
     settings_path: &Path,
     credentials: Option<AttributedValue<&str>>,
-    previous_credentials: Result<AttributedValue<AuthenticationInfo>>,
+    previous_credentials: Option<AttributedValue<AuthenticationInfo>>,
 ) {
     let scope = match profile {
         Some(p) => format!(" under profile `{p}`"),
@@ -244,12 +249,12 @@ fn print_login_summary(
             println!("Stored your {kind}{scope} in {}.", path.display());
         }
         _ => match previous_credentials {
-            Ok(AttributedValue::Keychain { .. }) => {
+            Some(AttributedValue::Keychain { .. }) => {
                 println!(
                     "Retained your previously stored credentials{scope} in the system keychain."
                 );
             }
-            Ok(AttributedValue::SettingsFile {
+            Some(AttributedValue::SettingsFile {
                 settings_file_path, ..
             }) => {
                 println!(
@@ -318,7 +323,7 @@ impl std::fmt::Display for AuthSetupType {
 async fn prompt_for_auth(
     prompter: &dyn Prompter,
     tenant: &str,
-    previous_value: &Result<AttributedValue<AuthenticationInfo>>,
+    previous_value: &Option<AttributedValue<AuthenticationInfo>>,
 ) -> Result<Option<PersistableCredentials>> {
     // ANTITHESIS_BASE_URL trumps the supplied tenant because the former is used by spec tests
     let base_url = env::var(settings::ANTITHESIS_BASE_URL_VAR_NAME)?
@@ -342,7 +347,7 @@ async fn prompt_for_auth(
     // highlight the first (preferred) option. Credentials from environment
     // variables are not stored, so they set no default.
     let previous_kind = match previous_value {
-        Ok(creds) if !matches!(creds, AttributedValue::EnvironmentVariable { .. }) => {
+        Some(creds) if !matches!(creds, AttributedValue::EnvironmentVariable { .. }) => {
             Some(creds.value())
         }
         _ => None,
@@ -366,11 +371,11 @@ async fn prompt_for_auth(
         None => Ok(None),
         Some(index) => match credential_options[index] {
             AuthSetupType::ApiKey => {
-                prompt_for_api_key(prompter, stored_api_key(previous_value)).map(Some)
+                prompt_for_api_key(prompter, stored_api_key(previous_value.as_ref())).map(Some)
             }
 
             AuthSetupType::Password => match previous_value.as_ref().map(AttributedValue::value) {
-                Ok(AuthenticationInfo::Password { username, .. }) => {
+                Some(AuthenticationInfo::Password { username, .. }) => {
                     prompt_for_username_password(prompter, Some(username))
                 }
                 _ => prompt_for_username_password(prompter, None),
@@ -383,7 +388,7 @@ async fn prompt_for_auth(
     }
 }
 
-/// How many leading characters of a stored secret its hint shows. Enough to
+/// How many trailing characters of a stored secret its hint shows. Enough to
 /// tell one key from another, far too few to reconstruct either.
 const HINT_VISIBLE_CHARS: usize = 4;
 
@@ -391,22 +396,27 @@ const HINT_VISIBLE_CHARS: usize = 4;
 /// the hint does not disclose how long the secret is.
 const HINT_STARS: usize = 8;
 
-/// A display-only stand-in for a stored secret — its first few characters, then
-/// stars, e.g. `sk-F********`. The prompt shows this so the user can see that
-/// there is a stored value to keep, and recognize which one it is.
+/// A display-only stand-in for a stored secret — stars, then its last few
+/// characters, e.g. `********9Pgw`. The prompt shows this so the user can see
+/// that there is a stored value to keep, and recognize which one it is.
+///
+/// The tail, not the head: every Antithesis API key opens with the same
+/// `antithesis_api_key_v2` prefix, so leading characters would distinguish
+/// nothing.
 fn secret_hint(secret: &str) -> String {
-    let visible: String = secret.chars().take(HINT_VISIBLE_CHARS).collect();
-    format!("{visible}{}", "*".repeat(HINT_STARS))
+    let skip = secret.chars().count().saturating_sub(HINT_VISIBLE_CHARS);
+    let tail: String = secret.chars().skip(skip).collect();
+    format!("{}{tail}", "*".repeat(HINT_STARS))
 }
 
 /// The API key already in storage, when that is what the previous credentials
 /// hold. Credentials read from the environment are left out on purpose: keeping
 /// one would copy an ambient secret into the credentials file. The menu's own
 /// default ignores them for the same reason.
-fn stored_api_key(previous: &Result<AttributedValue<AuthenticationInfo>>) -> Option<&str> {
+fn stored_api_key(previous: Option<&AttributedValue<AuthenticationInfo>>) -> Option<&str> {
     match previous {
-        Ok(AttributedValue::EnvironmentVariable { .. }) | Err(_) => None,
-        Ok(credentials) => match credentials.value() {
+        None | Some(AttributedValue::EnvironmentVariable { .. }) => None,
+        Some(credentials) => match credentials.value() {
             AuthenticationInfo::ApiKey { api_key } => Some(api_key),
             _ => None,
         },
@@ -882,16 +892,23 @@ mod tests {
 
     #[test]
     fn secret_hint_shows_a_prefix_and_a_fixed_run_of_stars() {
-        // The prefix is the key's own, so the user recognizes which key is
+        // The tail is the key's own, so the user recognizes which key is
         // stored; the star run is fixed, so two keys of different lengths hint
-        // identically.
-        assert_eq!(secret_hint("sk-FAKE-not-a-real-key"), "sk-F********");
-        assert_eq!(secret_hint("sk-FAKE-shorter"), "sk-F********");
+        // identically. Antithesis keys share a constant prefix, which is why the
+        // hint shows the end and not the start.
+        assert_eq!(
+            secret_hint("antithesis_api_key_v2_NOTREAL_9Pgw"),
+            "********9Pgw"
+        );
+        assert_eq!(
+            secret_hint("antithesis_api_key_v2_SHORTER_7Qxz"),
+            "********7Qxz"
+        );
     }
 
     #[test]
     fn secret_hint_never_shows_more_than_it_has() {
-        assert_eq!(secret_hint("ab"), "ab********");
+        assert_eq!(secret_hint("ab"), "********ab");
         assert_eq!(secret_hint(""), "********");
     }
 
@@ -918,31 +935,34 @@ mod tests {
 
     #[test]
     fn stored_api_key_reads_a_key_out_of_storage() {
-        let stored = Ok(AttributedValue::SettingsFile {
+        let stored = Some(AttributedValue::SettingsFile {
             value: AuthenticationInfo::ApiKey {
-                api_key: "sk-FAKE-not-a-real-key".to_owned(),
+                api_key: "antithesis_api_key_v2_NOTREAL_9Pgw".to_owned(),
             },
             settings_file_path: Path::new("/tmp/credentials.toml").to_path_buf(),
             profile: None,
         });
-        assert_eq!(stored_api_key(&stored), Some("sk-FAKE-not-a-real-key"));
+        assert_eq!(
+            stored_api_key(stored.as_ref()),
+            Some("antithesis_api_key_v2_NOTREAL_9Pgw")
+        );
     }
 
     #[test]
     fn stored_api_key_ignores_a_key_from_the_environment() {
         // Keeping it would copy an ambient secret into the credentials file.
-        let ambient = Ok(AttributedValue::EnvironmentVariable {
+        let ambient = Some(AttributedValue::EnvironmentVariable {
             value: AuthenticationInfo::ApiKey {
-                api_key: "sk-FAKE-not-a-real-key".to_owned(),
+                api_key: "antithesis_api_key_v2_NOTREAL_9Pgw".to_owned(),
             },
             environment_variable_names: vec!["ANTITHESIS_API_KEY"],
         });
-        assert_eq!(stored_api_key(&ambient), None);
+        assert_eq!(stored_api_key(ambient.as_ref()), None);
     }
 
     #[test]
     fn stored_api_key_ignores_credentials_of_another_kind() {
-        let password = Ok(AttributedValue::SettingsFile {
+        let password = Some(AttributedValue::SettingsFile {
             value: AuthenticationInfo::Password {
                 username: "user".to_owned(),
                 password: "FAKE-not-a-real-password".to_owned(),
@@ -950,8 +970,8 @@ mod tests {
             settings_file_path: Path::new("/tmp/credentials.toml").to_path_buf(),
             profile: None,
         });
-        assert_eq!(stored_api_key(&password), None);
-        assert_eq!(stored_api_key(&Err(eyre!("no credentials"))), None);
+        assert_eq!(stored_api_key(password.as_ref()), None);
+        assert_eq!(stored_api_key(None), None);
     }
 
     #[test]
@@ -1607,7 +1627,7 @@ mod tests {
         let env = LoginEnv::new();
         env.seed(
             ".config/snouty/credentials.toml",
-            "[default]\ntype = \"ApiKey\"\napi_key = \"sk-stored-key\"\n",
+            "[default]\ntype = \"ApiKey\"\napi_key = \"antithesis_api_key_v2_STORED_9Pgw\"\n",
         );
         let settings = env.resolve_settings(None);
         let prompter = Script::default()
@@ -1621,11 +1641,14 @@ mod tests {
 
         assert_eq!(
             prompter.password_hints(),
-            vec![Some("sk-s********".to_owned())],
+            vec![Some("********9Pgw".to_owned())],
             "the key prompt must show that a stored key is there to keep"
         );
         let creds = env.credentials();
-        assert!(creds.contains(r#"api_key = "sk-stored-key""#), "{creds}");
+        assert!(
+            creds.contains(r#"api_key = "antithesis_api_key_v2_STORED_9Pgw""#),
+            "{creds}"
+        );
         Ok(())
     }
 
@@ -1635,20 +1658,23 @@ mod tests {
         let env = LoginEnv::new();
         env.seed(
             ".config/snouty/credentials.toml",
-            "[default]\ntype = \"ApiKey\"\napi_key = \"sk-stored-key\"\n",
+            "[default]\ntype = \"ApiKey\"\napi_key = \"antithesis_api_key_v2_STORED_9Pgw\"\n",
         );
         let settings = env.resolve_settings(None);
         let prompter = Script::default()
             .input("mytenant")
             .input("myrepo")
             .select(0)
-            .password("sk-new-key")
+            .password("antithesis_api_key_v2_NEW_7Qxz")
             .build();
 
         do_cmd_login(None, None, None, settings, &prompter).await?;
 
         let creds = env.credentials();
-        assert!(creds.contains(r#"api_key = "sk-new-key""#), "{creds}");
+        assert!(
+            creds.contains(r#"api_key = "antithesis_api_key_v2_NEW_7Qxz""#),
+            "{creds}"
+        );
         Ok(())
     }
 
@@ -1659,7 +1685,7 @@ mod tests {
         let env = LoginEnv::new();
         // SAFETY: `LoginEnv` holds `ENV_LOCK` for this test's whole body, so no
         // other test reads or writes process env while this var is set.
-        unsafe { std::env::set_var("ANTITHESIS_API_KEY", "sk-ambient-key") };
+        unsafe { std::env::set_var("ANTITHESIS_API_KEY", "antithesis_api_key_v2_AMBIENT_5Kfn") };
         let settings = env.resolve_settings(None);
         let prompter = Script::default()
             .input("mytenant")

--- a/src/login.rs
+++ b/src/login.rs
@@ -50,7 +50,12 @@ trait Prompter {
     /// A masked secret (each character echoes as `*`). There is deliberately
     /// no confirmation round: Antithesis passwords are long generated strings
     /// that are pasted like API keys, not typed twice.
-    fn password(&self, prompt: &str) -> Result<String>;
+    ///
+    /// `hint` is a display-only stand-in for a secret already stored (see
+    /// [`secret_hint`]). When it is set, the prompt shows it and says that an
+    /// empty answer keeps the stored secret. The secret itself never reaches
+    /// the prompter.
+    fn password(&self, prompt: &str, hint: Option<&str>) -> Result<String>;
 }
 
 /// The production [`Prompter`]: `inquire` prompts reading the real terminal.
@@ -80,11 +85,20 @@ impl Prompter for InquirePrompter {
             .map(|choice| choice.index))
     }
 
-    fn password(&self, prompt: &str) -> Result<String> {
-        Ok(Password::new(prompt)
+    fn password(&self, prompt: &str, hint: Option<&str>) -> Result<String> {
+        // `inquire` has no default for a masked prompt, so the hint rides in
+        // the message, in the same `(value)` shape `Text` gives a default.
+        let message = match hint {
+            Some(hint) => format!("{prompt} ({hint})"),
+            None => prompt.to_owned(),
+        };
+        let mut password = Password::new(&message)
             .with_display_mode(PasswordDisplayMode::Masked)
-            .without_confirmation()
-            .prompt()?)
+            .without_confirmation();
+        if hint.is_some() {
+            password = password.with_help_message("hit enter to keep the stored value");
+        }
+        Ok(password.prompt()?)
     }
 }
 
@@ -351,7 +365,10 @@ async fn prompt_for_auth(
     match selection {
         None => Ok(None),
         Some(index) => match credential_options[index] {
-            AuthSetupType::ApiKey => prompt_for_api_key(prompter).map(Some),
+            AuthSetupType::ApiKey => {
+                prompt_for_api_key(prompter, stored_api_key(previous_value)).map(Some)
+            }
+
             AuthSetupType::Password => match previous_value.as_ref().map(AttributedValue::value) {
                 Ok(AuthenticationInfo::Password { username, .. }) => {
                     prompt_for_username_password(prompter, Some(username))
@@ -366,9 +383,53 @@ async fn prompt_for_auth(
     }
 }
 
-fn prompt_for_api_key(prompter: &dyn Prompter) -> Result<PersistableCredentials> {
+/// How many leading characters of a stored secret its hint shows. Enough to
+/// tell one key from another, far too few to reconstruct either.
+const HINT_VISIBLE_CHARS: usize = 4;
+
+/// How many stars stand in for the rest of a stored secret. A fixed count, so
+/// the hint does not disclose how long the secret is.
+const HINT_STARS: usize = 8;
+
+/// A display-only stand-in for a stored secret — its first few characters, then
+/// stars, e.g. `sk-F********`. The prompt shows this so the user can see that
+/// there is a stored value to keep, and recognize which one it is.
+fn secret_hint(secret: &str) -> String {
+    let visible: String = secret.chars().take(HINT_VISIBLE_CHARS).collect();
+    format!("{visible}{}", "*".repeat(HINT_STARS))
+}
+
+/// The API key already in storage, when that is what the previous credentials
+/// hold. Credentials read from the environment are left out on purpose: keeping
+/// one would copy an ambient secret into the credentials file. The menu's own
+/// default ignores them for the same reason.
+fn stored_api_key(previous: &Result<AttributedValue<AuthenticationInfo>>) -> Option<&str> {
+    match previous {
+        Ok(AttributedValue::EnvironmentVariable { .. }) | Err(_) => None,
+        Ok(credentials) => match credentials.value() {
+            AuthenticationInfo::ApiKey { api_key } => Some(api_key),
+            _ => None,
+        },
+    }
+}
+
+/// An empty answer at a masked prompt keeps the secret already stored — that is
+/// what the prompt's hint offers. With nothing stored, the empty answer stands.
+fn keep_stored_if_empty(entered: String, stored: Option<&str>) -> String {
+    match stored {
+        Some(stored) if entered.is_empty() => stored.to_owned(),
+        _ => entered,
+    }
+}
+
+fn prompt_for_api_key(
+    prompter: &dyn Prompter,
+    stored: Option<&str>,
+) -> Result<PersistableCredentials> {
+    let hint = stored.map(secret_hint);
+    let entered = prompter.password("Please enter your API Key", hint.as_deref())?;
     Ok(PersistableCredentials::ApiKey {
-        api_key: prompter.password("Please enter your API Key")?,
+        api_key: keep_stored_if_empty(entered, stored),
     })
 }
 
@@ -382,7 +443,7 @@ fn prompt_for_username_password(
     }
     // No confirmation round: like an API key, an Antithesis password is a
     // long generated string that is pasted, not typed.
-    let password = prompter.password("Please enter your password")?;
+    let password = prompter.password("Please enter your password", None)?;
 
     Ok(PersistableCredentials::Password { username, password })
 }
@@ -820,6 +881,80 @@ mod tests {
     use super::*;
 
     #[test]
+    fn secret_hint_shows_a_prefix_and_a_fixed_run_of_stars() {
+        // The prefix is the key's own, so the user recognizes which key is
+        // stored; the star run is fixed, so two keys of different lengths hint
+        // identically.
+        assert_eq!(secret_hint("sk-FAKE-not-a-real-key"), "sk-F********");
+        assert_eq!(secret_hint("sk-FAKE-shorter"), "sk-F********");
+    }
+
+    #[test]
+    fn secret_hint_never_shows_more_than_it_has() {
+        assert_eq!(secret_hint("ab"), "ab********");
+        assert_eq!(secret_hint(""), "********");
+    }
+
+    #[test]
+    fn empty_answer_keeps_the_stored_secret() {
+        assert_eq!(
+            keep_stored_if_empty(String::new(), Some("stored")),
+            "stored"
+        );
+    }
+
+    #[test]
+    fn a_typed_answer_replaces_the_stored_secret() {
+        assert_eq!(
+            keep_stored_if_empty("typed".to_owned(), Some("stored")),
+            "typed"
+        );
+    }
+
+    #[test]
+    fn empty_answer_stands_when_nothing_is_stored() {
+        assert_eq!(keep_stored_if_empty(String::new(), None), "");
+    }
+
+    #[test]
+    fn stored_api_key_reads_a_key_out_of_storage() {
+        let stored = Ok(AttributedValue::SettingsFile {
+            value: AuthenticationInfo::ApiKey {
+                api_key: "sk-FAKE-not-a-real-key".to_owned(),
+            },
+            settings_file_path: Path::new("/tmp/credentials.toml").to_path_buf(),
+            profile: None,
+        });
+        assert_eq!(stored_api_key(&stored), Some("sk-FAKE-not-a-real-key"));
+    }
+
+    #[test]
+    fn stored_api_key_ignores_a_key_from_the_environment() {
+        // Keeping it would copy an ambient secret into the credentials file.
+        let ambient = Ok(AttributedValue::EnvironmentVariable {
+            value: AuthenticationInfo::ApiKey {
+                api_key: "sk-FAKE-not-a-real-key".to_owned(),
+            },
+            environment_variable_names: vec!["ANTITHESIS_API_KEY"],
+        });
+        assert_eq!(stored_api_key(&ambient), None);
+    }
+
+    #[test]
+    fn stored_api_key_ignores_credentials_of_another_kind() {
+        let password = Ok(AttributedValue::SettingsFile {
+            value: AuthenticationInfo::Password {
+                username: "user".to_owned(),
+                password: "FAKE-not-a-real-password".to_owned(),
+            },
+            settings_file_path: Path::new("/tmp/credentials.toml").to_path_buf(),
+            profile: None,
+        });
+        assert_eq!(stored_api_key(&password), None);
+        assert_eq!(stored_api_key(&Err(eyre!("no credentials"))), None);
+    }
+
+    #[test]
     fn cli_config_deserializes_all_three_strategies() {
         let fixed: CliOAuthConfig =
             serde_json::from_str(r#"{"port_strategy":"fixed","ports":[12345,12346,12347]}"#)
@@ -985,6 +1120,11 @@ mod tests {
             self.0.push(Answer::Select(Some(index)));
             self
         }
+        /// Esc at a menu: the user skips it rather than choosing.
+        fn skip_select(mut self) -> Self {
+            self.0.push(Answer::Select(None));
+            self
+        }
         fn password(mut self, value: &str) -> Self {
             self.0.push(Answer::Password(value.to_owned()));
             self
@@ -994,6 +1134,7 @@ mod tests {
                 answers: RefCell::new(self.0.into()),
                 prompts: RefCell::new(Vec::new()),
                 selects: RefCell::new(Vec::new()),
+                password_hints: RefCell::new(Vec::new()),
             }
         }
     }
@@ -1005,6 +1146,8 @@ mod tests {
         prompts: RefCell<Vec<String>>,
         /// Each `select` call: its item list and its default index.
         selects: RefCell<Vec<(Vec<String>, usize)>>,
+        /// The hint shown by each `password` call, in order.
+        password_hints: RefCell<Vec<Option<String>>>,
     }
 
     impl ScriptedPrompter {
@@ -1023,6 +1166,11 @@ mod tests {
         /// The (items, default) pair passed to each `select`, in order.
         fn selects(&self) -> Vec<(Vec<String>, usize)> {
             self.selects.borrow().clone()
+        }
+
+        /// The hint shown by each `password` prompt, in order.
+        fn password_hints(&self) -> Vec<Option<String>> {
+            self.password_hints.borrow().clone()
         }
     }
 
@@ -1058,7 +1206,10 @@ mod tests {
             }
         }
 
-        fn password(&self, prompt: &str) -> Result<String> {
+        fn password(&self, prompt: &str, hint: Option<&str>) -> Result<String> {
+            self.password_hints
+                .borrow_mut()
+                .push(hint.map(str::to_owned));
             match self.next("password", prompt) {
                 Answer::Password(value) => Ok(value),
                 _ => panic!("next scripted answer was not a password at {prompt:?}"),
@@ -1331,6 +1482,11 @@ mod tests {
             "{}",
             env.settings()
         );
+        // The unparsable file is kept, not destroyed, so the user can recover
+        // anything it held.
+        let backup = std::fs::read_to_string(env.config_dir().join("settings.toml.bak"))
+            .expect("the unparsable settings must be kept as a backup");
+        assert_eq!(backup, "this is = = not valid toml");
         Ok(())
     }
 
@@ -1444,8 +1600,110 @@ mod tests {
         Ok(())
     }
 
-    // --- Real macOS Keychain -------------------------------------------------
+    /// A stored API key is offered back: the prompt shows a masked hint, and an
+    /// empty answer keeps the stored key rather than saving an empty one.
+    #[tokio::test]
+    async fn login_keeps_the_stored_api_key_on_an_empty_answer() -> Result<()> {
+        let env = LoginEnv::new();
+        env.seed(
+            ".config/snouty/credentials.toml",
+            "[default]\ntype = \"ApiKey\"\napi_key = \"sk-stored-key\"\n",
+        );
+        let settings = env.resolve_settings(None);
+        let prompter = Script::default()
+            .input("mytenant")
+            .input("myrepo")
+            .select(0) // API Key, the stored kind, is already the default
+            .password("") // hit enter
+            .build();
 
+        do_cmd_login(None, None, None, settings, &prompter).await?;
+
+        assert_eq!(
+            prompter.password_hints(),
+            vec![Some("sk-s********".to_owned())],
+            "the key prompt must show that a stored key is there to keep"
+        );
+        let creds = env.credentials();
+        assert!(creds.contains(r#"api_key = "sk-stored-key""#), "{creds}");
+        Ok(())
+    }
+
+    /// A key typed at the prompt replaces the stored one.
+    #[tokio::test]
+    async fn login_replaces_the_stored_api_key_when_one_is_typed() -> Result<()> {
+        let env = LoginEnv::new();
+        env.seed(
+            ".config/snouty/credentials.toml",
+            "[default]\ntype = \"ApiKey\"\napi_key = \"sk-stored-key\"\n",
+        );
+        let settings = env.resolve_settings(None);
+        let prompter = Script::default()
+            .input("mytenant")
+            .input("myrepo")
+            .select(0)
+            .password("sk-new-key")
+            .build();
+
+        do_cmd_login(None, None, None, settings, &prompter).await?;
+
+        let creds = env.credentials();
+        assert!(creds.contains(r#"api_key = "sk-new-key""#), "{creds}");
+        Ok(())
+    }
+
+    /// An API key in the environment is not offered back, because keeping it
+    /// would copy an ambient secret into the credentials file.
+    #[tokio::test]
+    async fn login_does_not_offer_back_an_api_key_from_the_environment() -> Result<()> {
+        let env = LoginEnv::new();
+        // SAFETY: `LoginEnv` holds `ENV_LOCK` for this test's whole body, so no
+        // other test reads or writes process env while this var is set.
+        unsafe { std::env::set_var("ANTITHESIS_API_KEY", "sk-ambient-key") };
+        let settings = env.resolve_settings(None);
+        let prompter = Script::default()
+            .input("mytenant")
+            .input("myrepo")
+            .select(0)
+            .password("sk-typed-key")
+            .build();
+
+        let result = do_cmd_login(None, None, None, settings, &prompter).await;
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("ANTITHESIS_API_KEY") };
+        result?;
+
+        assert_eq!(
+            prompter.password_hints(),
+            vec![None],
+            "an ambient key must not be offered as something to keep"
+        );
+        Ok(())
+    }
+
+    /// Esc at the credential menu skips credential storage: the tenant and
+    /// repository are still saved, and no credentials file is written.
+    #[tokio::test]
+    async fn login_skips_credential_storage_on_esc() -> Result<()> {
+        let env = LoginEnv::new();
+        let settings = env.resolve_settings(None);
+        let prompter = Script::default()
+            .input("mytenant")
+            .input("myrepo")
+            .skip_select()
+            .build();
+
+        do_cmd_login(None, None, None, settings, &prompter).await?;
+
+        assert!(env.settings().contains(r#"tenant = "mytenant""#));
+        assert!(
+            !env.config_dir().join("credentials.toml").exists(),
+            "Esc at the menu must write no credentials file"
+        );
+        Ok(())
+    }
+
+    // --- Real macOS Keychain -------------------------------------------------
     /// Run `/usr/bin/security` under `home` so its keychain preferences (default
     /// keychain, search list) land in the same `$HOME/Library/Preferences`
     /// snouty reads back — see [`login_persists_to_real_macos_keychain`].

--- a/tests/fixtures/validate/non-executable-command/docker-compose.yaml
+++ b/tests/fixtures/validate/non-executable-command/docker-compose.yaml
@@ -1,8 +1,13 @@
 # Bakes a recognized test command (test/quickstart/first_setup) that is missing
 # its executable bit into the image. Antithesis could never run it, so snouty
-# fails discovery during `validate` and names the offending command. Like the
-# unrecognized-command sample, this fails during discovery, so the service only
-# needs to stay up.
+# fails discovery during `validate` and names the offending command.
+#
+# `validate` discovers test commands only after it sees the setup-complete
+# event, so — like the unrecognized-command sample — the service must emit that
+# event before snouty can reach the discovery failure. It then stays up.
+#
+# `$$` escapes the dollar sign so docker-compose passes $ANTITHESIS_OUTPUT_DIR
+# through to the container shell instead of interpolating it at config time.
 #
 # Run scripts/build-validate-samples.sh to build the image — `snouty validate`
 # never builds or pulls.
@@ -10,4 +15,7 @@ services:
   app:
     image: snouty-sample-non-executable-command:latest
     build: .
-    command: ["tail", "-f", "/dev/null"]
+    command:
+      - sh
+      - -c
+      - "echo '{\"antithesis_setup\": {\"status\": \"complete\"}}' >> \"$$ANTITHESIS_OUTPUT_DIR/sdk.jsonl\"; exec tail -f /dev/null"

--- a/tests/fixtures/validate/unrecognized-command/docker-compose.yaml
+++ b/tests/fixtures/validate/unrecognized-command/docker-compose.yaml
@@ -1,9 +1,16 @@
 # Bakes a test command (test/quickstart/run_workload) whose name has no
 # recognized Antithesis prefix (first_, parallel_driver_, serial_driver_,
 # singleton_driver_, anytime_, eventually_, finally_, or helper_) into the
-# image. snouty discovers it during `validate`, can't classify it, and fails —
-# caught during discovery, before the setup-complete wait, so the service only
-# needs to stay up. Expected: validation fails naming the unrecognized command.
+# image. snouty discovers it during `validate`, can't classify it, and fails.
+# Expected: validation fails naming the unrecognized command.
+#
+# `validate` discovers test commands only after it sees the setup-complete
+# event, so the service must emit that event before snouty can reach the
+# discovery failure this sample exists to show. It then stays up, like the
+# `valid` sample.
+#
+# `$$` escapes the dollar sign so docker-compose passes $ANTITHESIS_OUTPUT_DIR
+# through to the container shell instead of interpolating it at config time.
 #
 # Run scripts/build-validate-samples.sh to build the image — `snouty validate`
 # never builds or pulls.
@@ -11,4 +18,7 @@ services:
   app:
     image: snouty-sample-unrecognized-command:latest
     build: .
-    command: ["tail", "-f", "/dev/null"]
+    command:
+      - sh
+      - -c
+      - "echo '{\"antithesis_setup\": {\"status\": \"complete\"}}' >> \"$$ANTITHESIS_OUTPUT_DIR/sdk.jsonl\"; exec tail -f /dev/null"

--- a/tests/login_pty.rs
+++ b/tests/login_pty.rs
@@ -50,7 +50,19 @@ const OAUTH_DISABLED: &str = r#"{"port_strategy":"disabled"}"#;
 /// isolated `$HOME` and a mock backend that answers the `/auth/cli/config`
 /// probe with [`OAUTH_DISABLED`].
 fn start_login() -> (tempfile::TempDir, OsSession) {
+    start_login_with(&[])
+}
+
+/// As [`start_login`], with each `(path, contents)` in `seed` written under the
+/// temp `$HOME` first — the pre-existing state a fresh login would not have.
+fn start_login_with(seed: &[(&str, &str)]) -> (tempfile::TempDir, OsSession) {
     let home = tempfile::TempDir::new().expect("temp HOME");
+    for (path, contents) in seed {
+        let path = home.path().join(path);
+        std::fs::create_dir_all(path.parent().expect("seed path has a parent"))
+            .expect("create the seed directory");
+        std::fs::write(path, contents).expect("write the seed file");
+    }
     let base_url = support::start_mock_server(OAUTH_DISABLED, 200);
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_snouty"));
@@ -195,6 +207,38 @@ fn accepts_an_api_key_longer_than_the_terminal_width() {
     assert!(
         creds.contains(&format!(r#"api_key = "{expected}""#)),
         "{creds}"
+    );
+}
+
+/// A stored API key is offered back at the prompt as a masked hint, and a bare
+/// Enter keeps it. The stored key never reaches the screen — only its first few
+/// characters, which is what makes the hint recognizable.
+#[test]
+fn bare_enter_keeps_the_stored_api_key() {
+    let stored = "sk-pty-stored-key";
+    let (home, mut session) = start_login_with(&[(
+        ".config/snouty/credentials.toml",
+        &format!("[default]\ntype = \"ApiKey\"\napi_key = \"{stored}\"\n"),
+    )]);
+
+    expect(
+        &mut session,
+        "What kind of credentials would you like to use?",
+    );
+    send(&mut session, "\r");
+    // The hint: the key's own prefix, then a fixed run of stars.
+    let mut seen = expect(&mut session, "Please enter your API Key (sk-p********)");
+    send(&mut session, "\r");
+    seen += &finish(session);
+
+    assert!(
+        !seen.contains(stored),
+        "the stored key must never be rendered whole"
+    );
+    let creds = credentials(home.path());
+    assert!(
+        creds.contains(&format!(r#"api_key = "{stored}""#)),
+        "a bare Enter must keep the stored key: {creds}"
     );
 }
 

--- a/tests/login_pty.rs
+++ b/tests/login_pty.rs
@@ -215,7 +215,7 @@ fn accepts_an_api_key_longer_than_the_terminal_width() {
 /// characters, which is what makes the hint recognizable.
 #[test]
 fn bare_enter_keeps_the_stored_api_key() {
-    let stored = "sk-pty-stored-key";
+    let stored = "antithesis_api_key_v2_PTYSTORED_9Pgw";
     let (home, mut session) = start_login_with(&[(
         ".config/snouty/credentials.toml",
         &format!("[default]\ntype = \"ApiKey\"\napi_key = \"{stored}\"\n"),
@@ -226,8 +226,9 @@ fn bare_enter_keeps_the_stored_api_key() {
         "What kind of credentials would you like to use?",
     );
     send(&mut session, "\r");
-    // The hint: the key's own prefix, then a fixed run of stars.
-    let mut seen = expect(&mut session, "Please enter your API Key (sk-p********)");
+    // The hint: stars, then the key's own last characters. Antithesis keys
+    // share a constant prefix, so the tail is what tells two of them apart.
+    let mut seen = expect(&mut session, "Please enter your API Key (********9Pgw)");
     send(&mut session, "\r");
     seen += &finish(session);
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,60 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.11"
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
+]
 
 [[package]]
 name = "snouty-scripts"
 version = "0.0.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pexpect" },
+    { name = "pyte" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pexpect", specifier = ">=4.9" },
+    { name = "pyte", specifier = ">=0.8.2" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]


### PR DESCRIPTION
Eleven of the gallery's 91 stories failed for harness reasons, so the
satisfaction review could not judge `snouty login` or two `snouty validate`
paths at all. Three separate causes, and a fourth found while fixing them.

The eight `login-*` stories exited 1 with "Cannot prompt for value when not
running in a TTY". `snouty login` prompts through `inquire`, which engages only
when stdin is a terminal, so piping answers at it took the non-interactive path
and died at the first prompt. Their scripted answers were stale too: menu index
numbers for what is now an arrow-driven menu.

Interactive commands are now their own kind of gallery story, beside the goal
and help ones. Nothing in the section is named for login — that is the only TTY
command today, not the last one. A story carries a dialogue of `(wait for,
send)` steps; `pexpect` types them at a real pseudo-terminal and `pyte` replays
the byte stream, so a frame is the screen exactly as it stood at one prompt. The
same stream is written beside the story as an asciinema recording. Frames split
at prompt boundaries rather than keypresses, and they earn their place on the
prompts that collapse: the credential menu is erased once chosen, so the closing
screen shows only the label that won. The tenant is contacted for real, because
the menu holds a single sign-on entry only where the tenant enables it, so the
menu step finds its row on screen instead of counting keypresses. Three
scenarios remain of the eight; `src/login.rs` already covered profile scoping,
an invalid tenant, and repairing broken settings against a scripted prompter,
and those tests now also cover Esc skipping credential storage and the settings
backup.

`validate-unrecognized-command` and `validate-non-executable-command` timed out.
This was a fixture bug rather than host timing: `validate` waits for the
setup-complete event first and discovers test commands only after it, and
neither fixture emitted that event, so both always timed out and never reached
the discovery failure they exist to show. Their header comments still claimed
discovery ran before the wait. Both now emit the event and then stay up, the way
the `valid` sample does.

`doctor-legacy-auth` asked for the word "legacy", which doctor stopped printing
when username/password became "deprecated" (#212), so a false FAIL was reported
on good output.

Writing the reuse-the-stored-values dialogue surfaced a regression, and it is
the only user-facing change here. `prompt_for_value` offers the stored tenant
and repository back, but `prompt_for_api_key` took no previous value: a user who
re-ran `snouty login` had to paste the key again, and hitting enter stored an
empty one. `inquire` has no default for a masked prompt, so the reuse rides on a
hint plus an empty answer. The hint is built from the stored key — its own first
characters, then a fixed run of stars, e.g. `sk-S********` — so it shows
whatever prefix the key carries and does not disclose the key's length. A key
that came from `ANTITHESIS_API_KEY` is not offered back, because keeping it
would copy an ambient secret into the credentials file.

A satisfaction review of the repaired gallery then found three more things:

- `doctor` answered an unset tenant with "set ANTITHESIS_TENANT or add it to a
  settings file", and missing credentials with "ask Antithesis support for an
  API key". Both are true and both are the slow route; `snouty login` sets
  tenant, repository, and credentials in one pass and was never named. Each of
  the three checks now says so in its own words, because all three fire at once
  on an unconfigured machine and the same sentence three times reads as noise.
- A story's shell block joined arguments on a bare space, so `--launcher Basic
  Test git` was shown unquoted — not the command that ran, and it fails if
  pasted. The command line now goes through `shlex.join`.
- `runs-events-multi-match` asserted that two needles return strictly fewer rows
  than one. `runs events` matches a single needle on the server, which returns
  at most `--limit` events, and filters the rest locally, so when the
  single-needle search is capped both searches report the cap while describing
  different sets. Snouty explains this in its own output; the check was failing
  good behaviour. Both stories now pass an explicit `--limit`, and the check
  reports that narrowing was not assertable rather than failing.

The review's rendering axis no longer measures a widest line against a
140-column threshold. A number says a line is long, not whether that hurts: a
wrapped table row is a defect, a wrapped signed URL is not. The axis now asks
what the wrap breaks.

`scripts/` gains its first two third-party dependencies, `pexpect` and `pyte`,
and a `[tool.pyright]` stanza so `uvx pyright` resolves them from `./.venv`.

All 78 stories the gallery generates today pass their automated checks.

fixes #219
