### PR TITLE
Drop the aarch64 cross-linker config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
`.cargo/config.toml` set the linker for `aarch64-unknown-linux-gnu` to `aarch64-linux-gnu-gcc`. It was added in December 2025, when the hand-written release workflow cross-compiled that target on an x86_64 runner and installed `gcc-aarch64-linux-gnu` for it. cargo-dist replaced that workflow one day later, and dist builds the target natively on `ubuntu-22.04-arm`. The cross-linker is unnecessary.

The file was not inert, though. Cargo applies `[target.<triple>].linker` even when the triple is the host, so the release linked through `aarch64-linux-gnu-gcc` on the ARM runner. If that binary left the runner image, the release broke. Cargo now links through `cc`, the same way the `x86_64-unknown-linux-gnu` target already does.

I proved this on this branch. A temporary `pr-run-mode = "upload"` commit built all five targets green with the file deleted, and the `aarch64-unknown-linux-gnu` artifact unpacks to `ELF 64-bit LSB pie executable, ARM aarch64`. That commit is gone. The branch now holds the deletion only.

The `protocol = "sparse"` setting is the cargo default since Rust 1.70, so it goes with the file.