### PR TITLE
runs exec: route the short stream form err to stderr

### DIFF
--- a/specs/runs_exec.txt
+++ b/specs/runs_exec.txt
@@ -59,6 +59,12 @@ stdout 'Linux antithesis 6.12.0'
 stderr 'warning: virtual clock drift detected'
 stderr 'end moment: -8206006569229276678 398.492'
 
+# The API also labels stderr output with the short form `err`. It routes to
+# stderr exactly like `stderr`, and never leaks onto stdout.
+snouty runs exec run-2 -3625518438076122494 398.4898056755774 short-stream-err
+stderr 'short-form stderr line'
+! stdout 'short-form stderr line'
+
 # Omitting SCRIPT reads the script from stdin. That is the only way to do it:
 # there is no `-` spelling, so there is one way to trigger a stdin read.
 stdin exec_script.txt

--- a/src/runs.rs
+++ b/src/runs.rs
@@ -1759,7 +1759,10 @@ fn render_exec_frame(frame: &ExecFrame) -> Result<()> {
     match frame {
         ExecFrame::Known(ExecEvent::Output { stream, text, .. }) => {
             let text = normalize_terminal_text(text);
-            if stream == "stderr" {
+            // Parse via `Stream` so the short form `err` routes to stderr
+            // too. Anything else — stdout, info, or an unrecognized label —
+            // goes to stdout, as before.
+            if stream.parse::<Stream>() == Ok(Stream::Stderr) {
                 eprintln!("{text}");
             } else {
                 outln!("{text}")?;

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1039,6 +1039,13 @@ fn mock_route_execute_command(run_id: &str, req_body: &str) -> (u16, String) {
             mock_exec_exited(0),
         ],
         "truncate-stream" => vec![mock_exec_output("stdout", "partial output", "398.491")],
+        // The API also labels stderr output with the short form `err`
+        // (observed on the live endpoint). snouty must route it like
+        // `stderr`.
+        "short-stream-err" => vec![
+            mock_exec_output("err", "short-form stderr line", "398.491"),
+            mock_exec_exited(0),
+        ],
         // A frame type this build does not know, and a known frame carrying a
         // field it does not know. The stream must survive both.
         "unknown-frames" => vec![


### PR DESCRIPTION
`render_exec_frame` compares the exec event's stream field to the literal `"stderr"`, but the events API also sends the short form `"err"` for the same stream. The literal comparison routes that stderr text to stdout, so `runs exec ... | jq` sees stderr lines mixed into the script's stdout. This change parses the field through the `Stream` enum, which accepts both forms. An unrecognized stream label still goes to stdout, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
